### PR TITLE
feat: add doc comment for rule options

### DIFF
--- a/packages/eslint-plugin-js/dts/rule-options.d.ts
+++ b/packages/eslint-plugin-js/dts/rule-options.d.ts
@@ -50,9 +50,9 @@ import type { RuleOptions as PaddingLineBetweenStatementsRuleOptions } from '../
 import type { RuleOptions as QuotePropsRuleOptions } from '../rules/quote-props/types'
 import type { RuleOptions as QuotesRuleOptions } from '../rules/quotes/types'
 import type { RuleOptions as RestSpreadSpacingRuleOptions } from '../rules/rest-spread-spacing/types'
+import type { RuleOptions as SemiRuleOptions } from '../rules/semi/types'
 import type { RuleOptions as SemiSpacingRuleOptions } from '../rules/semi-spacing/types'
 import type { RuleOptions as SemiStyleRuleOptions } from '../rules/semi-style/types'
-import type { RuleOptions as SemiRuleOptions } from '../rules/semi/types'
 import type { RuleOptions as SpaceBeforeBlocksRuleOptions } from '../rules/space-before-blocks/types'
 import type { RuleOptions as SpaceBeforeFunctionParenRuleOptions } from '../rules/space-before-function-paren/types'
 import type { RuleOptions as SpaceInParensRuleOptions } from '../rules/space-in-parens/types'
@@ -67,208 +67,677 @@ import type { RuleOptions as WrapRegexRuleOptions } from '../rules/wrap-regex/ty
 import type { RuleOptions as YieldStarSpacingRuleOptions } from '../rules/yield-star-spacing/types'
 
 export interface RuleOptions {
-  /** @see {@link https://eslint.style/rules/js/array-bracket-newline} */
+  /**
+   * Enforce linebreaks after opening and before closing array brackets
+   * @see https://eslint.style/rules/js/array-bracket-newline
+   */
   '@stylistic/js/array-bracket-newline': ArrayBracketNewlineRuleOptions
-  /** @see {@link https://eslint.style/rules/js/array-bracket-spacing} */
+  /**
+   * Enforce consistent spacing inside array brackets
+   * @see https://eslint.style/rules/js/array-bracket-spacing
+   */
   '@stylistic/js/array-bracket-spacing': ArrayBracketSpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/js/array-element-newline} */
+  /**
+   * Enforce line breaks after each array element
+   * @see https://eslint.style/rules/js/array-element-newline
+   */
   '@stylistic/js/array-element-newline': ArrayElementNewlineRuleOptions
-  /** @see {@link https://eslint.style/rules/js/arrow-parens} */
+  /**
+   * Require parentheses around arrow function arguments
+   * @see https://eslint.style/rules/js/arrow-parens
+   */
   '@stylistic/js/arrow-parens': ArrowParensRuleOptions
-  /** @see {@link https://eslint.style/rules/js/arrow-spacing} */
+  /**
+   * Enforce consistent spacing before and after the arrow in arrow functions
+   * @see https://eslint.style/rules/js/arrow-spacing
+   */
   '@stylistic/js/arrow-spacing': ArrowSpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/js/block-spacing} */
+  /**
+   * Disallow or enforce spaces inside of blocks after opening block and before closing block
+   * @see https://eslint.style/rules/js/block-spacing
+   */
   '@stylistic/js/block-spacing': BlockSpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/js/brace-style} */
+  /**
+   * Enforce consistent brace style for blocks
+   * @see https://eslint.style/rules/js/brace-style
+   */
   '@stylistic/js/brace-style': BraceStyleRuleOptions
-  /** @see {@link https://eslint.style/rules/js/comma-dangle} */
+  /**
+   * Require or disallow trailing commas
+   * @see https://eslint.style/rules/js/comma-dangle
+   */
   '@stylistic/js/comma-dangle': CommaDangleRuleOptions
-  /** @see {@link https://eslint.style/rules/js/comma-spacing} */
+  /**
+   * Enforce consistent spacing before and after commas
+   * @see https://eslint.style/rules/js/comma-spacing
+   */
   '@stylistic/js/comma-spacing': CommaSpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/js/comma-style} */
+  /**
+   * Enforce consistent comma style
+   * @see https://eslint.style/rules/js/comma-style
+   */
   '@stylistic/js/comma-style': CommaStyleRuleOptions
-  /** @see {@link https://eslint.style/rules/js/computed-property-spacing} */
+  /**
+   * Enforce consistent spacing inside computed property brackets
+   * @see https://eslint.style/rules/js/computed-property-spacing
+   */
   '@stylistic/js/computed-property-spacing': ComputedPropertySpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/js/dot-location} */
+  /**
+   * Enforce consistent newlines before and after dots
+   * @see https://eslint.style/rules/js/dot-location
+   */
   '@stylistic/js/dot-location': DotLocationRuleOptions
-  /** @see {@link https://eslint.style/rules/js/eol-last} */
+  /**
+   * Require or disallow newline at the end of files
+   * @see https://eslint.style/rules/js/eol-last
+   */
   '@stylistic/js/eol-last': EolLastRuleOptions
-  /** @see {@link https://eslint.style/rules/js/func-call-spacing} */
+  /**
+   * Require or disallow spacing between function identifiers and their invocations
+   * @see https://eslint.style/rules/js/func-call-spacing
+   */
   '@stylistic/js/func-call-spacing': FuncCallSpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/js/function-call-argument-newline} */
+  /**
+   * Enforce line breaks between arguments of a function call
+   * @see https://eslint.style/rules/js/function-call-argument-newline
+   */
   '@stylistic/js/function-call-argument-newline': FunctionCallArgumentNewlineRuleOptions
-  /** @see {@link https://eslint.style/rules/js/function-paren-newline} */
+  /**
+   * Enforce consistent line breaks inside function parentheses
+   * @see https://eslint.style/rules/js/function-paren-newline
+   */
   '@stylistic/js/function-paren-newline': FunctionParenNewlineRuleOptions
-  /** @see {@link https://eslint.style/rules/js/generator-star-spacing} */
+  /**
+   * Enforce consistent spacing around `*` operators in generator functions
+   * @see https://eslint.style/rules/js/generator-star-spacing
+   */
   '@stylistic/js/generator-star-spacing': GeneratorStarSpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/js/implicit-arrow-linebreak} */
+  /**
+   * Enforce the location of arrow function bodies
+   * @see https://eslint.style/rules/js/implicit-arrow-linebreak
+   */
   '@stylistic/js/implicit-arrow-linebreak': ImplicitArrowLinebreakRuleOptions
-  /** @see {@link https://eslint.style/rules/js/indent} */
+  /**
+   * Enforce consistent indentation
+   * @see https://eslint.style/rules/js/indent
+   */
   '@stylistic/js/indent': IndentRuleOptions
-  /** @see {@link https://eslint.style/rules/js/jsx-quotes} */
+  /**
+   * Enforce the consistent use of either double or single quotes in JSX attributes
+   * @see https://eslint.style/rules/js/jsx-quotes
+   */
   '@stylistic/js/jsx-quotes': JsxQuotesRuleOptions
-  /** @see {@link https://eslint.style/rules/js/key-spacing} */
+  /**
+   * Enforce consistent spacing between keys and values in object literal properties
+   * @see https://eslint.style/rules/js/key-spacing
+   */
   '@stylistic/js/key-spacing': KeySpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/js/keyword-spacing} */
+  /**
+   * Enforce consistent spacing before and after keywords
+   * @see https://eslint.style/rules/js/keyword-spacing
+   */
   '@stylistic/js/keyword-spacing': KeywordSpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/js/linebreak-style} */
+  /**
+   * Enforce consistent linebreak style
+   * @see https://eslint.style/rules/js/linebreak-style
+   */
   '@stylistic/js/linebreak-style': LinebreakStyleRuleOptions
-  /** @see {@link https://eslint.style/rules/js/lines-around-comment} */
+  /**
+   * Require empty lines around comments
+   * @see https://eslint.style/rules/js/lines-around-comment
+   */
   '@stylistic/js/lines-around-comment': LinesAroundCommentRuleOptions
-  /** @see {@link https://eslint.style/rules/js/lines-between-class-members} */
+  /**
+   * Require or disallow an empty line between class members
+   * @see https://eslint.style/rules/js/lines-between-class-members
+   */
   '@stylistic/js/lines-between-class-members': LinesBetweenClassMembersRuleOptions
-  /** @see {@link https://eslint.style/rules/js/max-len} */
+  /**
+   * Enforce a maximum line length
+   * @see https://eslint.style/rules/js/max-len
+   */
   '@stylistic/js/max-len': MaxLenRuleOptions
-  /** @see {@link https://eslint.style/rules/js/max-statements-per-line} */
+  /**
+   * Enforce a maximum number of statements allowed per line
+   * @see https://eslint.style/rules/js/max-statements-per-line
+   */
   '@stylistic/js/max-statements-per-line': MaxStatementsPerLineRuleOptions
-  /** @see {@link https://eslint.style/rules/js/multiline-ternary} */
+  /**
+   * Enforce newlines between operands of ternary expressions
+   * @see https://eslint.style/rules/js/multiline-ternary
+   */
   '@stylistic/js/multiline-ternary': MultilineTernaryRuleOptions
-  /** @see {@link https://eslint.style/rules/js/new-parens} */
+  /**
+   * Enforce or disallow parentheses when invoking a constructor with no arguments
+   * @see https://eslint.style/rules/js/new-parens
+   */
   '@stylistic/js/new-parens': NewParensRuleOptions
-  /** @see {@link https://eslint.style/rules/js/newline-per-chained-call} */
+  /**
+   * Require a newline after each call in a method chain
+   * @see https://eslint.style/rules/js/newline-per-chained-call
+   */
   '@stylistic/js/newline-per-chained-call': NewlinePerChainedCallRuleOptions
-  /** @see {@link https://eslint.style/rules/js/no-confusing-arrow} */
+  /**
+   * Disallow arrow functions where they could be confused with comparisons
+   * @see https://eslint.style/rules/js/no-confusing-arrow
+   */
   '@stylistic/js/no-confusing-arrow': NoConfusingArrowRuleOptions
-  /** @see {@link https://eslint.style/rules/js/no-extra-parens} */
+  /**
+   * Disallow unnecessary parentheses
+   * @see https://eslint.style/rules/js/no-extra-parens
+   */
   '@stylistic/js/no-extra-parens': NoExtraParensRuleOptions
-  /** @see {@link https://eslint.style/rules/js/no-extra-semi} */
+  /**
+   * Disallow unnecessary semicolons
+   * @see https://eslint.style/rules/js/no-extra-semi
+   */
   '@stylistic/js/no-extra-semi': NoExtraSemiRuleOptions
-  /** @see {@link https://eslint.style/rules/js/no-floating-decimal} */
+  /**
+   * Disallow leading or trailing decimal points in numeric literals
+   * @see https://eslint.style/rules/js/no-floating-decimal
+   */
   '@stylistic/js/no-floating-decimal': NoFloatingDecimalRuleOptions
-  /** @see {@link https://eslint.style/rules/js/no-mixed-operators} */
+  /**
+   * Disallow mixed binary operators
+   * @see https://eslint.style/rules/js/no-mixed-operators
+   */
   '@stylistic/js/no-mixed-operators': NoMixedOperatorsRuleOptions
-  /** @see {@link https://eslint.style/rules/js/no-mixed-spaces-and-tabs} */
+  /**
+   * Disallow mixed spaces and tabs for indentation
+   * @see https://eslint.style/rules/js/no-mixed-spaces-and-tabs
+   */
   '@stylistic/js/no-mixed-spaces-and-tabs': NoMixedSpacesAndTabsRuleOptions
-  /** @see {@link https://eslint.style/rules/js/no-multi-spaces} */
+  /**
+   * Disallow multiple spaces
+   * @see https://eslint.style/rules/js/no-multi-spaces
+   */
   '@stylistic/js/no-multi-spaces': NoMultiSpacesRuleOptions
-  /** @see {@link https://eslint.style/rules/js/no-multiple-empty-lines} */
+  /**
+   * Disallow multiple empty lines
+   * @see https://eslint.style/rules/js/no-multiple-empty-lines
+   */
   '@stylistic/js/no-multiple-empty-lines': NoMultipleEmptyLinesRuleOptions
-  /** @see {@link https://eslint.style/rules/js/no-tabs} */
+  /**
+   * Disallow all tabs
+   * @see https://eslint.style/rules/js/no-tabs
+   */
   '@stylistic/js/no-tabs': NoTabsRuleOptions
-  /** @see {@link https://eslint.style/rules/js/no-trailing-spaces} */
+  /**
+   * Disallow trailing whitespace at the end of lines
+   * @see https://eslint.style/rules/js/no-trailing-spaces
+   */
   '@stylistic/js/no-trailing-spaces': NoTrailingSpacesRuleOptions
-  /** @see {@link https://eslint.style/rules/js/no-whitespace-before-property} */
+  /**
+   * Disallow whitespace before properties
+   * @see https://eslint.style/rules/js/no-whitespace-before-property
+   */
   '@stylistic/js/no-whitespace-before-property': NoWhitespaceBeforePropertyRuleOptions
-  /** @see {@link https://eslint.style/rules/js/nonblock-statement-body-position} */
+  /**
+   * Enforce the location of single-line statements
+   * @see https://eslint.style/rules/js/nonblock-statement-body-position
+   */
   '@stylistic/js/nonblock-statement-body-position': NonblockStatementBodyPositionRuleOptions
-  /** @see {@link https://eslint.style/rules/js/object-curly-newline} */
+  /**
+   * Enforce consistent line breaks after opening and before closing braces
+   * @see https://eslint.style/rules/js/object-curly-newline
+   */
   '@stylistic/js/object-curly-newline': ObjectCurlyNewlineRuleOptions
-  /** @see {@link https://eslint.style/rules/js/object-curly-spacing} */
+  /**
+   * Enforce consistent spacing inside braces
+   * @see https://eslint.style/rules/js/object-curly-spacing
+   */
   '@stylistic/js/object-curly-spacing': ObjectCurlySpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/js/object-property-newline} */
+  /**
+   * Enforce placing object properties on separate lines
+   * @see https://eslint.style/rules/js/object-property-newline
+   */
   '@stylistic/js/object-property-newline': ObjectPropertyNewlineRuleOptions
-  /** @see {@link https://eslint.style/rules/js/one-var-declaration-per-line} */
+  /**
+   * Require or disallow newlines around variable declarations
+   * @see https://eslint.style/rules/js/one-var-declaration-per-line
+   */
   '@stylistic/js/one-var-declaration-per-line': OneVarDeclarationPerLineRuleOptions
-  /** @see {@link https://eslint.style/rules/js/operator-linebreak} */
+  /**
+   * Enforce consistent linebreak style for operators
+   * @see https://eslint.style/rules/js/operator-linebreak
+   */
   '@stylistic/js/operator-linebreak': OperatorLinebreakRuleOptions
-  /** @see {@link https://eslint.style/rules/js/padded-blocks} */
+  /**
+   * Require or disallow padding within blocks
+   * @see https://eslint.style/rules/js/padded-blocks
+   */
   '@stylistic/js/padded-blocks': PaddedBlocksRuleOptions
-  /** @see {@link https://eslint.style/rules/js/padding-line-between-statements} */
+  /**
+   * Require or disallow padding lines between statements
+   * @see https://eslint.style/rules/js/padding-line-between-statements
+   */
   '@stylistic/js/padding-line-between-statements': PaddingLineBetweenStatementsRuleOptions
-  /** @see {@link https://eslint.style/rules/js/quote-props} */
+  /**
+   * Require quotes around object literal property names
+   * @see https://eslint.style/rules/js/quote-props
+   */
   '@stylistic/js/quote-props': QuotePropsRuleOptions
-  /** @see {@link https://eslint.style/rules/js/quotes} */
+  /**
+   * Enforce the consistent use of either backticks, double, or single quotes
+   * @see https://eslint.style/rules/js/quotes
+   */
   '@stylistic/js/quotes': QuotesRuleOptions
-  /** @see {@link https://eslint.style/rules/js/rest-spread-spacing} */
+  /**
+   * Enforce spacing between rest and spread operators and their expressions
+   * @see https://eslint.style/rules/js/rest-spread-spacing
+   */
   '@stylistic/js/rest-spread-spacing': RestSpreadSpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/js/semi-spacing} */
-  '@stylistic/js/semi-spacing': SemiSpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/js/semi-style} */
-  '@stylistic/js/semi-style': SemiStyleRuleOptions
-  /** @see {@link https://eslint.style/rules/js/semi} */
+  /**
+   * Require or disallow semicolons instead of ASI
+   * @see https://eslint.style/rules/js/semi
+   */
   '@stylistic/js/semi': SemiRuleOptions
