### PR TITLE
docs: update deadlink

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-ESLint Stylistic is a collection of stylistic rules for ESLint, migrated from `eslint` core and `@typescript-eslint` repo to shift the maintenance effort to the community. Learn more about [why we need this project](/contribute/why).
+ESLint Stylistic is a collection of stylistic rules for ESLint, migrated from `eslint` core and `@typescript-eslint` repo to shift the maintenance effort to the community. Learn more about [why we need this project](/guide/why).
 
 ## Packages
 


### PR DESCRIPTION
- `/contribute/why` is a dead link