### PR TITLE
docs: address some general grammar issues

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -6,11 +6,11 @@ Before you start migrating, check the [project progress](/contribute/project-pro
 
 ## When Should I Migrate?
 
-For production projects, we would recommend to wait a bit longer, until ESLint officially announces the deprecation list.
+For production projects, we would recommend waiting a bit longer, until ESLint officially announces the deprecation list.
 
-At the current stage, the packages are already useable. We are more then happy to see you start trying them out and give us feedbacks.
+At the current stage, the packages are already useable. We are more then happy to see you start trying them out and give us feedback.
 
-The benefit of migrating:
+The benefits of migrating:
 
 - Clear scope of rules, you can see more clearly what rules are related to code style by the prefix `@stylistic/`
 - Better IDE experience, you can config your IDE to [hide the error messages for code style rules](/guide/faq#the-error-messages-squiggly-lines-for-code-style-are-annoying) with scoping and does require to list manually.
@@ -18,7 +18,7 @@ The benefit of migrating:
 
 The downside of migrating **now**:
 
-- We are still waiting for ESLint and `typescript-eslint` teams to announce the official deprecation list. We suggest to pin the dependency version to avoid unexpected breakage.
+- We are still waiting for ESLint and `typescript-eslint` teams to announce the official deprecation list. We suggest pinning the dependency version to avoid unexpected breakage.
 
 ## Manual Migrate
 
@@ -38,7 +38,7 @@ There are two ways to migrate your project to ESLint Stylistic:
 
 ### Approach 1: Migrate to Single Plugin
 
-To make the rules configuration easier, we merged all these 3 plugins into one single plugin.
+To make the rules configuration easier, we merged all three plugins into one single plugin.
 
 ```sh
 npm i -D @stylistic/eslint-plugin
@@ -69,7 +69,7 @@ module.exports = {
 }
 ```
 
-And usually typescript-eslint would ask you to disable able the built-in rules, in favor of the `@typescript-eslint` version. With ESLint Stylistic, you only need one rule to handle both JavaScript and TypeScript.
+And usually typescript-eslint would ask you to disable the built-in rules, in favor of the `@typescript-eslint` version. With ESLint Stylistic, you only need one rule to handle both JavaScript and TypeScript:
 
 ```js
 // .eslintrc.js
@@ -158,7 +158,7 @@ module.exports = {
 
 ## ESLint Migrate Plugin
 
-We provides an ESLint plugin for migrating built-in stylistic rules to the `@stylistic` namespace.
+We provide an ESLint plugin for migrating built-in stylistic rules to the `@stylistic` namespace.
 
 ```sh
 npm i -D @stylistic/eslint-plugin-migrate

--- a/docs/guide/why.md
+++ b/docs/guide/why.md
@@ -20,4 +20,4 @@ With stylistic rules in ESLint, we are able to achieve similar formatting compat
 
 This project is maintained for those who cares such details and want to have full control of the code style.
 
-If you are interested in learning more, we recommended reading [Anthony Fu](https://antfu.me/)'s [*Why I don't use Prettier*](https://antfu.me/posts/why-not-prettier) post.
+If you are interested in learning more, we recommend reading [Anthony Fu](https://antfu.me/)'s [*Why I don't use Prettier*](https://antfu.me/posts/why-not-prettier) post.

--- a/docs/packages/default.md
+++ b/docs/packages/default.md
@@ -2,7 +2,7 @@
 
 Stylistic rules for ESLint, works for both JavaScript, TypeScript and JSX.
 
-This plugin is a merge all three plugins:
+This plugin provides the rules from:
 
 - [`@stylistic/eslint-plugin-js`](./js)
 - [`@stylistic/eslint-plugin-ts`](./ts)
@@ -14,7 +14,7 @@ This plugin is a merge all three plugins:
 npm i -D @stylistic/eslint-plugin
 ```
 
-Add `@stylistic` to your plugins list, and rename [stylistic rules](#rules) adding `@stylistic` prefix:
+Add `@stylistic` to your plugins list, and prefix [stylistic rules](#rules) with `@stylistic`:
 
 ```js
 // .eslintrc.js

--- a/docs/packages/js.md
+++ b/docs/packages/js.md
@@ -5,7 +5,7 @@ JavaScript stylistic rules for ESLint, migrated from [eslint core](https://githu
 Credits to all contributors who have committed to the original rules.
 
 ::: tip
-Recommended to use [`@stylistic/eslint-plugin`](/packages/default), which support both JavaScript and TypeScript rules automatically, without the need to manually overrides.
+We recommend using [`@stylistic/eslint-plugin`](/packages/default) as it includes the rules for both JavaScript and TypeScript
 :::
 
 ## Install
@@ -14,7 +14,7 @@ Recommended to use [`@stylistic/eslint-plugin`](/packages/default), which suppor
 npm i -D @stylistic/eslint-plugin-js
 ```
 
-Add `@stylistic/js` to your plugins list, and rename [stylistic rules](#rules) adding `@stylistic/js` prefix:
+Add `@stylistic/js` to your plugins list, and prefix [stylistic rules](#rules) with `@stylistic/js`:
 
 ```js
 // .eslintrc.js

--- a/docs/packages/jsx.md
+++ b/docs/packages/jsx.md
@@ -1,11 +1,11 @@
 # @stylistic/eslint-plugin-jsx
 
-JSX stylistic rules for ESLint, migrated from [`eslint-plugin-react`](https://github.com/jsx-eslint/eslint-plugin-react). Decoupled from React and support generic JSX syntax.
+JSX stylistic rules for ESLint, migrated from [`eslint-plugin-react`](https://github.com/jsx-eslint/eslint-plugin-react). Decoupled from React and supports generic JSX syntax.
 
 Credits to all contributors who have committed to the original rules.
 
 ::: tip
-Recommended to use [`@stylistic/eslint-plugin`](/packages/default), which support both JavaScript and TypeScript rules automatically, without the need to manually overrides.
+We recommend using [`@stylistic/eslint-plugin`](/packages/default) as it includes the rules for both JavaScript and TypeScript
 :::
 
 ## Install
@@ -14,7 +14,7 @@ Recommended to use [`@stylistic/eslint-plugin`](/packages/default), which suppor
 npm i -D @stylistic/eslint-plugin-jsx
 ```
 
-Add `@stylistic/jsx` to your plugins list, and rename [stylistic rules](#rules) adding `@stylistic/js` prefix:
+Add `@stylistic/jsx` to your plugins list, and change the prefix for [stylistic rules](#rules) from `react` to  `@stylistic/js`:
 
 ```ts
 // .eslintrc.js

--- a/docs/packages/ts.md
+++ b/docs/packages/ts.md
@@ -5,7 +5,7 @@ TypeScript stylistic rules for ESLint, migrated from [`typescript-eslint`](https
 Credits to all contributors who have committed to the original rules.
 
 ::: tip
-Recommended to use [`@stylistic/eslint-plugin`](/packages/default), which support both JavaScript and TypeScript rules automatically, without the need to manually overrides.
+We recommend using [`@stylistic/eslint-plugin`](/packages/default) as it includes the rules for both JavaScript and TypeScript
 :::
 
 ## Install
@@ -14,7 +14,7 @@ Recommended to use [`@stylistic/eslint-plugin`](/packages/default), which suppor
 npm i -D @stylistic/eslint-plugin-ts
 ```
 
-Add `@stylistic/ts` to your plugins list, and rename [stylistic rules](#rules) from `@typescript-eslint/` prefix to `@stylistic/ts/`:
+Add `@stylistic/ts` to your plugins list, and change the prefix for [stylistic rules](#rules) from `@typescript-eslint/` to `@stylistic/ts/`:
 
 ```js
 // .eslintrc.js


### PR DESCRIPTION
I noticed these while reading through the docs in preparation for migrating my configs - there's still a few places where the grammar should be improved, but this is at least a start.