-  /** @see {@link https://eslint.style/rules/js/space-before-blocks} */
+  /**
+   * Enforce consistent spacing before and after semicolons
+   * @see https://eslint.style/rules/js/semi-spacing
+   */
+  '@stylistic/js/semi-spacing': SemiSpacingRuleOptions
+  /**
+   * Enforce location of semicolons
+   * @see https://eslint.style/rules/js/semi-style
+   */
+  '@stylistic/js/semi-style': SemiStyleRuleOptions
+  /**
+   * Enforce consistent spacing before blocks
+   * @see https://eslint.style/rules/js/space-before-blocks
+   */
   '@stylistic/js/space-before-blocks': SpaceBeforeBlocksRuleOptions
-  /** @see {@link https://eslint.style/rules/js/space-before-function-paren} */
+  /**
+   * Enforce consistent spacing before `function` definition opening parenthesis
+   * @see https://eslint.style/rules/js/space-before-function-paren
+   */
   '@stylistic/js/space-before-function-paren': SpaceBeforeFunctionParenRuleOptions
-  /** @see {@link https://eslint.style/rules/js/space-in-parens} */
+  /**
+   * Enforce consistent spacing inside parentheses
+   * @see https://eslint.style/rules/js/space-in-parens
+   */
   '@stylistic/js/space-in-parens': SpaceInParensRuleOptions
-  /** @see {@link https://eslint.style/rules/js/space-infix-ops} */
+  /**
+   * Require spacing around infix operators
+   * @see https://eslint.style/rules/js/space-infix-ops
+   */
   '@stylistic/js/space-infix-ops': SpaceInfixOpsRuleOptions
-  /** @see {@link https://eslint.style/rules/js/space-unary-ops} */
+  /**
+   * Enforce consistent spacing before or after unary operators
+   * @see https://eslint.style/rules/js/space-unary-ops
+   */
   '@stylistic/js/space-unary-ops': SpaceUnaryOpsRuleOptions
-  /** @see {@link https://eslint.style/rules/js/spaced-comment} */
+  /**
+   * Enforce consistent spacing after the `//` or `/*` in a comment
+   * @see https://eslint.style/rules/js/spaced-comment
+   */
   '@stylistic/js/spaced-comment': SpacedCommentRuleOptions
-  /** @see {@link https://eslint.style/rules/js/switch-colon-spacing} */
+  /**
+   * Enforce spacing around colons of switch statements
+   * @see https://eslint.style/rules/js/switch-colon-spacing
+   */
   '@stylistic/js/switch-colon-spacing': SwitchColonSpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/js/template-curly-spacing} */
+  /**
+   * Require or disallow spacing around embedded expressions of template strings
+   * @see https://eslint.style/rules/js/template-curly-spacing
+   */
   '@stylistic/js/template-curly-spacing': TemplateCurlySpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/js/template-tag-spacing} */
+  /**
+   * Require or disallow spacing between template tags and their literals
+   * @see https://eslint.style/rules/js/template-tag-spacing
+   */
   '@stylistic/js/template-tag-spacing': TemplateTagSpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/js/wrap-iife} */
+  /**
+   * Require parentheses around immediate `function` invocations
+   * @see https://eslint.style/rules/js/wrap-iife
+   */
   '@stylistic/js/wrap-iife': WrapIifeRuleOptions
-  /** @see {@link https://eslint.style/rules/js/wrap-regex} */
+  /**
+   * Require parenthesis around regex literals
+   * @see https://eslint.style/rules/js/wrap-regex
+   */
   '@stylistic/js/wrap-regex': WrapRegexRuleOptions
-  /** @see {@link https://eslint.style/rules/js/yield-star-spacing} */
+  /**
+   * Require or disallow spacing around the `*` in `yield*` expressions
+   * @see https://eslint.style/rules/js/yield-star-spacing
+   */
   '@stylistic/js/yield-star-spacing': YieldStarSpacingRuleOptions
 }
 
 export interface UnprefixedRuleOptions {
+  /**
+   * Enforce linebreaks after opening and before closing array brackets
+   * @see https://eslint.style/rules/js/array-bracket-newline
+   */
   'array-bracket-newline': ArrayBracketNewlineRuleOptions
+  /**
+   * Enforce consistent spacing inside array brackets
+   * @see https://eslint.style/rules/js/array-bracket-spacing
+   */
   'array-bracket-spacing': ArrayBracketSpacingRuleOptions
+  /**
+   * Enforce line breaks after each array element
+   * @see https://eslint.style/rules/js/array-element-newline
+   */
   'array-element-newline': ArrayElementNewlineRuleOptions
+  /**
+   * Require parentheses around arrow function arguments
+   * @see https://eslint.style/rules/js/arrow-parens
+   */
   'arrow-parens': ArrowParensRuleOptions
+  /**
+   * Enforce consistent spacing before and after the arrow in arrow functions
+   * @see https://eslint.style/rules/js/arrow-spacing
+   */
   'arrow-spacing': ArrowSpacingRuleOptions
+  /**
+   * Disallow or enforce spaces inside of blocks after opening block and before closing block
+   * @see https://eslint.style/rules/js/block-spacing
+   */
   'block-spacing': BlockSpacingRuleOptions
+  /**
+   * Enforce consistent brace style for blocks
+   * @see https://eslint.style/rules/js/brace-style
+   */
   'brace-style': BraceStyleRuleOptions
+  /**
+   * Require or disallow trailing commas
+   * @see https://eslint.style/rules/js/comma-dangle
+   */
   'comma-dangle': CommaDangleRuleOptions
+  /**
+   * Enforce consistent spacing before and after commas
+   * @see https://eslint.style/rules/js/comma-spacing
+   */
   'comma-spacing': CommaSpacingRuleOptions
+  /**
+   * Enforce consistent comma style
+   * @see https://eslint.style/rules/js/comma-style
+   */
   'comma-style': CommaStyleRuleOptions
+  /**
+   * Enforce consistent spacing inside computed property brackets
+   * @see https://eslint.style/rules/js/computed-property-spacing
+   */
   'computed-property-spacing': ComputedPropertySpacingRuleOptions
+  /**
+   * Enforce consistent newlines before and after dots
+   * @see https://eslint.style/rules/js/dot-location
+   */
   'dot-location': DotLocationRuleOptions
+  /**
+   * Require or disallow newline at the end of files
+   * @see https://eslint.style/rules/js/eol-last
+   */
   'eol-last': EolLastRuleOptions
+  /**
+   * Require or disallow spacing between function identifiers and their invocations
+   * @see https://eslint.style/rules/js/func-call-spacing
+   */
   'func-call-spacing': FuncCallSpacingRuleOptions
+  /**
+   * Enforce line breaks between arguments of a function call
+   * @see https://eslint.style/rules/js/function-call-argument-newline
+   */
   'function-call-argument-newline': FunctionCallArgumentNewlineRuleOptions
+  /**
+   * Enforce consistent line breaks inside function parentheses
+   * @see https://eslint.style/rules/js/function-paren-newline
+   */
   'function-paren-newline': FunctionParenNewlineRuleOptions
+  /**
+   * Enforce consistent spacing around `*` operators in generator functions
+   * @see https://eslint.style/rules/js/generator-star-spacing
+   */
   'generator-star-spacing': GeneratorStarSpacingRuleOptions
+  /**
+   * Enforce the location of arrow function bodies
+   * @see https://eslint.style/rules/js/implicit-arrow-linebreak
+   */
   'implicit-arrow-linebreak': ImplicitArrowLinebreakRuleOptions
+  /**
+   * Enforce consistent indentation
+   * @see https://eslint.style/rules/js/indent
+   */
   'indent': IndentRuleOptions
+  /**
+   * Enforce the consistent use of either double or single quotes in JSX attributes
+   * @see https://eslint.style/rules/js/jsx-quotes
+   */
   'jsx-quotes': JsxQuotesRuleOptions
+  /**
+   * Enforce consistent spacing between keys and values in object literal properties
+   * @see https://eslint.style/rules/js/key-spacing
+   */
   'key-spacing': KeySpacingRuleOptions
+  /**
+   * Enforce consistent spacing before and after keywords
+   * @see https://eslint.style/rules/js/keyword-spacing
+   */
   'keyword-spacing': KeywordSpacingRuleOptions
+  /**
+   * Enforce consistent linebreak style
+   * @see https://eslint.style/rules/js/linebreak-style
+   */
   'linebreak-style': LinebreakStyleRuleOptions
+  /**
+   * Require empty lines around comments
+   * @see https://eslint.style/rules/js/lines-around-comment
+   */
   'lines-around-comment': LinesAroundCommentRuleOptions
+  /**
+   * Require or disallow an empty line between class members
+   * @see https://eslint.style/rules/js/lines-between-class-members
+   */
   'lines-between-class-members': LinesBetweenClassMembersRuleOptions
+  /**
+   * Enforce a maximum line length
+   * @see https://eslint.style/rules/js/max-len
+   */
   'max-len': MaxLenRuleOptions
+  /**
+   * Enforce a maximum number of statements allowed per line
+   * @see https://eslint.style/rules/js/max-statements-per-line
+   */
   'max-statements-per-line': MaxStatementsPerLineRuleOptions
+  /**
+   * Enforce newlines between operands of ternary expressions
+   * @see https://eslint.style/rules/js/multiline-ternary
+   */
   'multiline-ternary': MultilineTernaryRuleOptions
+  /**
+   * Enforce or disallow parentheses when invoking a constructor with no arguments
+   * @see https://eslint.style/rules/js/new-parens
+   */
   'new-parens': NewParensRuleOptions
+  /**
+   * Require a newline after each call in a method chain
+   * @see https://eslint.style/rules/js/newline-per-chained-call
+   */
   'newline-per-chained-call': NewlinePerChainedCallRuleOptions
+  /**
+   * Disallow arrow functions where they could be confused with comparisons
+   * @see https://eslint.style/rules/js/no-confusing-arrow
+   */
   'no-confusing-arrow': NoConfusingArrowRuleOptions
+  /**
+   * Disallow unnecessary parentheses
+   * @see https://eslint.style/rules/js/no-extra-parens
+   */
   'no-extra-parens': NoExtraParensRuleOptions
+  /**
+   * Disallow unnecessary semicolons
+   * @see https://eslint.style/rules/js/no-extra-semi
+   */
   'no-extra-semi': NoExtraSemiRuleOptions
+  /**
+   * Disallow leading or trailing decimal points in numeric literals
+   * @see https://eslint.style/rules/js/no-floating-decimal
+   */
   'no-floating-decimal': NoFloatingDecimalRuleOptions
+  /**
+   * Disallow mixed binary operators
+   * @see https://eslint.style/rules/js/no-mixed-operators
+   */
   'no-mixed-operators': NoMixedOperatorsRuleOptions
+  /**
+   * Disallow mixed spaces and tabs for indentation
+   * @see https://eslint.style/rules/js/no-mixed-spaces-and-tabs
+   */
   'no-mixed-spaces-and-tabs': NoMixedSpacesAndTabsRuleOptions
+  /**
+   * Disallow multiple spaces
+   * @see https://eslint.style/rules/js/no-multi-spaces
+   */
   'no-multi-spaces': NoMultiSpacesRuleOptions
+  /**
+   * Disallow multiple empty lines
+   * @see https://eslint.style/rules/js/no-multiple-empty-lines
+   */
   'no-multiple-empty-lines': NoMultipleEmptyLinesRuleOptions
+  /**
+   * Disallow all tabs
+   * @see https://eslint.style/rules/js/no-tabs
+   */
   'no-tabs': NoTabsRuleOptions
+  /**
+   * Disallow trailing whitespace at the end of lines
+   * @see https://eslint.style/rules/js/no-trailing-spaces
+   */
   'no-trailing-spaces': NoTrailingSpacesRuleOptions
+  /**
+   * Disallow whitespace before properties
+   * @see https://eslint.style/rules/js/no-whitespace-before-property
+   */
   'no-whitespace-before-property': NoWhitespaceBeforePropertyRuleOptions
+  /**
+   * Enforce the location of single-line statements
+   * @see https://eslint.style/rules/js/nonblock-statement-body-position
+   */
   'nonblock-statement-body-position': NonblockStatementBodyPositionRuleOptions
+  /**
+   * Enforce consistent line breaks after opening and before closing braces
+   * @see https://eslint.style/rules/js/object-curly-newline
+   */
   'object-curly-newline': ObjectCurlyNewlineRuleOptions
+  /**
+   * Enforce consistent spacing inside braces
+   * @see https://eslint.style/rules/js/object-curly-spacing
+   */
   'object-curly-spacing': ObjectCurlySpacingRuleOptions
+  /**
+   * Enforce placing object properties on separate lines
+   * @see https://eslint.style/rules/js/object-property-newline
+   */
   'object-property-newline': ObjectPropertyNewlineRuleOptions
+  /**
+   * Require or disallow newlines around variable declarations
+   * @see https://eslint.style/rules/js/one-var-declaration-per-line
+   */
   'one-var-declaration-per-line': OneVarDeclarationPerLineRuleOptions
+  /**
+   * Enforce consistent linebreak style for operators
+   * @see https://eslint.style/rules/js/operator-linebreak
+   */
   'operator-linebreak': OperatorLinebreakRuleOptions
+  /**
+   * Require or disallow padding within blocks
+   * @see https://eslint.style/rules/js/padded-blocks
+   */
   'padded-blocks': PaddedBlocksRuleOptions
+  /**
+   * Require or disallow padding lines between statements
+   * @see https://eslint.style/rules/js/padding-line-between-statements
+   */
   'padding-line-between-statements': PaddingLineBetweenStatementsRuleOptions
+  /**
+   * Require quotes around object literal property names
+   * @see https://eslint.style/rules/js/quote-props
+   */
   'quote-props': QuotePropsRuleOptions
+  /**
+   * Enforce the consistent use of either backticks, double, or single quotes
+   * @see https://eslint.style/rules/js/quotes
+   */
   'quotes': QuotesRuleOptions
+  /**
+   * Enforce spacing between rest and spread operators and their expressions
+   * @see https://eslint.style/rules/js/rest-spread-spacing
+   */
   'rest-spread-spacing': RestSpreadSpacingRuleOptions
-  'semi-spacing': SemiSpacingRuleOptions
-  'semi-style': SemiStyleRuleOptions
+  /**
+   * Require or disallow semicolons instead of ASI
+   * @see https://eslint.style/rules/js/semi
+   */
   'semi': SemiRuleOptions
+  /**
+   * Enforce consistent spacing before and after semicolons
+   * @see https://eslint.style/rules/js/semi-spacing
+   */
+  'semi-spacing': SemiSpacingRuleOptions
+  /**
+   * Enforce location of semicolons
+   * @see https://eslint.style/rules/js/semi-style
+   */
+  'semi-style': SemiStyleRuleOptions
+  /**
+   * Enforce consistent spacing before blocks
+   * @see https://eslint.style/rules/js/space-before-blocks
+   */
   'space-before-blocks': SpaceBeforeBlocksRuleOptions
+  /**
+   * Enforce consistent spacing before `function` definition opening parenthesis
+   * @see https://eslint.style/rules/js/space-before-function-paren
+   */
   'space-before-function-paren': SpaceBeforeFunctionParenRuleOptions
+  /**
+   * Enforce consistent spacing inside parentheses
+   * @see https://eslint.style/rules/js/space-in-parens
+   */
   'space-in-parens': SpaceInParensRuleOptions
+  /**
+   * Require spacing around infix operators
+   * @see https://eslint.style/rules/js/space-infix-ops
+   */
   'space-infix-ops': SpaceInfixOpsRuleOptions
+  /**
+   * Enforce consistent spacing before or after unary operators
+   * @see https://eslint.style/rules/js/space-unary-ops
+   */
   'space-unary-ops': SpaceUnaryOpsRuleOptions
+  /**
+   * Enforce consistent spacing after the `//` or `/*` in a comment
+   * @see https://eslint.style/rules/js/spaced-comment
+   */
   'spaced-comment': SpacedCommentRuleOptions
+  /**
+   * Enforce spacing around colons of switch statements
+   * @see https://eslint.style/rules/js/switch-colon-spacing
+   */
   'switch-colon-spacing': SwitchColonSpacingRuleOptions
+  /**
+   * Require or disallow spacing around embedded expressions of template strings
+   * @see https://eslint.style/rules/js/template-curly-spacing
+   */
   'template-curly-spacing': TemplateCurlySpacingRuleOptions
+  /**
+   * Require or disallow spacing between template tags and their literals
+   * @see https://eslint.style/rules/js/template-tag-spacing
+   */
   'template-tag-spacing': TemplateTagSpacingRuleOptions
+  /**
+   * Require parentheses around immediate `function` invocations
+   * @see https://eslint.style/rules/js/wrap-iife
+   */
   'wrap-iife': WrapIifeRuleOptions
+  /**
+   * Require parenthesis around regex literals
+   * @see https://eslint.style/rules/js/wrap-regex
+   */
   'wrap-regex': WrapRegexRuleOptions
+  /**
+   * Require or disallow spacing around the `*` in `yield*` expressions
+   * @see https://eslint.style/rules/js/yield-star-spacing
+   */
   'yield-star-spacing': YieldStarSpacingRuleOptions
 }

