### PR TITLE
fix: docs link

### DIFF
--- a/docs/.vitepress/components/RuleItem.vue
+++ b/docs/.vitepress/components/RuleItem.vue
@@ -8,8 +8,10 @@ const props = defineProps<{
 }>()
 
 const shortId = computed(() => {
-  if (props.package.shortId === 'default')
-    return props.rule.docsEntry.includes('eslint-plugin-js') ? 'js' : 'ts'
+  if (props.package.shortId === 'default') {
+    const docsEntry = props.rule.docsEntry
+    return docsEntry.includes('eslint-plugin-ts') ? 'ts' : docsEntry.includes('eslint-plugin-jsx') ? 'jsx' : 'js'
+  }
   return props.package.shortId
 })
 </script>


### PR DESCRIPTION
`eslint-plugin-jsx` also includes `eslint-plugin-js`, so jsx rules will jump to js rules.