--- a/packages/eslint-plugin-js/dts/rule-options.d.ts
+++ b/packages/eslint-plugin-js/dts/rule-options.d.ts
@@ -67,355 +67,140 @@ import type { RuleOptions as WrapRegexRuleOptions } from '../rules/wrap-regex/ty
 import type { RuleOptions as YieldStarSpacingRuleOptions } from '../rules/yield-star-spacing/types'
 
 export interface RuleOptions {
-  /**
-   * This rule enforces line breaks after opening and before closing array brackets.
-   * @see {@link https://eslint.style/rules/js/array-bracket-newline}
-   */
+  /** @see {@link https://eslint.style/rules/js/array-bracket-newline} */
   '@stylistic/js/array-bracket-newline': ArrayBracketNewlineRuleOptions
-  /**
-   * This rule enforces consistent spacing inside array brackets.
-   * @see {@link https://eslint.style/rules/js/array-bracket-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/js/array-bracket-spacing} */
   '@stylistic/js/array-bracket-spacing': ArrayBracketSpacingRuleOptions
-  /**
-   * This rule enforces line breaks between array elements.
-   * @see {@link https://eslint.style/rules/js/array-element-newline}
-   */
+  /** @see {@link https://eslint.style/rules/js/array-element-newline} */
   '@stylistic/js/array-element-newline': ArrayElementNewlineRuleOptions
-  /**
-   * This rule enforces parentheses around arrow function parameters regardless of arity.
-   * @see {@link https://eslint.style/rules/js/arrow-parens}
-   */
+  /** @see {@link https://eslint.style/rules/js/arrow-parens} */
   '@stylistic/js/arrow-parens': ArrowParensRuleOptions
-  /**
-   * This rule normalize style of spacing before/after an arrow function's arrow(=>)
-   * @see {@link https://eslint.style/rules/js/arrow-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/js/arrow-spacing} */
   '@stylistic/js/arrow-spacing': ArrowSpacingRuleOptions
-  /**
-   * This rule enforces consistent spacing inside an open block token and the next token on the same line.
-   * This rule also enforces consistent spacing inside a close block token and previous token on the same line.
-   * @see {@link https://eslint.style/rules/js/block-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/js/block-spacing} */
   '@stylistic/js/block-spacing': BlockSpacingRuleOptions
-  /**
-   * This rule enforces consistent brace style for blocks.
-   * @see {@link https://eslint.style/rules/js/brace-style}
-   */
+  /** @see {@link https://eslint.style/rules/js/brace-style} */
   '@stylistic/js/brace-style': BraceStyleRuleOptions
-  /**
-   * This rule enforces consistent use of trailing commas in object and array literals.
-   * @see {@link https://eslint.style/rules/js/comma-dangle}
-   */
+  /** @see {@link https://eslint.style/rules/js/comma-dangle} */
   '@stylistic/js/comma-dangle': CommaDangleRuleOptions
-  /**
-   * This rule enforces consistent spacing before and after commas in variable declarations, array literals, object literals, function parameters, and sequences.
-   * @see {@link https://eslint.style/rules/js/comma-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/js/comma-spacing} */
   '@stylistic/js/comma-spacing': CommaSpacingRuleOptions
-  /**
-   * The Comma Style rule enforces styles for comma-separated lists. There are two comma styles primarily used in JavaScript:
-   * @see {@link https://eslint.style/rules/js/comma-style}
-   */
+  /** @see {@link https://eslint.style/rules/js/comma-style} */
   '@stylistic/js/comma-style': CommaStyleRuleOptions
-  /**
-   * This rule enforce consistent comma style in array literals, object literals, and variable declarations.
-   * @see {@link https://eslint.style/rules/js/computed-property-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/js/computed-property-spacing} */
   '@stylistic/js/computed-property-spacing': ComputedPropertySpacingRuleOptions
-  /**
-   * This rule aims to enforce newline consistency in member expressions.
-   * This rule prevents the use of mixed newlines around the dot in a member expression.
-   * @see {@link https://eslint.style/rules/js/dot-location}
-   */
+  /** @see {@link https://eslint.style/rules/js/dot-location} */
   '@stylistic/js/dot-location': DotLocationRuleOptions
-  /**
-   * This rule enforces at least one newline (or absence thereof) at the end of non-empty files.
-   * @see {@link https://eslint.style/rules/js/eol-last}
-   */
+  /** @see {@link https://eslint.style/rules/js/eol-last} */
   '@stylistic/js/eol-last': EolLastRuleOptions
-  /**
-   * This rule requires or disallows spaces between the function name and the opening parenthesis that calls it.
-   * @see {@link https://eslint.style/rules/js/func-call-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/js/func-call-spacing} */
   '@stylistic/js/func-call-spacing': FuncCallSpacingRuleOptions
-  /**
-   * This rule enforces line breaks between arguments of a function call.
-   * @see {@link https://eslint.style/rules/js/function-call-argument-newline}
-   */
+  /** @see {@link https://eslint.style/rules/js/function-call-argument-newline} */
   '@stylistic/js/function-call-argument-newline': FunctionCallArgumentNewlineRuleOptions
-  /**
-   * This rule enforces consistent line breaks inside parentheses of function parameters or arguments.
-   * @see {@link https://eslint.style/rules/js/function-paren-newline}
-   */
+  /** @see {@link https://eslint.style/rules/js/function-paren-newline} */
   '@stylistic/js/function-paren-newline': FunctionParenNewlineRuleOptions
-  /**
-   * This rule aims to enforce spacing around the * of generator functions.
-   * @see {@link https://eslint.style/rules/js/generator-star-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/js/generator-star-spacing} */
   '@stylistic/js/generator-star-spacing': GeneratorStarSpacingRuleOptions
-  /**
-   * This rule aims to enforce a consistent location for an arrow function containing an implicit return.
-   * @see {@link https://eslint.style/rules/js/implicit-arrow-linebreak}
-   */
+  /** @see {@link https://eslint.style/rules/js/implicit-arrow-linebreak} */
   '@stylistic/js/implicit-arrow-linebreak': ImplicitArrowLinebreakRuleOptions
-  /**
-   * This rule enforces a consistent indentation style. The default style is 4 spaces.
-   * @see {@link https://eslint.style/rules/js/indent}
-   */
+  /** @see {@link https://eslint.style/rules/js/indent} */
   '@stylistic/js/indent': IndentRuleOptions
-  /**
-   * This rule enforces the consistent use of either double or single quotes in JSX attributes.
-   * @see {@link https://eslint.style/rules/js/jsx-quotes}
-   */
+  /** @see {@link https://eslint.style/rules/js/jsx-quotes} */
   '@stylistic/js/jsx-quotes': JsxQuotesRuleOptions
-  /**
-   * This rule enforces consistent spacing between keys and values in object literal properties. In the case of long lines, it is acceptable to add a new line wherever whitespace is allowed.
-   * @see {@link https://eslint.style/rules/js/key-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/js/key-spacing} */
   '@stylistic/js/key-spacing': KeySpacingRuleOptions
-  /**
-   * This rule enforces consistent spacing around keywords and keyword-like tokens.
-   * @see {@link https://eslint.style/rules/js/keyword-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/js/keyword-spacing} */
   '@stylistic/js/keyword-spacing': KeywordSpacingRuleOptions
-  /**
-   * This rule enforces consistent line endings independent of operating system, VCS, or editor used across your codebase.
-   * @see {@link https://eslint.style/rules/js/linebreak-style}
-   */
+  /** @see {@link https://eslint.style/rules/js/linebreak-style} */
   '@stylistic/js/linebreak-style': LinebreakStyleRuleOptions
-  /**
-   * This rule requires empty lines before and/or after comments. It can be enabled separately for both block (/*) and line (//) comments.
-   * This rule does not apply to comments that appear on the same line as code and does not require empty lines at the beginning or end of a file.
-   * @see {@link https://eslint.style/rules/js/lines-around-comment}
-   */
+  /** @see {@link https://eslint.style/rules/js/lines-around-comment} */
   '@stylistic/js/lines-around-comment': LinesAroundCommentRuleOptions
-  /**
-   * This rule improves readability by enforcing lines between class members.
-   * It will not check empty lines before the first member and after the last member, since that is already taken care of by padded-blocks.
-   * @see {@link https://eslint.style/rules/js/lines-between-class-members}
-   */
+  /** @see {@link https://eslint.style/rules/js/lines-between-class-members} */
   '@stylistic/js/lines-between-class-members': LinesBetweenClassMembersRuleOptions
-  /**
-   * This rule enforces a maximum line length to increase code readability and maintainability.
-   * The length of a line is defined as the number of Unicode characters in the line.
-   * @see {@link https://eslint.style/rules/js/max-len}
-   */
+  /** @see {@link https://eslint.style/rules/js/max-len} */
   '@stylistic/js/max-len': MaxLenRuleOptions
-  /**
-   * This rule enforces a maximum number of statements allowed per line.
-   * @see {@link https://eslint.style/rules/js/max-statements-per-line}
-   */
+  /** @see {@link https://eslint.style/rules/js/max-statements-per-line} */
   '@stylistic/js/max-statements-per-line': MaxStatementsPerLineRuleOptions
-  /**
-   * This rule enforces or disallows newlines between operands of a ternary expression. Note: The location of the operators is not enforced by this rule.
-   * Please see the {@link https://eslint.style/rules/js/operator-linebreak operator-linebreak} rule if you are interested in enforcing the location of the operators themselves.
-   * @see {@link https://eslint.style/rules/js/multiline-ternary}
-   */
+  /** @see {@link https://eslint.style/rules/js/multiline-ternary} */
   '@stylistic/js/multiline-ternary': MultilineTernaryRuleOptions
-  /**
-   * This rule can enforce or disallow parentheses when invoking a constructor with no arguments using the new keyword.
-   * @see {@link https://eslint.style/rules/js/new-parens}
-   */
+  /** @see {@link https://eslint.style/rules/js/new-parens} */
   '@stylistic/js/new-parens': NewParensRuleOptions
-  /**
-   * This rule requires a newline after each call in a method chain or deep member access. Computed property accesses such as instance[something] are excluded.
-   * @see {@link https://eslint.style/rules/js/newline-per-chained-call}
-   */
+  /** @see {@link https://eslint.style/rules/js/newline-per-chained-call} */
   '@stylistic/js/newline-per-chained-call': NewlinePerChainedCallRuleOptions
-  /**
-   * This rule warns against using the arrow function syntax in places where it could be confused with a comparison operator.
-   * @see {@link https://eslint.style/rules/js/no-confusing-arrow}
-   */
+  /** @see {@link https://eslint.style/rules/js/no-confusing-arrow} */
   '@stylistic/js/no-confusing-arrow': NoConfusingArrowRuleOptions
-  /**
-   * This rule restricts the use of parentheses to only where they are necessary.
-   * @see {@link https://eslint.style/rules/js/no-extra-parens}
-   */
+  /** @see {@link https://eslint.style/rules/js/no-extra-parens} */
   '@stylistic/js/no-extra-parens': NoExtraParensRuleOptions
-  /**
-   * This rule disallows unnecessary semicolons.
-   * @see {@link https://eslint.style/rules/js/no-extra-semi}
-   */
+  /** @see {@link https://eslint.style/rules/js/no-extra-semi} */
   '@stylistic/js/no-extra-semi': NoExtraSemiRuleOptions
-  /**
-   * This rule is aimed at eliminating floating decimal points and will warn whenever a numeric value has a decimal point but is missing a number either before or after it.
-   * @see {@link https://eslint.style/rules/js/no-floating-decimal}
-   */
+  /** @see {@link https://eslint.style/rules/js/no-floating-decimal} */
   '@stylistic/js/no-floating-decimal': NoFloatingDecimalRuleOptions
-  /**
-   * This rule checks BinaryExpression, LogicalExpression and ConditionalExpression.
-   * This rule may conflict with {@link https://eslint.style/rules/js/no-extra-parens no-extra-parens} rule.
-   * If you use both this and {@link https://eslint.style/rules/js/no-extra-parens no-extra-parens} rule together, you need to use the nestedBinaryExpressions option of {@link https://eslint.style/rules/js/no-extra-parens no-extra-parens }rule.
-   * @see {@link https://eslint.style/rules/js/no-mixed-operators}
-   */
+  /** @see {@link https://eslint.style/rules/js/no-mixed-operators} */
   '@stylistic/js/no-mixed-operators': NoMixedOperatorsRuleOptions
-  /**
-   * This rule disallows mixed spaces and tabs for indentation.
-   * @see {@link https://eslint.style/rules/js/no-mixed-spaces-and-tabs}
-   */
+  /** @see {@link https://eslint.style/rules/js/no-mixed-spaces-and-tabs} */
   '@stylistic/js/no-mixed-spaces-and-tabs': NoMixedSpacesAndTabsRuleOptions
-  /**
-   * This rule aims to disallow multiple whitespace around logical expressions, conditional expressions, declarations, array elements, object properties, sequences and function parameters.
-   * @see {@link https://eslint.style/rules/js/no-multi-spaces}
-   */
+  /** @see {@link https://eslint.style/rules/js/no-multi-spaces} */
   '@stylistic/js/no-multi-spaces': NoMultiSpacesRuleOptions
-  /**
-   * This rule aims to reduce the scrolling required when reading through your code. It will warn when the maximum amount of empty lines has been exceeded.
-   * @see {@link https://eslint.style/rules/js/no-multiple-empty-lines}
-   */
+  /** @see {@link https://eslint.style/rules/js/no-multiple-empty-lines} */
   '@stylistic/js/no-multiple-empty-lines': NoMultipleEmptyLinesRuleOptions
-  /**
-   * This rule looks for tabs anywhere inside a file: code, comments or anything else.
-   * @see {@link https://eslint.style/rules/js/no-tabs}
-   */
+  /** @see {@link https://eslint.style/rules/js/no-tabs} */
   '@stylistic/js/no-tabs': NoTabsRuleOptions
-  /**
-   * This rule disallows trailing whitespace (spaces, tabs, and other Unicode whitespace characters) at the end of lines.
-   * @see {@link https://eslint.style/rules/js/no-trailing-spaces}
-   */
+  /** @see {@link https://eslint.style/rules/js/no-trailing-spaces} */
   '@stylistic/js/no-trailing-spaces': NoTrailingSpacesRuleOptions
-  /**
-   * This rule disallows whitespace around the dot or before the opening bracket before properties of objects if they are on the same line.
-   * This rule allows whitespace when the object and property are on separate lines, as it is common to add newlines to longer chains of properties
-   * @see {@link https://eslint.style/rules/js/no-whitespace-before-property}
-   */
+  /** @see {@link https://eslint.style/rules/js/no-whitespace-before-property} */
   '@stylistic/js/no-whitespace-before-property': NoWhitespaceBeforePropertyRuleOptions
-  /**
-   * This rule aims to enforce a consistent location for single-line statements.
-   * @see {@link https://eslint.style/rules/js/nonblock-statement-body-position}
-   */
+  /** @see {@link https://eslint.style/rules/js/nonblock-statement-body-position} */
   '@stylistic/js/nonblock-statement-body-position': NonblockStatementBodyPositionRuleOptions
-  /**
-   * This rule requires or disallows a line break between { and its following token, and between } and its preceding token of object literals or destructuring assignments.
-   * @see {@link https://eslint.style/rules/js/object-curly-newline}
-   */
+  /** @see {@link https://eslint.style/rules/js/object-curly-newline} */
   '@stylistic/js/object-curly-newline': ObjectCurlyNewlineRuleOptions
-  /**
-   * This rule enforces consistent spacing inside braces of object literals, destructuring assignments, and import/export specifiers.
-   * @see {@link https://eslint.style/rules/js/object-curly-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/js/object-curly-spacing} */
   '@stylistic/js/object-curly-spacing': ObjectCurlySpacingRuleOptions
-  /**
-   * This rule permits you to restrict the locations of property specifications in object literals.
-   * @see {@link https://eslint.style/rules/js/object-property-newline}
-   */
+  /** @see {@link https://eslint.style/rules/js/object-property-newline} */
   '@stylistic/js/object-property-newline': ObjectPropertyNewlineRuleOptions
-  /**
-   * This rule enforces a consistent newlines around variable declarations. This rule ignores variable declarations inside for loop conditionals.
-   * @see {@link https://eslint.style/rules/js/one-var-declaration-per-line}
-   */
+  /** @see {@link https://eslint.style/rules/js/one-var-declaration-per-line} */
   '@stylistic/js/one-var-declaration-per-line': OneVarDeclarationPerLineRuleOptions
-  /**
-   * This rule enforces a consistent linebreak style for operators.
-   * @see {@link https://eslint.style/rules/js/operator-linebreak}
-   */
+  /** @see {@link https://eslint.style/rules/js/operator-linebreak} */
   '@stylistic/js/operator-linebreak': OperatorLinebreakRuleOptions
-  /**
-   * This rule enforces consistent empty line padding within blocks.
-   * @see {@link https://eslint.style/rules/js/padded-blocks}
-   */
+  /** @see {@link https://eslint.style/rules/js/padded-blocks} */
   '@stylistic/js/padded-blocks': PaddedBlocksRuleOptions
-  /**
-   * This rule does nothing if no configurations are provided.
-   * @see {@link https://eslint.style/rules/js/padding-line-between-statements}
-   */
+  /** @see {@link https://eslint.style/rules/js/padding-line-between-statements} */
   '@stylistic/js/padding-line-between-statements': PaddingLineBetweenStatementsRuleOptions
-  /**
-   * This rule requires quotes around object literal property names.
-   * @see {@link https://eslint.style/rules/js/quote-props}
-   */
+  /** @see {@link https://eslint.style/rules/js/quote-props} */
   '@stylistic/js/quote-props': QuotePropsRuleOptions
-  /**
-   * This rule enforces the consistent use of either backticks, double, or single quotes.
-   * This rule is aware of directive prologues such as "use strict" and will not flag or autofix them if doing so will change how the directive prologue is interpreted.
-   * @see {@link https://eslint.style/rules/js/quotes}
-   */
+  /** @see {@link https://eslint.style/rules/js/quotes} */
   '@stylistic/js/quotes': QuotesRuleOptions
-  /**
-   * This rule aims to enforce consistent spacing between rest and spread operators and their expressions. The rule also supports object rest and spread properties in ES2018.
-   * @see {@link https://eslint.style/rules/js/rest-spread-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/js/rest-spread-spacing} */
   '@stylistic/js/rest-spread-spacing': RestSpreadSpacingRuleOptions
-  /**
-   * This rule aims to enforce spacing around a semicolon.
-   * This rule prevents the use of spaces before a semicolon in expressions.
-   * @see {@link https://eslint.style/rules/js/semi-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/js/semi-spacing} */
   '@stylistic/js/semi-spacing': SemiSpacingRuleOptions
-  /**
-   * This rule reports line terminators around semicolons.
-   * @see {@link https://eslint.style/rules/js/semi-style}
-   */
+  /** @see {@link https://eslint.style/rules/js/semi-style} */
   '@stylistic/js/semi-style': SemiStyleRuleOptions
-  /**
-   * This rule enforces consistent use of semicolons.
-   * @see {@link https://eslint.style/rules/js/semi}
-   */
+  /** @see {@link https://eslint.style/rules/js/semi} */
   '@stylistic/js/semi': SemiRuleOptions
-  /**
-   * This rule will enforce consistency of spacing before blocks. It is only applied on blocks that don’t begin on a new line.
-   * @see {@link https://eslint.style/rules/js/space-before-blocks}
-   */
+  /** @see {@link https://eslint.style/rules/js/space-before-blocks} */
   '@stylistic/js/space-before-blocks': SpaceBeforeBlocksRuleOptions
-  /**
-   * This rule aims to enforce consistent spacing before function parentheses and as such, will warn whenever whitespace doesn't match the preferences specified.
-   * @see {@link https://eslint.style/rules/js/space-before-function-paren}
-   */
+  /** @see {@link https://eslint.style/rules/js/space-before-function-paren} */
   '@stylistic/js/space-before-function-paren': SpaceBeforeFunctionParenRuleOptions
-  /**
-   * This rule will enforce consistent spacing directly inside of parentheses, by disallowing or requiring one or more spaces to the right of ( and to the left of ).
-   * As long as you do not explicitly disallow empty parentheses using the "empty" exception , () will be allowed.
-   * @see {@link https://eslint.style/rules/js/space-in-parens}
-   */
+  /** @see {@link https://eslint.style/rules/js/space-in-parens} */
   '@stylistic/js/space-in-parens': SpaceInParensRuleOptions
-  /**
-   * This rule is aimed at ensuring there are spaces around infix operators.
-   * @see {@link https://eslint.style/rules/js/space-infix-ops}
-   */
+  /** @see {@link https://eslint.style/rules/js/space-infix-ops} */
   '@stylistic/js/space-infix-ops': SpaceInfixOpsRuleOptions
-  /**
-   * This rule enforces consistency regarding the spaces after words unary operators and after/before nonwords unary operators.
-   * @see {@link https://eslint.style/rules/js/space-unary-ops}
-   */
+  /** @see {@link https://eslint.style/rules/js/space-unary-ops} */
   '@stylistic/js/space-unary-ops': SpaceUnaryOpsRuleOptions
-  /**
-   * This rule will enforce consistency of spacing after the start of a comment // or /*. It also provides several exceptions for various documentation styles.
-   * @see {@link https://eslint.style/rules/js/spaced-comment}
-   */
+  /** @see {@link https://eslint.style/rules/js/spaced-comment} */
   '@stylistic/js/spaced-comment': SpacedCommentRuleOptions
-  /**
-   * This rule controls spacing around colons of case and default clauses in switch statements.
-   * This rule does the check only if the consecutive tokens exist on the same line.
-   * @see {@link https://eslint.style/rules/js/switch-colon-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/js/switch-colon-spacing} */
   '@stylistic/js/switch-colon-spacing': SwitchColonSpacingRuleOptions
-  /**
-   * This rule aims to maintain consistency around the spacing inside of template literals.
-   * @see {@link https://eslint.style/rules/js/template-curly-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/js/template-curly-spacing} */
   '@stylistic/js/template-curly-spacing': TemplateCurlySpacingRuleOptions
-  /**
-   * This rule aims to maintain consistency around the spacing between template tag functions and their template literals.
-   * @see {@link https://eslint.style/rules/js/template-tag-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/js/template-tag-spacing} */
   '@stylistic/js/template-tag-spacing': TemplateTagSpacingRuleOptions
-  /**
-   * This rule requires all immediately-invoked function expressions to be wrapped in parentheses.
-   * @see {@link https://eslint.style/rules/js/wrap-iife}
-   */
+  /** @see {@link https://eslint.style/rules/js/wrap-iife} */
   '@stylistic/js/wrap-iife': WrapIifeRuleOptions
-  /**
-   * This is used to disambiguate the slash operator and facilitates more readable code.
-   * @see {@link https://eslint.style/rules/js/wrap-regex}
-   */
+  /** @see {@link https://eslint.style/rules/js/wrap-regex} */
   '@stylistic/js/wrap-regex': WrapRegexRuleOptions
-  /**
-   * This rule enforces spacing around the * in yield* expressions.
-   * @see {@link https://eslint.style/rules/js/yield-star-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/js/yield-star-spacing} */
   '@stylistic/js/yield-star-spacing': YieldStarSpacingRuleOptions
-
 }
 
 export interface UnprefixedRuleOptions {

--- a/packages/eslint-plugin-js/dts/rule-options.d.ts
+++ b/packages/eslint-plugin-js/dts/rule-options.d.ts
@@ -67,73 +67,355 @@ import type { RuleOptions as WrapRegexRuleOptions } from '../rules/wrap-regex/ty
 import type { RuleOptions as YieldStarSpacingRuleOptions } from '../rules/yield-star-spacing/types'
 
 export interface RuleOptions {
+  /**
+   * This rule enforces line breaks after opening and before closing array brackets.
+   * @see {@link https://eslint.style/rules/js/array-bracket-newline}
+   */
   '@stylistic/js/array-bracket-newline': ArrayBracketNewlineRuleOptions
+  /**
+   * This rule enforces consistent spacing inside array brackets.
+   * @see {@link https://eslint.style/rules/js/array-bracket-spacing}
+   */
   '@stylistic/js/array-bracket-spacing': ArrayBracketSpacingRuleOptions
+  /**
+   * This rule enforces line breaks between array elements.
+   * @see {@link https://eslint.style/rules/js/array-element-newline}
+   */
   '@stylistic/js/array-element-newline': ArrayElementNewlineRuleOptions
+  /**
+   * This rule enforces parentheses around arrow function parameters regardless of arity.
+   * @see {@link https://eslint.style/rules/js/arrow-parens}
+   */
   '@stylistic/js/arrow-parens': ArrowParensRuleOptions
+  /**
+   * This rule normalize style of spacing before/after an arrow function's arrow(=>)
+   * @see {@link https://eslint.style/rules/js/arrow-spacing}
+   */
   '@stylistic/js/arrow-spacing': ArrowSpacingRuleOptions
+  /**
+   * This rule enforces consistent spacing inside an open block token and the next token on the same line.
+   * This rule also enforces consistent spacing inside a close block token and previous token on the same line.
+   * @see {@link https://eslint.style/rules/js/block-spacing}
+   */
   '@stylistic/js/block-spacing': BlockSpacingRuleOptions
+  /**
+   * This rule enforces consistent brace style for blocks.
+   * @see {@link https://eslint.style/rules/js/brace-style}
+   */
   '@stylistic/js/brace-style': BraceStyleRuleOptions
+  /**
+   * This rule enforces consistent use of trailing commas in object and array literals.
+   * @see {@link https://eslint.style/rules/js/comma-dangle}
+   */
   '@stylistic/js/comma-dangle': CommaDangleRuleOptions
+  /**
+   * This rule enforces consistent spacing before and after commas in variable declarations, array literals, object literals, function parameters, and sequences.
+   * @see {@link https://eslint.style/rules/js/comma-spacing}
+   */
   '@stylistic/js/comma-spacing': CommaSpacingRuleOptions
+  /**
+   * The Comma Style rule enforces styles for comma-separated lists. There are two comma styles primarily used in JavaScript:
+   * @see {@link https://eslint.style/rules/js/comma-style}
+   */
   '@stylistic/js/comma-style': CommaStyleRuleOptions
+  /**
+   * This rule enforce consistent comma style in array literals, object literals, and variable declarations.
+   * @see {@link https://eslint.style/rules/js/computed-property-spacing}
+   */
   '@stylistic/js/computed-property-spacing': ComputedPropertySpacingRuleOptions
+  /**
+   * This rule aims to enforce newline consistency in member expressions.
+   * This rule prevents the use of mixed newlines around the dot in a member expression.
+   * @see {@link https://eslint.style/rules/js/dot-location}
+   */
   '@stylistic/js/dot-location': DotLocationRuleOptions
+  /**
+   * This rule enforces at least one newline (or absence thereof) at the end of non-empty files.
+   * @see {@link https://eslint.style/rules/js/eol-last}
+   */
   '@stylistic/js/eol-last': EolLastRuleOptions
+  /**
+   * This rule requires or disallows spaces between the function name and the opening parenthesis that calls it.
+   * @see {@link https://eslint.style/rules/js/func-call-spacing}
+   */
   '@stylistic/js/func-call-spacing': FuncCallSpacingRuleOptions
+  /**
+   * This rule enforces line breaks between arguments of a function call.
+   * @see {@link https://eslint.style/rules/js/function-call-argument-newline}
+   */
   '@stylistic/js/function-call-argument-newline': FunctionCallArgumentNewlineRuleOptions
+  /**
+   * This rule enforces consistent line breaks inside parentheses of function parameters or arguments.
+   * @see {@link https://eslint.style/rules/js/function-paren-newline}
+   */
   '@stylistic/js/function-paren-newline': FunctionParenNewlineRuleOptions
+  /**
+   * This rule aims to enforce spacing around the * of generator functions.
+   * @see {@link https://eslint.style/rules/js/generator-star-spacing}
+   */
   '@stylistic/js/generator-star-spacing': GeneratorStarSpacingRuleOptions
+  /**
+   * This rule aims to enforce a consistent location for an arrow function containing an implicit return.
+   * @see {@link https://eslint.style/rules/js/implicit-arrow-linebreak}
+   */
   '@stylistic/js/implicit-arrow-linebreak': ImplicitArrowLinebreakRuleOptions
+  /**
+   * This rule enforces a consistent indentation style. The default style is 4 spaces.
+   * @see {@link https://eslint.style/rules/js/indent}
+   */
   '@stylistic/js/indent': IndentRuleOptions
+  /**
+   * This rule enforces the consistent use of either double or single quotes in JSX attributes.
+   * @see {@link https://eslint.style/rules/js/jsx-quotes}
+   */
   '@stylistic/js/jsx-quotes': JsxQuotesRuleOptions
+  /**
+   * This rule enforces consistent spacing between keys and values in object literal properties. In the case of long lines, it is acceptable to add a new line wherever whitespace is allowed.
+   * @see {@link https://eslint.style/rules/js/key-spacing}
+   */
   '@stylistic/js/key-spacing': KeySpacingRuleOptions
+  /**
+   * This rule enforces consistent spacing around keywords and keyword-like tokens.
+   * @see {@link https://eslint.style/rules/js/keyword-spacing}
+   */
   '@stylistic/js/keyword-spacing': KeywordSpacingRuleOptions
+  /**
+   * This rule enforces consistent line endings independent of operating system, VCS, or editor used across your codebase.
+   * @see {@link https://eslint.style/rules/js/linebreak-style}
+   */
   '@stylistic/js/linebreak-style': LinebreakStyleRuleOptions
+  /**
+   * This rule requires empty lines before and/or after comments. It can be enabled separately for both block (/*) and line (//) comments.
+   * This rule does not apply to comments that appear on the same line as code and does not require empty lines at the beginning or end of a file.
+   * @see {@link https://eslint.style/rules/js/lines-around-comment}
+   */
   '@stylistic/js/lines-around-comment': LinesAroundCommentRuleOptions
+  /**
+   * This rule improves readability by enforcing lines between class members.
+   * It will not check empty lines before the first member and after the last member, since that is already taken care of by padded-blocks.
+   * @see {@link https://eslint.style/rules/js/lines-between-class-members}
+   */
   '@stylistic/js/lines-between-class-members': LinesBetweenClassMembersRuleOptions
+  /**
+   * This rule enforces a maximum line length to increase code readability and maintainability.
+   * The length of a line is defined as the number of Unicode characters in the line.
+   * @see {@link https://eslint.style/rules/js/max-len}
+   */
   '@stylistic/js/max-len': MaxLenRuleOptions
+  /**
+   * This rule enforces a maximum number of statements allowed per line.
+   * @see {@link https://eslint.style/rules/js/max-statements-per-line}
+   */
   '@stylistic/js/max-statements-per-line': MaxStatementsPerLineRuleOptions
+  /**
+   * This rule enforces or disallows newlines between operands of a ternary expression. Note: The location of the operators is not enforced by this rule.
+   * Please see the {@link https://eslint.style/rules/js/operator-linebreak operator-linebreak} rule if you are interested in enforcing the location of the operators themselves.
+   * @see {@link https://eslint.style/rules/js/multiline-ternary}
+   */
   '@stylistic/js/multiline-ternary': MultilineTernaryRuleOptions
+  /**
+   * This rule can enforce or disallow parentheses when invoking a constructor with no arguments using the new keyword.
+   * @see {@link https://eslint.style/rules/js/new-parens}
+   */
   '@stylistic/js/new-parens': NewParensRuleOptions
+  /**
+   * This rule requires a newline after each call in a method chain or deep member access. Computed property accesses such as instance[something] are excluded.
+   * @see {@link https://eslint.style/rules/js/newline-per-chained-call}
+   */
   '@stylistic/js/newline-per-chained-call': NewlinePerChainedCallRuleOptions
+  /**
+   * This rule warns against using the arrow function syntax in places where it could be confused with a comparison operator.
+   * @see {@link https://eslint.style/rules/js/no-confusing-arrow}
+   */
   '@stylistic/js/no-confusing-arrow': NoConfusingArrowRuleOptions
+  /**
+   * This rule restricts the use of parentheses to only where they are necessary.
+   * @see {@link https://eslint.style/rules/js/no-extra-parens}
+   */
   '@stylistic/js/no-extra-parens': NoExtraParensRuleOptions
+  /**
+   * This rule disallows unnecessary semicolons.
+   * @see {@link https://eslint.style/rules/js/no-extra-semi}
+   */
   '@stylistic/js/no-extra-semi': NoExtraSemiRuleOptions
+  /**
+   * This rule is aimed at eliminating floating decimal points and will warn whenever a numeric value has a decimal point but is missing a number either before or after it.
+   * @see {@link https://eslint.style/rules/js/no-floating-decimal}
+   */
   '@stylistic/js/no-floating-decimal': NoFloatingDecimalRuleOptions
+  /**
+   * This rule checks BinaryExpression, LogicalExpression and ConditionalExpression.
+   * This rule may conflict with {@link https://eslint.style/rules/js/no-extra-parens no-extra-parens} rule.
+   * If you use both this and {@link https://eslint.style/rules/js/no-extra-parens no-extra-parens} rule together, you need to use the nestedBinaryExpressions option of {@link https://eslint.style/rules/js/no-extra-parens no-extra-parens }rule.
+   * @see {@link https://eslint.style/rules/js/no-mixed-operators}
+   */
   '@stylistic/js/no-mixed-operators': NoMixedOperatorsRuleOptions
+  /**
+   * This rule disallows mixed spaces and tabs for indentation.
+   * @see {@link https://eslint.style/rules/js/no-mixed-spaces-and-tabs}
+   */
   '@stylistic/js/no-mixed-spaces-and-tabs': NoMixedSpacesAndTabsRuleOptions
+  /**
+   * This rule aims to disallow multiple whitespace around logical expressions, conditional expressions, declarations, array elements, object properties, sequences and function parameters.
+   * @see {@link https://eslint.style/rules/js/no-multi-spaces}
+   */
   '@stylistic/js/no-multi-spaces': NoMultiSpacesRuleOptions
+  /**
+   * This rule aims to reduce the scrolling required when reading through your code. It will warn when the maximum amount of empty lines has been exceeded.
+   * @see {@link https://eslint.style/rules/js/no-multiple-empty-lines}
+   */
   '@stylistic/js/no-multiple-empty-lines': NoMultipleEmptyLinesRuleOptions
+  /**
+   * This rule looks for tabs anywhere inside a file: code, comments or anything else.
+   * @see {@link https://eslint.style/rules/js/no-tabs}
+   */
   '@stylistic/js/no-tabs': NoTabsRuleOptions
+  /**
+   * This rule disallows trailing whitespace (spaces, tabs, and other Unicode whitespace characters) at the end of lines.
+   * @see {@link https://eslint.style/rules/js/no-trailing-spaces}
+   */
   '@stylistic/js/no-trailing-spaces': NoTrailingSpacesRuleOptions
+  /**
+   * This rule disallows whitespace around the dot or before the opening bracket before properties of objects if they are on the same line.
+   * This rule allows whitespace when the object and property are on separate lines, as it is common to add newlines to longer chains of properties
+   * @see {@link https://eslint.style/rules/js/no-whitespace-before-property}
+   */
   '@stylistic/js/no-whitespace-before-property': NoWhitespaceBeforePropertyRuleOptions
+  /**
+   * This rule aims to enforce a consistent location for single-line statements.
+   * @see {@link https://eslint.style/rules/js/nonblock-statement-body-position}
+   */
   '@stylistic/js/nonblock-statement-body-position': NonblockStatementBodyPositionRuleOptions
+  /**
+   * This rule requires or disallows a line break between { and its following token, and between } and its preceding token of object literals or destructuring assignments.
+   * @see {@link https://eslint.style/rules/js/object-curly-newline}
+   */
   '@stylistic/js/object-curly-newline': ObjectCurlyNewlineRuleOptions
+  /**
+   * This rule enforces consistent spacing inside braces of object literals, destructuring assignments, and import/export specifiers.
+   * @see {@link https://eslint.style/rules/js/object-curly-spacing}
+   */
   '@stylistic/js/object-curly-spacing': ObjectCurlySpacingRuleOptions
+  /**
+   * This rule permits you to restrict the locations of property specifications in object literals.
+   * @see {@link https://eslint.style/rules/js/object-property-newline}
+   */
   '@stylistic/js/object-property-newline': ObjectPropertyNewlineRuleOptions
+  /**
+   * This rule enforces a consistent newlines around variable declarations. This rule ignores variable declarations inside for loop conditionals.
+   * @see {@link https://eslint.style/rules/js/one-var-declaration-per-line}
+   */
   '@stylistic/js/one-var-declaration-per-line': OneVarDeclarationPerLineRuleOptions
+  /**
+   * This rule enforces a consistent linebreak style for operators.
+   * @see {@link https://eslint.style/rules/js/operator-linebreak}
+   */
   '@stylistic/js/operator-linebreak': OperatorLinebreakRuleOptions
+  /**
+   * This rule enforces consistent empty line padding within blocks.
+   * @see {@link https://eslint.style/rules/js/padded-blocks}
+   */
   '@stylistic/js/padded-blocks': PaddedBlocksRuleOptions
+  /**
+   * This rule does nothing if no configurations are provided.
+   * @see {@link https://eslint.style/rules/js/padding-line-between-statements}
+   */
   '@stylistic/js/padding-line-between-statements': PaddingLineBetweenStatementsRuleOptions
+  /**
+   * This rule requires quotes around object literal property names.
+   * @see {@link https://eslint.style/rules/js/quote-props}
+   */
   '@stylistic/js/quote-props': QuotePropsRuleOptions
+  /**
+   * This rule enforces the consistent use of either backticks, double, or single quotes.
+   * This rule is aware of directive prologues such as "use strict" and will not flag or autofix them if doing so will change how the directive prologue is interpreted.
+   * @see {@link https://eslint.style/rules/js/quotes}
+   */
   '@stylistic/js/quotes': QuotesRuleOptions
+  /**
+   * This rule aims to enforce consistent spacing between rest and spread operators and their expressions. The rule also supports object rest and spread properties in ES2018.
+   * @see {@link https://eslint.style/rules/js/rest-spread-spacing}
+   */
   '@stylistic/js/rest-spread-spacing': RestSpreadSpacingRuleOptions
+  /**
+   * This rule aims to enforce spacing around a semicolon.
+   * This rule prevents the use of spaces before a semicolon in expressions.
+   * @see {@link https://eslint.style/rules/js/semi-spacing}
+   */
   '@stylistic/js/semi-spacing': SemiSpacingRuleOptions
+  /**
+   * This rule reports line terminators around semicolons.
+   * @see {@link https://eslint.style/rules/js/semi-style}
+   */
   '@stylistic/js/semi-style': SemiStyleRuleOptions
+  /**
+   * This rule enforces consistent use of semicolons.
+   * @see {@link https://eslint.style/rules/js/semi}
+   */
   '@stylistic/js/semi': SemiRuleOptions
+  /**
+   * This rule will enforce consistency of spacing before blocks. It is only applied on blocks that don’t begin on a new line.
+   * @see {@link https://eslint.style/rules/js/space-before-blocks}
+   */
   '@stylistic/js/space-before-blocks': SpaceBeforeBlocksRuleOptions
+  /**
+   * This rule aims to enforce consistent spacing before function parentheses and as such, will warn whenever whitespace doesn't match the preferences specified.
+   * @see {@link https://eslint.style/rules/js/space-before-function-paren}
+   */
   '@stylistic/js/space-before-function-paren': SpaceBeforeFunctionParenRuleOptions
+  /**
+   * This rule will enforce consistent spacing directly inside of parentheses, by disallowing or requiring one or more spaces to the right of ( and to the left of ).
+   * As long as you do not explicitly disallow empty parentheses using the "empty" exception , () will be allowed.
+   * @see {@link https://eslint.style/rules/js/space-in-parens}
+   */
   '@stylistic/js/space-in-parens': SpaceInParensRuleOptions
+  /**
+   * This rule is aimed at ensuring there are spaces around infix operators.
+   * @see {@link https://eslint.style/rules/js/space-infix-ops}
+   */
   '@stylistic/js/space-infix-ops': SpaceInfixOpsRuleOptions
+  /**
+   * This rule enforces consistency regarding the spaces after words unary operators and after/before nonwords unary operators.
+   * @see {@link https://eslint.style/rules/js/space-unary-ops}
+   */
   '@stylistic/js/space-unary-ops': SpaceUnaryOpsRuleOptions
+  /**
+   * This rule will enforce consistency of spacing after the start of a comment // or /*. It also provides several exceptions for various documentation styles.
+   * @see {@link https://eslint.style/rules/js/spaced-comment}
+   */
   '@stylistic/js/spaced-comment': SpacedCommentRuleOptions
+  /**
+   * This rule controls spacing around colons of case and default clauses in switch statements.
+   * This rule does the check only if the consecutive tokens exist on the same line.
+   * @see {@link https://eslint.style/rules/js/switch-colon-spacing}
+   */
   '@stylistic/js/switch-colon-spacing': SwitchColonSpacingRuleOptions
+  /**
+   * This rule aims to maintain consistency around the spacing inside of template literals.
+   * @see {@link https://eslint.style/rules/js/template-curly-spacing}
+   */
   '@stylistic/js/template-curly-spacing': TemplateCurlySpacingRuleOptions
+  /**
+   * This rule aims to maintain consistency around the spacing between template tag functions and their template literals.
+   * @see {@link https://eslint.style/rules/js/template-tag-spacing}
+   */
   '@stylistic/js/template-tag-spacing': TemplateTagSpacingRuleOptions
+  /**
+   * This rule requires all immediately-invoked function expressions to be wrapped in parentheses.
+   * @see {@link https://eslint.style/rules/js/wrap-iife}
+   */
   '@stylistic/js/wrap-iife': WrapIifeRuleOptions
+  /**
+   * This is used to disambiguate the slash operator and facilitates more readable code.
+   * @see {@link https://eslint.style/rules/js/wrap-regex}
+   */
   '@stylistic/js/wrap-regex': WrapRegexRuleOptions
+  /**
+   * This rule enforces spacing around the * in yield* expressions.
+   * @see {@link https://eslint.style/rules/js/yield-star-spacing}
+   */
   '@stylistic/js/yield-star-spacing': YieldStarSpacingRuleOptions
+
 }
 
 export interface UnprefixedRuleOptions {

--- a/packages/eslint-plugin-jsx/dts/rule-options.d.ts
+++ b/packages/eslint-plugin-jsx/dts/rule-options.d.ts
@@ -18,24 +18,100 @@ import type { RuleOptions as JsxWrapMultilinesRuleOptions } from '../rules/jsx-w
 import type { RuleOptions as SelfClosingCompRuleOptions } from '../rules/self-closing-comp/types'
 
 export interface RuleOptions {
+  /**
+   * Enforce or disallow spaces inside of curly braces in JSX attributes and expressions.
+   * @see {@link https://eslint.style/rules/jsx/jsx-child-element-spacing}
+   */
   '@stylistic/jsx/jsx-child-element-spacing': JsxChildElementSpacingRuleOptions
+  /**
+   * Enforce the closing bracket location for JSX multiline elements.
+   * @see {@link https://eslint.style/rules/jsx/jsx-closing-bracket-location}
+   */
   '@stylistic/jsx/jsx-closing-bracket-location': JsxClosingBracketLocationRuleOptions
+  /**
+   * Enforce the closing tag location for multiline JSX elements.
+   * For situations where JSX expressions are unnecessary, please refer to the {@link https://legacy.reactjs.org/docs/jsx-in-depth.html React doc} and {@link https://github.com/facebook/react/blob/v15.4.0-rc.3/docs/docs/02.3-jsx-gotchas.md#html-entities this page about JSX gotchas}.
+   * @see {@link https://eslint.style/rules/jsx/jsx-closing-tag-location}
+   */
   '@stylistic/jsx/jsx-closing-tag-location': JsxClosingTagLocationRuleOptions
+  /**
+   * Disallow unnecessary JSX expressions when literals alone are sufficient or enforce JSX expressions on literals in JSX children or attributes.
+   * For situations where JSX expressions are unnecessary, please refer to the {@link https://legacy.reactjs.org/docs/jsx-in-depth.html React doc} and {@link https://github.com/facebook/react/blob/v15.4.0-rc.3/docs/docs/02.3-jsx-gotchas.md#html-entities this page about JSX gotchas}.
+   * @see {@link https://eslint.style/rules/jsx/jsx-curly-brace-presence}
+   */
   '@stylistic/jsx/jsx-curly-brace-presence': JsxCurlyBracePresenceRuleOptions
+  /**
+   * Enforce consistent linebreaks in curly braces in JSX attributes and expressions.
+   * @see {@link https://eslint.style/rules/jsx/jsx-curly-newline}
+   */
   '@stylistic/jsx/jsx-curly-newline': JsxCurlyNewlineRuleOptions
+  /**
+   * Enforce or disallow spaces inside of curly braces in JSX attributes and expressions.
+   * @see {@link https://eslint.style/rules/jsx/jsx-curly-spacing}
+   */
   '@stylistic/jsx/jsx-curly-spacing': JsxCurlySpacingRuleOptions
+  /**
+   * Enforce or disallow spaces around equal signs in JSX attributes.
+   * @see {@link https://eslint.style/rules/jsx/jsx-equals-spacing}
+   */
   '@stylistic/jsx/jsx-equals-spacing': JsxEqualsSpacingRuleOptions
+  /**
+   * Enforce proper position of the first property in JSX.
+   * @see {@link https://eslint.style/rules/jsx/jsx-first-prop-new-line}
+   */
   '@stylistic/jsx/jsx-first-prop-new-line': JsxFirstPropNewLineRuleOptions
+  /**
+   * Enforce props indentation in JSX.
+   * @see {@link https://eslint.style/rules/jsx/jsx-indent-props}
+   */
   '@stylistic/jsx/jsx-indent-props': JsxIndentPropsRuleOptions
+  /**
+   * Enforce JSX indentation.
+   * Note: The fixer will fix whitespace and tabs indentation.
+   * @see {@link https://eslint.style/rules/jsx/jsx-indent}
+   */
   '@stylistic/jsx/jsx-indent': JsxIndentRuleOptions
+  /**
+   * Enforce maximum of props on a single line in JSX.
+   * @see {@link https://eslint.style/rules/jsx/jsx-max-props-per-line}
+   */
   '@stylistic/jsx/jsx-max-props-per-line': JsxMaxPropsPerLineRuleOptions
+  /**
+   * Require or prevent a new line after jsx elements and expressions
+   * @see {@link https://eslint.style/rules/jsx/jsx-newline}
+   */
   '@stylistic/jsx/jsx-newline': JsxNewlineRuleOptions
+  /**
+   * Require one JSX element per line.
+   * Note: The fixer will insert line breaks between any expression that are on the same line.
+   * @see {@link https://eslint.style/rules/jsx/jsx-one-expression-per-line}
+   */
   '@stylistic/jsx/jsx-one-expression-per-line': JsxOneExpressionPerLineRuleOptions
+  /**
+   * Disallow multiple spaces between inline JSX props.
+   * Enforces that there is exactly one space between all attributes and after tag name and the first attribute in the same line.
+   * @see {@link https://eslint.style/rules/jsx/jsx-props-no-multi-spaces}
+   */
   '@stylistic/jsx/jsx-props-no-multi-spaces': JsxPropsNoMultiSpacesRuleOptions
+  /**
+   * Enforce props alphabetical sorting.
+   * @see {@link https://eslint.style/rules/jsx/jsx-sort-props}
+   */
   '@stylistic/jsx/jsx-sort-props': JsxSortPropsRuleOptions
+  /**
+   * Enforce whitespace in and around the JSX opening and closing brackets.
+   * Enforce or forbid spaces after the opening bracket, before the closing bracket, before the closing bracket of self-closing elements, and between the angle bracket and slash of JSX closing or self-closing elements.
+   * @see {@link https://eslint.style/rules/jsx/jsx-tag-spacing}
+   */
   '@stylistic/jsx/jsx-tag-spacing': JsxTagSpacingRuleOptions
+  /**
+   * Disallow missing parentheses around multiline JSX.
+   * Wrapping multiline JSX in parentheses can improve readability and/or convenience.
+   * @see {@link https://eslint.style/rules/jsx/jsx-wrap-multilines}
+   */
   '@stylistic/jsx/jsx-wrap-multilines': JsxWrapMultilinesRuleOptions
   '@stylistic/jsx/self-closing-comp': SelfClosingCompRuleOptions
+
 }
 
 export interface UnprefixedRuleOptions {

--- a/packages/eslint-plugin-jsx/dts/rule-options.d.ts
+++ b/packages/eslint-plugin-jsx/dts/rule-options.d.ts
@@ -18,100 +18,42 @@ import type { RuleOptions as JsxWrapMultilinesRuleOptions } from '../rules/jsx-w
 import type { RuleOptions as SelfClosingCompRuleOptions } from '../rules/self-closing-comp/types'
 
 export interface RuleOptions {
-  /**
-   * Enforce or disallow spaces inside of curly braces in JSX attributes and expressions.
-   * @see {@link https://eslint.style/rules/jsx/jsx-child-element-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/jsx/jsx-child-element-spacing} */
   '@stylistic/jsx/jsx-child-element-spacing': JsxChildElementSpacingRuleOptions
-  /**
-   * Enforce the closing bracket location for JSX multiline elements.
-   * @see {@link https://eslint.style/rules/jsx/jsx-closing-bracket-location}
-   */
+  /** @see {@link https://eslint.style/rules/jsx/jsx-closing-bracket-location} */
   '@stylistic/jsx/jsx-closing-bracket-location': JsxClosingBracketLocationRuleOptions
-  /**
-   * Enforce the closing tag location for multiline JSX elements.
-   * For situations where JSX expressions are unnecessary, please refer to the {@link https://legacy.reactjs.org/docs/jsx-in-depth.html React doc} and {@link https://github.com/facebook/react/blob/v15.4.0-rc.3/docs/docs/02.3-jsx-gotchas.md#html-entities this page about JSX gotchas}.
-   * @see {@link https://eslint.style/rules/jsx/jsx-closing-tag-location}
-   */
+  /** @see {@link https://eslint.style/rules/jsx/jsx-closing-tag-location} */
   '@stylistic/jsx/jsx-closing-tag-location': JsxClosingTagLocationRuleOptions
-  /**
-   * Disallow unnecessary JSX expressions when literals alone are sufficient or enforce JSX expressions on literals in JSX children or attributes.
-   * For situations where JSX expressions are unnecessary, please refer to the {@link https://legacy.reactjs.org/docs/jsx-in-depth.html React doc} and {@link https://github.com/facebook/react/blob/v15.4.0-rc.3/docs/docs/02.3-jsx-gotchas.md#html-entities this page about JSX gotchas}.
-   * @see {@link https://eslint.style/rules/jsx/jsx-curly-brace-presence}
-   */
+  /** @see {@link https://eslint.style/rules/jsx/jsx-curly-brace-presence} */
   '@stylistic/jsx/jsx-curly-brace-presence': JsxCurlyBracePresenceRuleOptions
-  /**
-   * Enforce consistent linebreaks in curly braces in JSX attributes and expressions.
-   * @see {@link https://eslint.style/rules/jsx/jsx-curly-newline}
-   */
+  /** @see {@link https://eslint.style/rules/jsx/jsx-curly-newline} */
   '@stylistic/jsx/jsx-curly-newline': JsxCurlyNewlineRuleOptions
-  /**
-   * Enforce or disallow spaces inside of curly braces in JSX attributes and expressions.
-   * @see {@link https://eslint.style/rules/jsx/jsx-curly-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/jsx/jsx-curly-spacing} */
   '@stylistic/jsx/jsx-curly-spacing': JsxCurlySpacingRuleOptions
-  /**
-   * Enforce or disallow spaces around equal signs in JSX attributes.
-   * @see {@link https://eslint.style/rules/jsx/jsx-equals-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/jsx/jsx-equals-spacing} */
   '@stylistic/jsx/jsx-equals-spacing': JsxEqualsSpacingRuleOptions
-  /**
-   * Enforce proper position of the first property in JSX.
-   * @see {@link https://eslint.style/rules/jsx/jsx-first-prop-new-line}
-   */
+  /** @see {@link https://eslint.style/rules/jsx/jsx-first-prop-new-line} */
   '@stylistic/jsx/jsx-first-prop-new-line': JsxFirstPropNewLineRuleOptions
-  /**
-   * Enforce props indentation in JSX.
-   * @see {@link https://eslint.style/rules/jsx/jsx-indent-props}
-   */
+  /** @see {@link https://eslint.style/rules/jsx/jsx-indent-props} */
   '@stylistic/jsx/jsx-indent-props': JsxIndentPropsRuleOptions
-  /**
-   * Enforce JSX indentation.
-   * Note: The fixer will fix whitespace and tabs indentation.
-   * @see {@link https://eslint.style/rules/jsx/jsx-indent}
-   */
+  /** @see {@link https://eslint.style/rules/jsx/jsx-indent} */
   '@stylistic/jsx/jsx-indent': JsxIndentRuleOptions
-  /**
-   * Enforce maximum of props on a single line in JSX.
-   * @see {@link https://eslint.style/rules/jsx/jsx-max-props-per-line}
-   */
+  /** @see {@link https://eslint.style/rules/jsx/jsx-max-props-per-line} */
   '@stylistic/jsx/jsx-max-props-per-line': JsxMaxPropsPerLineRuleOptions
-  /**
-   * Require or prevent a new line after jsx elements and expressions
-   * @see {@link https://eslint.style/rules/jsx/jsx-newline}
-   */
+  /** @see {@link https://eslint.style/rules/jsx/jsx-newline} */
   '@stylistic/jsx/jsx-newline': JsxNewlineRuleOptions
-  /**
-   * Require one JSX element per line.
-   * Note: The fixer will insert line breaks between any expression that are on the same line.
-   * @see {@link https://eslint.style/rules/jsx/jsx-one-expression-per-line}
-   */
+  /** @see {@link https://eslint.style/rules/jsx/jsx-one-expression-per-line} */
   '@stylistic/jsx/jsx-one-expression-per-line': JsxOneExpressionPerLineRuleOptions
-  /**
-   * Disallow multiple spaces between inline JSX props.
-   * Enforces that there is exactly one space between all attributes and after tag name and the first attribute in the same line.
-   * @see {@link https://eslint.style/rules/jsx/jsx-props-no-multi-spaces}
-   */
+  /** @see {@link https://eslint.style/rules/jsx/jsx-props-no-multi-spaces} */
   '@stylistic/jsx/jsx-props-no-multi-spaces': JsxPropsNoMultiSpacesRuleOptions
-  /**
-   * Enforce props alphabetical sorting.
-   * @see {@link https://eslint.style/rules/jsx/jsx-sort-props}
-   */
+  /** @see {@link https://eslint.style/rules/jsx/jsx-sort-props} */
   '@stylistic/jsx/jsx-sort-props': JsxSortPropsRuleOptions
-  /**
-   * Enforce whitespace in and around the JSX opening and closing brackets.
-   * Enforce or forbid spaces after the opening bracket, before the closing bracket, before the closing bracket of self-closing elements, and between the angle bracket and slash of JSX closing or self-closing elements.
-   * @see {@link https://eslint.style/rules/jsx/jsx-tag-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/jsx/jsx-tag-spacing} */
   '@stylistic/jsx/jsx-tag-spacing': JsxTagSpacingRuleOptions
-  /**
-   * Disallow missing parentheses around multiline JSX.
-   * Wrapping multiline JSX in parentheses can improve readability and/or convenience.
-   * @see {@link https://eslint.style/rules/jsx/jsx-wrap-multilines}
-   */
+  /** @see {@link https://eslint.style/rules/jsx/jsx-wrap-multilines} */
   '@stylistic/jsx/jsx-wrap-multilines': JsxWrapMultilinesRuleOptions
+  /** @see {@link https://eslint.style/rules/jsx/self-closing-comp} */
   '@stylistic/jsx/self-closing-comp': SelfClosingCompRuleOptions
-
 }
 
 export interface UnprefixedRuleOptions {

--- a/packages/eslint-plugin-jsx/dts/rule-options.d.ts
+++ b/packages/eslint-plugin-jsx/dts/rule-options.d.ts
@@ -6,73 +6,199 @@ import type { RuleOptions as JsxCurlyNewlineRuleOptions } from '../rules/jsx-cur
 import type { RuleOptions as JsxCurlySpacingRuleOptions } from '../rules/jsx-curly-spacing/types'
 import type { RuleOptions as JsxEqualsSpacingRuleOptions } from '../rules/jsx-equals-spacing/types'
 import type { RuleOptions as JsxFirstPropNewLineRuleOptions } from '../rules/jsx-first-prop-new-line/types'
-import type { RuleOptions as JsxIndentPropsRuleOptions } from '../rules/jsx-indent-props/types'
 import type { RuleOptions as JsxIndentRuleOptions } from '../rules/jsx-indent/types'
+import type { RuleOptions as JsxIndentPropsRuleOptions } from '../rules/jsx-indent-props/types'
 import type { RuleOptions as JsxMaxPropsPerLineRuleOptions } from '../rules/jsx-max-props-per-line/types'
 import type { RuleOptions as JsxNewlineRuleOptions } from '../rules/jsx-newline/types'
 import type { RuleOptions as JsxOneExpressionPerLineRuleOptions } from '../rules/jsx-one-expression-per-line/types'
 import type { RuleOptions as JsxPropsNoMultiSpacesRuleOptions } from '../rules/jsx-props-no-multi-spaces/types'
+import type { RuleOptions as JsxSelfClosingCompRuleOptions } from '../rules/jsx-self-closing-comp/types'
 import type { RuleOptions as JsxSortPropsRuleOptions } from '../rules/jsx-sort-props/types'
 import type { RuleOptions as JsxTagSpacingRuleOptions } from '../rules/jsx-tag-spacing/types'
 import type { RuleOptions as JsxWrapMultilinesRuleOptions } from '../rules/jsx-wrap-multilines/types'
-import type { RuleOptions as SelfClosingCompRuleOptions } from '../rules/self-closing-comp/types'
 
 export interface RuleOptions {
-  /** @see {@link https://eslint.style/rules/jsx/jsx-child-element-spacing} */
+  /**
+   * Enforce or disallow spaces inside of curly braces in JSX attributes and expressions
+   * @see https://eslint.style/rules/jsx/jsx-child-element-spacing
+   */
   '@stylistic/jsx/jsx-child-element-spacing': JsxChildElementSpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/jsx/jsx-closing-bracket-location} */
+  /**
+   * Enforce closing bracket location in JSX
+   * @see https://eslint.style/rules/jsx/jsx-closing-bracket-location
+   */
   '@stylistic/jsx/jsx-closing-bracket-location': JsxClosingBracketLocationRuleOptions
-  /** @see {@link https://eslint.style/rules/jsx/jsx-closing-tag-location} */
+  /**
+   * Enforce closing tag location for multiline JSX
+   * @see https://eslint.style/rules/jsx/jsx-closing-tag-location
+   */
   '@stylistic/jsx/jsx-closing-tag-location': JsxClosingTagLocationRuleOptions
-  /** @see {@link https://eslint.style/rules/jsx/jsx-curly-brace-presence} */
+  /**
+   * Disallow unnecessary JSX expressions when literals alone are sufficient or enforce JSX expressions on literals in JSX children or attributes
+   * @see https://eslint.style/rules/jsx/jsx-curly-brace-presence
+   */
   '@stylistic/jsx/jsx-curly-brace-presence': JsxCurlyBracePresenceRuleOptions
-  /** @see {@link https://eslint.style/rules/jsx/jsx-curly-newline} */
+  /**
+   * Enforce consistent linebreaks in curly braces in JSX attributes and expressions
+   * @see https://eslint.style/rules/jsx/jsx-curly-newline
+   */
   '@stylistic/jsx/jsx-curly-newline': JsxCurlyNewlineRuleOptions
-  /** @see {@link https://eslint.style/rules/jsx/jsx-curly-spacing} */
+  /**
+   * Enforce or disallow spaces inside of curly braces in JSX attributes and expressions
+   * @see https://eslint.style/rules/jsx/jsx-curly-spacing
+   */
   '@stylistic/jsx/jsx-curly-spacing': JsxCurlySpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/jsx/jsx-equals-spacing} */
+  /**
+   * Enforce or disallow spaces around equal signs in JSX attributes
+   * @see https://eslint.style/rules/jsx/jsx-equals-spacing
+   */
   '@stylistic/jsx/jsx-equals-spacing': JsxEqualsSpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/jsx/jsx-first-prop-new-line} */
+  /**
+   * Enforce proper position of the first property in JSX
+   * @see https://eslint.style/rules/jsx/jsx-first-prop-new-line
+   */
   '@stylistic/jsx/jsx-first-prop-new-line': JsxFirstPropNewLineRuleOptions
-  /** @see {@link https://eslint.style/rules/jsx/jsx-indent-props} */
-  '@stylistic/jsx/jsx-indent-props': JsxIndentPropsRuleOptions
-  /** @see {@link https://eslint.style/rules/jsx/jsx-indent} */
+  /**
+   * Enforce JSX indentation
+   * @see https://eslint.style/rules/jsx/jsx-indent
+   */
   '@stylistic/jsx/jsx-indent': JsxIndentRuleOptions
-  /** @see {@link https://eslint.style/rules/jsx/jsx-max-props-per-line} */
+  /**
+   * Enforce props indentation in JSX
+   * @see https://eslint.style/rules/jsx/jsx-indent-props
+   */
+  '@stylistic/jsx/jsx-indent-props': JsxIndentPropsRuleOptions
+  /**
+   * Enforce maximum of props on a single line in JSX
+   * @see https://eslint.style/rules/jsx/jsx-max-props-per-line
+   */
   '@stylistic/jsx/jsx-max-props-per-line': JsxMaxPropsPerLineRuleOptions
-  /** @see {@link https://eslint.style/rules/jsx/jsx-newline} */
+  /**
+   * Require or prevent a new line after jsx elements and expressions.
+   * @see https://eslint.style/rules/jsx/jsx-newline
+   */
   '@stylistic/jsx/jsx-newline': JsxNewlineRuleOptions
-  /** @see {@link https://eslint.style/rules/jsx/jsx-one-expression-per-line} */
+  /**
+   * Require one JSX element per line
+   * @see https://eslint.style/rules/jsx/jsx-one-expression-per-line
+   */
   '@stylistic/jsx/jsx-one-expression-per-line': JsxOneExpressionPerLineRuleOptions
-  /** @see {@link https://eslint.style/rules/jsx/jsx-props-no-multi-spaces} */
+  /**
+   * Disallow multiple spaces between inline JSX props
+   * @see https://eslint.style/rules/jsx/jsx-props-no-multi-spaces
+   */
   '@stylistic/jsx/jsx-props-no-multi-spaces': JsxPropsNoMultiSpacesRuleOptions
-  /** @see {@link https://eslint.style/rules/jsx/jsx-sort-props} */
+  /**
+   * Disallow extra closing tags for components without children
+   * @see https://eslint.style/rules/jsx/jsx-self-closing-comp
+   */
+  '@stylistic/jsx/jsx-self-closing-comp': JsxSelfClosingCompRuleOptions
+  /**
+   * Enforce props alphabetical sorting
+   * @see https://eslint.style/rules/jsx/jsx-sort-props
+   */
   '@stylistic/jsx/jsx-sort-props': JsxSortPropsRuleOptions
-  /** @see {@link https://eslint.style/rules/jsx/jsx-tag-spacing} */
+  /**
+   * Enforce whitespace in and around the JSX opening and closing brackets
+   * @see https://eslint.style/rules/jsx/jsx-tag-spacing
+   */
   '@stylistic/jsx/jsx-tag-spacing': JsxTagSpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/jsx/jsx-wrap-multilines} */
+  /**
+   * Disallow missing parentheses around multiline JSX
+   * @see https://eslint.style/rules/jsx/jsx-wrap-multilines
+   */
   '@stylistic/jsx/jsx-wrap-multilines': JsxWrapMultilinesRuleOptions
-  /** @see {@link https://eslint.style/rules/jsx/self-closing-comp} */
-  '@stylistic/jsx/self-closing-comp': SelfClosingCompRuleOptions
 }
 
 export interface UnprefixedRuleOptions {
+  /**
+   * Enforce or disallow spaces inside of curly braces in JSX attributes and expressions
+   * @see https://eslint.style/rules/jsx/jsx-child-element-spacing
+   */
   'jsx-child-element-spacing': JsxChildElementSpacingRuleOptions
+  /**
+   * Enforce closing bracket location in JSX
+   * @see https://eslint.style/rules/jsx/jsx-closing-bracket-location
+   */
   'jsx-closing-bracket-location': JsxClosingBracketLocationRuleOptions
+  /**
+   * Enforce closing tag location for multiline JSX
+   * @see https://eslint.style/rules/jsx/jsx-closing-tag-location
+   */
   'jsx-closing-tag-location': JsxClosingTagLocationRuleOptions
+  /**
+   * Disallow unnecessary JSX expressions when literals alone are sufficient or enforce JSX expressions on literals in JSX children or attributes
+   * @see https://eslint.style/rules/jsx/jsx-curly-brace-presence
+   */
   'jsx-curly-brace-presence': JsxCurlyBracePresenceRuleOptions
+  /**
+   * Enforce consistent linebreaks in curly braces in JSX attributes and expressions
+   * @see https://eslint.style/rules/jsx/jsx-curly-newline
+   */
   'jsx-curly-newline': JsxCurlyNewlineRuleOptions
+  /**
+   * Enforce or disallow spaces inside of curly braces in JSX attributes and expressions
+   * @see https://eslint.style/rules/jsx/jsx-curly-spacing
+   */
   'jsx-curly-spacing': JsxCurlySpacingRuleOptions
+  /**
+   * Enforce or disallow spaces around equal signs in JSX attributes
+   * @see https://eslint.style/rules/jsx/jsx-equals-spacing
+   */
   'jsx-equals-spacing': JsxEqualsSpacingRuleOptions
+  /**
+   * Enforce proper position of the first property in JSX
+   * @see https://eslint.style/rules/jsx/jsx-first-prop-new-line
+   */
   'jsx-first-prop-new-line': JsxFirstPropNewLineRuleOptions
-  'jsx-indent-props': JsxIndentPropsRuleOptions
+  /**
+   * Enforce JSX indentation
+   * @see https://eslint.style/rules/jsx/jsx-indent
+   */
   'jsx-indent': JsxIndentRuleOptions
+  /**
+   * Enforce props indentation in JSX
+   * @see https://eslint.style/rules/jsx/jsx-indent-props
+   */
+  'jsx-indent-props': JsxIndentPropsRuleOptions
+  /**
+   * Enforce maximum of props on a single line in JSX
+   * @see https://eslint.style/rules/jsx/jsx-max-props-per-line
+   */
   'jsx-max-props-per-line': JsxMaxPropsPerLineRuleOptions
+  /**
+   * Require or prevent a new line after jsx elements and expressions.
+   * @see https://eslint.style/rules/jsx/jsx-newline
+   */
   'jsx-newline': JsxNewlineRuleOptions
+  /**
+   * Require one JSX element per line
+   * @see https://eslint.style/rules/jsx/jsx-one-expression-per-line
+   */
   'jsx-one-expression-per-line': JsxOneExpressionPerLineRuleOptions
+  /**
+   * Disallow multiple spaces between inline JSX props
+   * @see https://eslint.style/rules/jsx/jsx-props-no-multi-spaces
+   */
   'jsx-props-no-multi-spaces': JsxPropsNoMultiSpacesRuleOptions
+  /**
+   * Disallow extra closing tags for components without children
+   * @see https://eslint.style/rules/jsx/jsx-self-closing-comp
+   */
+  'jsx-self-closing-comp': JsxSelfClosingCompRuleOptions
+  /**
+   * Enforce props alphabetical sorting
+   * @see https://eslint.style/rules/jsx/jsx-sort-props
+   */
   'jsx-sort-props': JsxSortPropsRuleOptions
+  /**
+   * Enforce whitespace in and around the JSX opening and closing brackets
+   * @see https://eslint.style/rules/jsx/jsx-tag-spacing
+   */
   'jsx-tag-spacing': JsxTagSpacingRuleOptions
+  /**
+   * Disallow missing parentheses around multiline JSX
+   * @see https://eslint.style/rules/jsx/jsx-wrap-multilines
+   */
   'jsx-wrap-multilines': JsxWrapMultilinesRuleOptions
-  'self-closing-comp': SelfClosingCompRuleOptions
 }

--- a/packages/eslint-plugin-ts/dts/rule-options.d.ts
+++ b/packages/eslint-plugin-ts/dts/rule-options.d.ts
@@ -106,13 +106,14 @@ export interface RuleOptions {
    */
   '@stylistic/ts/object-curly-spacing': ObjectCurlySpacingRuleOptions
   /**
-   * This rule extends the base
+   * This rule extends the base {@link https://eslint.style/rules/js/padding-line-between-statements padding-line-between-statements} rule.
+   * It adds support for TypeScript constructs such as interface and type.
    * @see {@link https://eslint.style/rules/ts/padding-line-between-statements}
    */
   '@stylistic/ts/padding-line-between-statements': PaddingLineBetweenStatementsRuleOptions
   /**
-   * This rule extends the base {@link https://eslint.style/rules/js/padding-line-between-statements padding-line-between-statements} rule.
-   * It adds support for TypeScript constructs such as interface and type.
+   * This rule extends the base {@link https://eslint.style/rules/js/quotes quotes} rule.
+   * It adds support for TypeScript features which allow quoted names, but not backtick quoted names.
    * @see {@link https://eslint.style/rules/ts/quotes}
    */
   '@stylistic/ts/quotes': QuotesRuleOptions

--- a/packages/eslint-plugin-ts/dts/rule-options.d.ts
+++ b/packages/eslint-plugin-ts/dts/rule-options.d.ts
@@ -21,27 +21,131 @@ import type { RuleOptions as SpaceInfixOpsRuleOptions } from '../rules/space-inf
 import type { RuleOptions as TypeAnnotationSpacingRuleOptions } from '../rules/type-annotation-spacing/types'
 
 export interface RuleOptions {
+  /**
+   * This rule extends the base {@link https://eslint.style/rules/js/block-spacing block-spacing} rule.
+   * This version adds support for TypeScript related blocks (interfaces, object type literals and enums).
+   * @see {@link https://eslint.style/rules/ts/block-spacing}
+   */
   '@stylistic/ts/block-spacing': BlockSpacingRuleOptions
+  /**
+   * This rule extends the base {@link https://eslint.style/rules/js/brace-style brace-style} rule.
+   * It adds support for enum, interface, namespace and module declarations.
+   * @see {@link https://eslint.style/rules/ts/brace-style}
+   */
   '@stylistic/ts/brace-style': BraceStyleRuleOptions
+  /**
+   * This rule extends the base {@link https://eslint.style/rules/js/comma-dangle comma-dangle} rule.
+   * It adds support for TypeScript syntax.
+   * See the {@link https://eslint.org/docs/latest/rules/comma-dangle ESLint documentation} for more details on the comma-dangle rule.
+   * @see {@link https://eslint.style/rules/ts/comma-dangle}
+   */
   '@stylistic/ts/comma-dangle': CommaDangleRuleOptions
+  /**
+   * This rule extends the base {@link https://eslint.style/rules/js/comma-spacing comma-spacing} rule.
+   * It adds support for trailing comma in a types parameters list.
+   * @see {@link https://eslint.style/rules/ts/comma-spacing}
+   */
   '@stylistic/ts/comma-spacing': CommaSpacingRuleOptions
+  /**
+   * This rule extends the base {@link https://eslint.style/rules/js/func-call-spacing func-call-spacing} rule.
+   * It adds support for generic type parameters on function calls.
+   * @see {@link https://eslint.style/rules/ts/func-call-spacing}
+   */
   '@stylistic/ts/func-call-spacing': FuncCallSpacingRuleOptions
+  /**
+   * This rule extends the base {@link https://eslint.style/rules/js/indent indent} rule. It adds support for TypeScript nodes.
+   * Please read Issue {@link https://github.com/typescript-eslint/typescript-eslint/issues/1824 #1824: Problems with the indent rule} before using this rule!
+   * @see {@link https://eslint.style/rules/ts/indent}
+   */
   '@stylistic/ts/indent': IndentRuleOptions
+  /**
+   * This rule extends the base {@link https://eslint.style/rules/js/key-spacing key-spacing} rule.
+   * It adds support for type annotations on interfaces, classes and type literals properties.
+   * @see {@link https://eslint.style/rules/ts/key-spacing}
+   */
   '@stylistic/ts/key-spacing': KeySpacingRuleOptions
+  /**
+   * This rule extends the base {@link https://eslint.style/rules/js/keyword-spacing keyword-spacing} rule.
+   * It adds support for generic type parameters on function calls.
+   * @see {@link https://eslint.style/rules/ts/keyword-spacing}
+   */
   '@stylistic/ts/keyword-spacing': KeywordSpacingRuleOptions
+  /**
+   * This rule extends the base {@link https://eslint.style/rules/js/lines-around-comment lines-around-comment} rule.
+   * It adds support for TypeScript syntax.
+   * See the {@link https://eslint.org/docs/latest/rules/lines-around-comment ESLint documentation} for more details on the lines-around-comment rule.
+   * @see {@link https://eslint.style/rules/ts/lines-around-comment}
+   */
   '@stylistic/ts/lines-around-comment': LinesAroundCommentRuleOptions
+  /**
+   * This rule extends the base {@link https://eslint.style/rules/js/lines-between-class-members lines-between-class-members} rule.
+   * It adds support for ignoring overload methods in a class.
+   * @see {@link https://eslint.style/rules/ts/lines-between-class-members}
+   */
   '@stylistic/ts/lines-between-class-members': LinesBetweenClassMembersRuleOptions
+  /**
+   * This rule enforces keeping to one configurable code style. It can also standardize the presence (or absence) of a delimiter in the last member of a construct, as well as a separate delimiter syntax for single line declarations.
+   * @see {@link https://eslint.style/rules/ts/member-delimiter-style}
+   */
   '@stylistic/ts/member-delimiter-style': MemberDelimiterStyleRuleOptions
+  /**
+   * This rule extends the base {@link https://eslint.style/rules/js/no-extra-parens no-extra-parens} rule.
+   * It adds support for TypeScript type assertions.
+   * @see {@link https://eslint.style/rules/ts/no-extra-parens}
+   */
   '@stylistic/ts/no-extra-parens': NoExtraParensRuleOptions
+  /**
+   * This rule extends the base {@link https://eslint.style/rules/js/no-extra-semi no-extra-semi }rule. It adds support for class properties.
+   * @see {@link https://eslint.style/rules/ts/no-extra-semi}
+   */
   '@stylistic/ts/no-extra-semi': NoExtraSemiRuleOptions
+  /**
+   * This rule extends the base {@link https://eslint.style/rules/js/object-curly-spacing object-curly-spacing} rule.
+   * It adds support for TypeScript's object types.
+   * @see {@link https://eslint.style/rules/ts/object-curly-spacing}
+   */
   '@stylistic/ts/object-curly-spacing': ObjectCurlySpacingRuleOptions
+  /**
+   * This rule extends the base
+   * @see {@link https://eslint.style/rules/ts/padding-line-between-statements}
+   */
   '@stylistic/ts/padding-line-between-statements': PaddingLineBetweenStatementsRuleOptions
+  /**
+   * This rule extends the base {@link https://eslint.style/rules/js/padding-line-between-statements padding-line-between-statements} rule.
+   * It adds support for TypeScript constructs such as interface and type.
+   * @see {@link https://eslint.style/rules/ts/quotes}
+   */
   '@stylistic/ts/quotes': QuotesRuleOptions
+  /**
+   * This rule extends the base {@link https://eslint.style/rules/js/semi semi} rule.
+   * It adds support for TypeScript features that require semicolons.
+   * @see {@link https://eslint.style/rules/ts/semi}
+   */
   '@stylistic/ts/semi': SemiRuleOptions
+  /**
+   * This rule extends the base {@link https://eslint.style/rules/js/space-before-blocks space-before-blocks} rule.
+   * It adds support for interfaces and enums.
+   * @see {@link https://eslint.style/rules/ts/space-before-blocks}
+   */
   '@stylistic/ts/space-before-blocks': SpaceBeforeBlocksRuleOptions
+  /**
+   * This rule extends the base {@link https://eslint.style/rules/js/space-before-function-paren space-before-function-paren }rule.
+   * It adds support for generic type parameters on function calls.
+   * @see {@link https://eslint.style/rules/ts/space-before-function-paren}
+   */
   '@stylistic/ts/space-before-function-paren': SpaceBeforeFunctionParenRuleOptions
+  /**
+   * This rule extends the base {@link https://eslint.style/rules/js/space-infix-ops space-infix-ops} rule.
+   * It adds support for enum members.
+   * @see {@link https://eslint.style/rules/ts/space-infix-ops}
+   */
   '@stylistic/ts/space-infix-ops': SpaceInfixOpsRuleOptions
+  /**
+   * This rule aims to enforce specific spacing patterns around type annotations and function types in type literals.
+   * @see {@link https://eslint.style/rules/ts/type-annotation-spacing}
+   */
   '@stylistic/ts/type-annotation-spacing': TypeAnnotationSpacingRuleOptions
+
 }
 
 export interface UnprefixedRuleOptions {

--- a/packages/eslint-plugin-ts/dts/rule-options.d.ts
+++ b/packages/eslint-plugin-ts/dts/rule-options.d.ts
@@ -21,132 +21,48 @@ import type { RuleOptions as SpaceInfixOpsRuleOptions } from '../rules/space-inf
 import type { RuleOptions as TypeAnnotationSpacingRuleOptions } from '../rules/type-annotation-spacing/types'
 
 export interface RuleOptions {
-  /**
-   * This rule extends the base {@link https://eslint.style/rules/js/block-spacing block-spacing} rule.
-   * This version adds support for TypeScript related blocks (interfaces, object type literals and enums).
-   * @see {@link https://eslint.style/rules/ts/block-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/ts/block-spacing} */
   '@stylistic/ts/block-spacing': BlockSpacingRuleOptions
-  /**
-   * This rule extends the base {@link https://eslint.style/rules/js/brace-style brace-style} rule.
-   * It adds support for enum, interface, namespace and module declarations.
-   * @see {@link https://eslint.style/rules/ts/brace-style}
-   */
+  /** @see {@link https://eslint.style/rules/ts/brace-style} */
   '@stylistic/ts/brace-style': BraceStyleRuleOptions
-  /**
-   * This rule extends the base {@link https://eslint.style/rules/js/comma-dangle comma-dangle} rule.
-   * It adds support for TypeScript syntax.
-   * See the {@link https://eslint.org/docs/latest/rules/comma-dangle ESLint documentation} for more details on the comma-dangle rule.
-   * @see {@link https://eslint.style/rules/ts/comma-dangle}
-   */
+  /** @see {@link https://eslint.style/rules/ts/comma-dangle} */
   '@stylistic/ts/comma-dangle': CommaDangleRuleOptions
-  /**
-   * This rule extends the base {@link https://eslint.style/rules/js/comma-spacing comma-spacing} rule.
-   * It adds support for trailing comma in a types parameters list.
-   * @see {@link https://eslint.style/rules/ts/comma-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/ts/comma-spacing} */
   '@stylistic/ts/comma-spacing': CommaSpacingRuleOptions
-  /**
-   * This rule extends the base {@link https://eslint.style/rules/js/func-call-spacing func-call-spacing} rule.
-   * It adds support for generic type parameters on function calls.
-   * @see {@link https://eslint.style/rules/ts/func-call-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/ts/func-call-spacing} */
   '@stylistic/ts/func-call-spacing': FuncCallSpacingRuleOptions
-  /**
-   * This rule extends the base {@link https://eslint.style/rules/js/indent indent} rule. It adds support for TypeScript nodes.
-   * Please read Issue {@link https://github.com/typescript-eslint/typescript-eslint/issues/1824 #1824: Problems with the indent rule} before using this rule!
-   * @see {@link https://eslint.style/rules/ts/indent}
-   */
+  /** @see {@link https://eslint.style/rules/ts/indent} */
   '@stylistic/ts/indent': IndentRuleOptions
-  /**
-   * This rule extends the base {@link https://eslint.style/rules/js/key-spacing key-spacing} rule.
-   * It adds support for type annotations on interfaces, classes and type literals properties.
-   * @see {@link https://eslint.style/rules/ts/key-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/ts/key-spacing} */
   '@stylistic/ts/key-spacing': KeySpacingRuleOptions
-  /**
-   * This rule extends the base {@link https://eslint.style/rules/js/keyword-spacing keyword-spacing} rule.
-   * It adds support for generic type parameters on function calls.
-   * @see {@link https://eslint.style/rules/ts/keyword-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/ts/keyword-spacing} */
   '@stylistic/ts/keyword-spacing': KeywordSpacingRuleOptions
-  /**
-   * This rule extends the base {@link https://eslint.style/rules/js/lines-around-comment lines-around-comment} rule.
-   * It adds support for TypeScript syntax.
-   * See the {@link https://eslint.org/docs/latest/rules/lines-around-comment ESLint documentation} for more details on the lines-around-comment rule.
-   * @see {@link https://eslint.style/rules/ts/lines-around-comment}
-   */
+  /** @see {@link https://eslint.style/rules/ts/lines-around-comment} */
   '@stylistic/ts/lines-around-comment': LinesAroundCommentRuleOptions
-  /**
-   * This rule extends the base {@link https://eslint.style/rules/js/lines-between-class-members lines-between-class-members} rule.
-   * It adds support for ignoring overload methods in a class.
-   * @see {@link https://eslint.style/rules/ts/lines-between-class-members}
-   */
+  /** @see {@link https://eslint.style/rules/ts/lines-between-class-members} */
   '@stylistic/ts/lines-between-class-members': LinesBetweenClassMembersRuleOptions
-  /**
-   * This rule enforces keeping to one configurable code style. It can also standardize the presence (or absence) of a delimiter in the last member of a construct, as well as a separate delimiter syntax for single line declarations.
-   * @see {@link https://eslint.style/rules/ts/member-delimiter-style}
-   */
+  /** @see {@link https://eslint.style/rules/ts/member-delimiter-style} */
   '@stylistic/ts/member-delimiter-style': MemberDelimiterStyleRuleOptions
-  /**
-   * This rule extends the base {@link https://eslint.style/rules/js/no-extra-parens no-extra-parens} rule.
-   * It adds support for TypeScript type assertions.
-   * @see {@link https://eslint.style/rules/ts/no-extra-parens}
-   */
+  /** @see {@link https://eslint.style/rules/ts/no-extra-parens} */
   '@stylistic/ts/no-extra-parens': NoExtraParensRuleOptions
-  /**
-   * This rule extends the base {@link https://eslint.style/rules/js/no-extra-semi no-extra-semi }rule. It adds support for class properties.
-   * @see {@link https://eslint.style/rules/ts/no-extra-semi}
-   */
+  /** @see {@link https://eslint.style/rules/ts/no-extra-semi} */
   '@stylistic/ts/no-extra-semi': NoExtraSemiRuleOptions
-  /**
-   * This rule extends the base {@link https://eslint.style/rules/js/object-curly-spacing object-curly-spacing} rule.
-   * It adds support for TypeScript's object types.
-   * @see {@link https://eslint.style/rules/ts/object-curly-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/ts/object-curly-spacing} */
   '@stylistic/ts/object-curly-spacing': ObjectCurlySpacingRuleOptions
-  /**
-   * This rule extends the base {@link https://eslint.style/rules/js/padding-line-between-statements padding-line-between-statements} rule.
-   * It adds support for TypeScript constructs such as interface and type.
-   * @see {@link https://eslint.style/rules/ts/padding-line-between-statements}
-   */
+  /** @see {@link https://eslint.style/rules/ts/padding-line-between-statements} */
   '@stylistic/ts/padding-line-between-statements': PaddingLineBetweenStatementsRuleOptions
-  /**
-   * This rule extends the base {@link https://eslint.style/rules/js/quotes quotes} rule.
-   * It adds support for TypeScript features which allow quoted names, but not backtick quoted names.
-   * @see {@link https://eslint.style/rules/ts/quotes}
-   */
+  /** @see {@link https://eslint.style/rules/ts/quotes} */
   '@stylistic/ts/quotes': QuotesRuleOptions
-  /**
-   * This rule extends the base {@link https://eslint.style/rules/js/semi semi} rule.
-   * It adds support for TypeScript features that require semicolons.
-   * @see {@link https://eslint.style/rules/ts/semi}
-   */
+  /** @see {@link https://eslint.style/rules/ts/semi} */
   '@stylistic/ts/semi': SemiRuleOptions
-  /**
-   * This rule extends the base {@link https://eslint.style/rules/js/space-before-blocks space-before-blocks} rule.
-   * It adds support for interfaces and enums.
-   * @see {@link https://eslint.style/rules/ts/space-before-blocks}
-   */
+  /** @see {@link https://eslint.style/rules/ts/space-before-blocks} */
   '@stylistic/ts/space-before-blocks': SpaceBeforeBlocksRuleOptions
-  /**
-   * This rule extends the base {@link https://eslint.style/rules/js/space-before-function-paren space-before-function-paren }rule.
-   * It adds support for generic type parameters on function calls.
-   * @see {@link https://eslint.style/rules/ts/space-before-function-paren}
-   */
+  /** @see {@link https://eslint.style/rules/ts/space-before-function-paren} */
   '@stylistic/ts/space-before-function-paren': SpaceBeforeFunctionParenRuleOptions
-  /**
-   * This rule extends the base {@link https://eslint.style/rules/js/space-infix-ops space-infix-ops} rule.
-   * It adds support for enum members.
-   * @see {@link https://eslint.style/rules/ts/space-infix-ops}
-   */
+  /** @see {@link https://eslint.style/rules/ts/space-infix-ops} */
   '@stylistic/ts/space-infix-ops': SpaceInfixOpsRuleOptions
-  /**
-   * This rule aims to enforce specific spacing patterns around type annotations and function types in type literals.
-   * @see {@link https://eslint.style/rules/ts/type-annotation-spacing}
-   */
+  /** @see {@link https://eslint.style/rules/ts/type-annotation-spacing} */
   '@stylistic/ts/type-annotation-spacing': TypeAnnotationSpacingRuleOptions
-
 }
 
 export interface UnprefixedRuleOptions {

--- a/packages/eslint-plugin-ts/dts/rule-options.d.ts
+++ b/packages/eslint-plugin-ts/dts/rule-options.d.ts
@@ -21,70 +21,217 @@ import type { RuleOptions as SpaceInfixOpsRuleOptions } from '../rules/space-inf
 import type { RuleOptions as TypeAnnotationSpacingRuleOptions } from '../rules/type-annotation-spacing/types'
 
 export interface RuleOptions {
-  /** @see {@link https://eslint.style/rules/ts/block-spacing} */
+  /**
+   * Disallow or enforce spaces inside of blocks after opening block and before closing block
+   * @see https://eslint.style/rules/ts/block-spacing
+   */
   '@stylistic/ts/block-spacing': BlockSpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/ts/brace-style} */
+  /**
+   * Enforce consistent brace style for blocks
+   * @see https://eslint.style/rules/ts/brace-style
+   */
   '@stylistic/ts/brace-style': BraceStyleRuleOptions
-  /** @see {@link https://eslint.style/rules/ts/comma-dangle} */
+  /**
+   * Require or disallow trailing commas
+   * @see https://eslint.style/rules/ts/comma-dangle
+   */
   '@stylistic/ts/comma-dangle': CommaDangleRuleOptions
-  /** @see {@link https://eslint.style/rules/ts/comma-spacing} */
+  /**
+   * Enforce consistent spacing before and after commas
+   * @see https://eslint.style/rules/ts/comma-spacing
+   */
   '@stylistic/ts/comma-spacing': CommaSpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/ts/func-call-spacing} */
+  /**
+   * Require or disallow spacing between function identifiers and their invocations
+   * @see https://eslint.style/rules/ts/func-call-spacing
+   */
   '@stylistic/ts/func-call-spacing': FuncCallSpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/ts/indent} */
+  /**
+   * Enforce consistent indentation
+   * @see https://eslint.style/rules/ts/indent
+   */
   '@stylistic/ts/indent': IndentRuleOptions
-  /** @see {@link https://eslint.style/rules/ts/key-spacing} */
+  /**
+   * Enforce consistent spacing between property names and type annotations in types and interfaces
+   * @see https://eslint.style/rules/ts/key-spacing
+   */
   '@stylistic/ts/key-spacing': KeySpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/ts/keyword-spacing} */
+  /**
+   * Enforce consistent spacing before and after keywords
+   * @see https://eslint.style/rules/ts/keyword-spacing
+   */
   '@stylistic/ts/keyword-spacing': KeywordSpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/ts/lines-around-comment} */
+  /**
+   * Require empty lines around comments
+   * @see https://eslint.style/rules/ts/lines-around-comment
+   */
   '@stylistic/ts/lines-around-comment': LinesAroundCommentRuleOptions
-  /** @see {@link https://eslint.style/rules/ts/lines-between-class-members} */
+  /**
+   * Require or disallow an empty line between class members
+   * @see https://eslint.style/rules/ts/lines-between-class-members
+   */
   '@stylistic/ts/lines-between-class-members': LinesBetweenClassMembersRuleOptions
-  /** @see {@link https://eslint.style/rules/ts/member-delimiter-style} */
+  /**
+   * Require a specific member delimiter style for interfaces and type literals
+   * @see https://eslint.style/rules/ts/member-delimiter-style
+   */
   '@stylistic/ts/member-delimiter-style': MemberDelimiterStyleRuleOptions
-  /** @see {@link https://eslint.style/rules/ts/no-extra-parens} */
+  /**
+   * Disallow unnecessary parentheses
+   * @see https://eslint.style/rules/ts/no-extra-parens
+   */
   '@stylistic/ts/no-extra-parens': NoExtraParensRuleOptions
-  /** @see {@link https://eslint.style/rules/ts/no-extra-semi} */
+  /**
+   * Disallow unnecessary semicolons
+   * @see https://eslint.style/rules/ts/no-extra-semi
+   */
   '@stylistic/ts/no-extra-semi': NoExtraSemiRuleOptions
-  /** @see {@link https://eslint.style/rules/ts/object-curly-spacing} */
+  /**
+   * Enforce consistent spacing inside braces
+   * @see https://eslint.style/rules/ts/object-curly-spacing
+   */
   '@stylistic/ts/object-curly-spacing': ObjectCurlySpacingRuleOptions
-  /** @see {@link https://eslint.style/rules/ts/padding-line-between-statements} */
+  /**
+   * Require or disallow padding lines between statements
+   * @see https://eslint.style/rules/ts/padding-line-between-statements
+   */
   '@stylistic/ts/padding-line-between-statements': PaddingLineBetweenStatementsRuleOptions
-  /** @see {@link https://eslint.style/rules/ts/quotes} */
+  /**
+   * Enforce the consistent use of either backticks, double, or single quotes
+   * @see https://eslint.style/rules/ts/quotes
+   */
   '@stylistic/ts/quotes': QuotesRuleOptions
-  /** @see {@link https://eslint.style/rules/ts/semi} */
+  /**
+   * Require or disallow semicolons instead of ASI
+   * @see https://eslint.style/rules/ts/semi
+   */
   '@stylistic/ts/semi': SemiRuleOptions
-  /** @see {@link https://eslint.style/rules/ts/space-before-blocks} */
+  /**
+   * Enforce consistent spacing before blocks
+   * @see https://eslint.style/rules/ts/space-before-blocks
+   */
   '@stylistic/ts/space-before-blocks': SpaceBeforeBlocksRuleOptions
-  /** @see {@link https://eslint.style/rules/ts/space-before-function-paren} */
+  /**
+   * Enforce consistent spacing before function parenthesis
+   * @see https://eslint.style/rules/ts/space-before-function-paren
+   */
   '@stylistic/ts/space-before-function-paren': SpaceBeforeFunctionParenRuleOptions
-  /** @see {@link https://eslint.style/rules/ts/space-infix-ops} */
+  /**
+   * Require spacing around infix operators
+   * @see https://eslint.style/rules/ts/space-infix-ops
+   */
   '@stylistic/ts/space-infix-ops': SpaceInfixOpsRuleOptions
-  /** @see {@link https://eslint.style/rules/ts/type-annotation-spacing} */
+  /**
+   * Require consistent spacing around type annotations
+   * @see https://eslint.style/rules/ts/type-annotation-spacing
+   */
   '@stylistic/ts/type-annotation-spacing': TypeAnnotationSpacingRuleOptions
 }
 
 export interface UnprefixedRuleOptions {
+  /**
+   * Disallow or enforce spaces inside of blocks after opening block and before closing block
+   * @see https://eslint.style/rules/ts/block-spacing
+   */
   'block-spacing': BlockSpacingRuleOptions
+  /**
+   * Enforce consistent brace style for blocks
+   * @see https://eslint.style/rules/ts/brace-style
+   */
   'brace-style': BraceStyleRuleOptions
+  /**
+   * Require or disallow trailing commas
+   * @see https://eslint.style/rules/ts/comma-dangle
+   */
   'comma-dangle': CommaDangleRuleOptions
+  /**
+   * Enforce consistent spacing before and after commas
+   * @see https://eslint.style/rules/ts/comma-spacing
+   */
   'comma-spacing': CommaSpacingRuleOptions
+  /**
+   * Require or disallow spacing between function identifiers and their invocations
+   * @see https://eslint.style/rules/ts/func-call-spacing
+   */
   'func-call-spacing': FuncCallSpacingRuleOptions
+  /**
+   * Enforce consistent indentation
+   * @see https://eslint.style/rules/ts/indent
+   */
   'indent': IndentRuleOptions
+  /**
+   * Enforce consistent spacing between property names and type annotations in types and interfaces
+   * @see https://eslint.style/rules/ts/key-spacing
+   */
   'key-spacing': KeySpacingRuleOptions
+  /**
+   * Enforce consistent spacing before and after keywords
+   * @see https://eslint.style/rules/ts/keyword-spacing
+   */
   'keyword-spacing': KeywordSpacingRuleOptions
+  /**
+   * Require empty lines around comments
+   * @see https://eslint.style/rules/ts/lines-around-comment
+   */
   'lines-around-comment': LinesAroundCommentRuleOptions
+  /**
+   * Require or disallow an empty line between class members
+   * @see https://eslint.style/rules/ts/lines-between-class-members
+   */
   'lines-between-class-members': LinesBetweenClassMembersRuleOptions
+  /**
+   * Require a specific member delimiter style for interfaces and type literals
+   * @see https://eslint.style/rules/ts/member-delimiter-style
+   */
   'member-delimiter-style': MemberDelimiterStyleRuleOptions
+  /**
+   * Disallow unnecessary parentheses
+   * @see https://eslint.style/rules/ts/no-extra-parens
+   */
   'no-extra-parens': NoExtraParensRuleOptions
+  /**
+   * Disallow unnecessary semicolons
+   * @see https://eslint.style/rules/ts/no-extra-semi
+   */
   'no-extra-semi': NoExtraSemiRuleOptions
+  /**
+   * Enforce consistent spacing inside braces
+   * @see https://eslint.style/rules/ts/object-curly-spacing
+   */
   'object-curly-spacing': ObjectCurlySpacingRuleOptions
+  /**
+   * Require or disallow padding lines between statements
+   * @see https://eslint.style/rules/ts/padding-line-between-statements
+   */
   'padding-line-between-statements': PaddingLineBetweenStatementsRuleOptions
+  /**
+   * Enforce the consistent use of either backticks, double, or single quotes
+   * @see https://eslint.style/rules/ts/quotes
+   */
   'quotes': QuotesRuleOptions
+  /**
+   * Require or disallow semicolons instead of ASI
+   * @see https://eslint.style/rules/ts/semi
+   */
   'semi': SemiRuleOptions
+  /**
+   * Enforce consistent spacing before blocks
+   * @see https://eslint.style/rules/ts/space-before-blocks
+   */
   'space-before-blocks': SpaceBeforeBlocksRuleOptions
+  /**
+   * Enforce consistent spacing before function parenthesis
+   * @see https://eslint.style/rules/ts/space-before-function-paren
+   */
   'space-before-function-paren': SpaceBeforeFunctionParenRuleOptions
+  /**
+   * Require spacing around infix operators
+   * @see https://eslint.style/rules/ts/space-infix-ops
+   */
   'space-infix-ops': SpaceInfixOpsRuleOptions
+  /**
+   * Require consistent spacing around type annotations
+   * @see https://eslint.style/rules/ts/type-annotation-spacing
+   */
   'type-annotation-spacing': TypeAnnotationSpacingRuleOptions
 }

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -294,15 +294,21 @@ export type RuleOptions = ${ruleOptionTypeValue}
     const name = basename(rule).replace(/\.\w+$/, '')
     return `import type { RuleOptions as ${pascalCase(name)}RuleOptions } from '../rules/${name}/types'`
   })
+  // For generating jsdoc
+  const docsLink = `https://eslint.style/rules/${prefix.replace('@stylistic/', '')}/`
 
   await fs.writeFile(
     join(targetRoot, 'dts', 'rule-options.d.ts'),
 `${ruleOptionsImports.join('\n')}
 
 export interface RuleOptions {
-  ${rules.map((rule) => {
+  ${rules.flatMap((rule) => {
 const name = basename(rule).replace(/\.\w+$/, '')
-return `'${prefix}/${name}': ${pascalCase(name)}RuleOptions`
+const link = docsLink + name
+return [
+  `/** @see {@link ${link}} */`,
+  `'${prefix}/${name}': ${pascalCase(name)}RuleOptions`,
+]
 }).join('\n    ')}
 }
 

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -18,7 +18,6 @@
 import { existsSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { basename, join } from 'node:path'
-import { pascalCase } from 'change-case'
 import fs from 'fs-extra'
 import fg from 'fast-glob'
 import type { JSONSchema4 } from 'json-schema'
@@ -288,52 +287,6 @@ export type RuleOptions = ${ruleOptionTypeValue}
 'utf-8',
     )
   }))
-
-  // Write eslint-define-config support file
-  const ruleOptionsImports = rules.map((rule) => {
-    const name = basename(rule).replace(/\.\w+$/, '')
-    return `import type { RuleOptions as ${pascalCase(name)}RuleOptions } from '../rules/${name}/types'`
-  })
-  // For generating jsdoc
-  const docsLink = `https://eslint.style/rules/${prefix.replace('@stylistic/', '')}/`
-
-  await fs.writeFile(
-    join(targetRoot, 'dts', 'rule-options.d.ts'),
-`${ruleOptionsImports.join('\n')}
-
-export interface RuleOptions {
-  ${rules.flatMap((rule) => {
-const name = basename(rule).replace(/\.\w+$/, '')
-const link = docsLink + name
-return [
-  `/** @see {@link ${link}} */`,
-  `'${prefix}/${name}': ${pascalCase(name)}RuleOptions`,
-]
-}).join('\n    ')}
-}
-
-export interface UnprefixedRuleOptions {
-  ${rules.map((rule) => {
-const name = basename(rule).replace(/\.\w+$/, '')
-return `'${name}': ${pascalCase(name)}RuleOptions`
-}).join('\n    ')}
-}
-`,
-'utf-8',
-  )
-
-  await fs.writeFile(
-    join(targetRoot, 'dts', 'define-config-support.d.ts'),
-`import type { RuleOptions } from './rule-options'
-
-declare module 'eslint-define-config' {
-  export interface CustomRuleOptions extends RuleOptions {}
-}
-
-export {}
-`,
-'utf-8',
-  )
 }
 
 async function migrateTS() {


### PR DESCRIPTION
I use `eslint-stylistic` to create my own eslint rules, but it doesn't provide docs link or description, so this pr is aimed to add these.

![image](https://github.com/eslint-stylistic/eslint-stylistic/assets/99574369/d1628c5f-e710-4818-ad99-3b2ad31c7564)
