### PR TITLE
docs: fix grammar issues and improve writing

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -10,13 +10,13 @@ According to [`typescript-eslint`'s definition](https://typescript-eslint.io/lin
 
 ---
 
-- **Logical**: Rules that care about the logic in runtime behavior of code (such as missing awaits or invalid logical checks).
-- **Stylistic**: Rules that care about style concerns which do impact runtime behavior of code, but generally not logic. These are mostly around naming or which roughly-equivalent syntax constructs to use (such as function declarations vs. arrow functions).
-  - **Formatting**: Stylistic rules that care only about trivia (semicolons, whitespace, etc.) without impacting the runtime behavior of the code. These rules conflict with dedicated formatters such as Prettier.
+- **Logical**: Rules that are concerned with the logic and runtime behavior of code (such as missing awaits or invalid logical checks).
+- **Stylistic**: Rules that focus on style concerns which do not generally impact the runtime behavior of code. These are mostly about naming or which roughly equivalent syntax constructs to use (such as function declarations vs. arrow functions).
+  - **Formatting**: A subset of Stylistic rules that are solely concerned with trivia (semicolons, whitespace, etc.) and do not affect the runtime behavior of the code. These rules may conflict with dedicated formatters such as Prettier.
 
 ---
 
-For ESLint Stylistic, our main scope is the **formatting** and **stylistic** rules inherited from `eslint` / `typescript-eslint`. We will maintain some stylistic rules, but not all stylistic rules will be included. It depends whether the upstream projects want to keep them. We are welcoming new rules proposed by the community in the future when we move to the maintenance stage and develop the infrastructure for introducing experimental rules. Track on [Project Progress](/contribute/project-progress) for more details.
+For ESLint Stylistic, our primary focus is on the **formatting** and **stylistic** rules inherited from `eslint` and `typescript-eslint`. We will maintain some stylistic rules; however, not all will be included. Their inclusion depends on whether the upstream projects choose to retain them. We welcome new rules proposed by the community for the future when we move into the maintenance phase and develop the infrastructure to introduce experimental rules. For more details, track the [Project Progress](/contribute/project-progress).
 
 ## How to auto-format on save?
 

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -4,13 +4,13 @@
 
 For production projects, we would recommend waiting a bit longer, until ESLint officially announces the deprecation list.
 
-At the current stage, the packages are already useable. We are more then happy to see you start trying them out and give us feedback.
+At the current stage, the packages are already usable. We are more than happy to see you start trying them out and giving us feedback.
 
 The benefits of migrating:
 
-- Future-proof, the rules in core will no longer be updated and might be removed at some point. The maintenance work will be shifted to here.
-- Clear scope of rules, you can see more clearly what rules are related to code style by the prefix `@stylistic/`
-- Better IDE experience, you can config your IDE to [hide the error messages for code style rules](/guide/faq#the-error-messages-squiggly-lines-for-code-style-are-annoying) with scoping and does require to list manually.
+- Future-proof; the rules in core will no longer be updated and might be removed at some point. The maintenance work will be shifted to here.
+- Clear scope of rules; you can see more clearly what rules are related to code style by the prefix `@stylistic/`
+- Better IDE experience; you can configure your IDE to [hide the error messages for code style rules](/guide/faq#the-error-messages-squiggly-lines-for-code-style-are-annoying) with scoping and not require listing manually.
 
 ::: tip
 Check the [project progress](/contribute/project-progress) first to learn more about the current status of this project.
@@ -22,7 +22,7 @@ ESLint Stylistic is migrated from 3 different sources packages:
 
 - `eslint` -> `@stylistic/eslint-plugin-js`
   - Built-in stylistic rules for JavaScript
-- `@typescript-eslint/eslint-plugin` -> `@stylistic/eslint-plugin-ts` 
+- `@typescript-eslint/eslint-plugin` -> `@stylistic/eslint-plugin-ts`
   - Stylistic rules for TypeScript
 - `eslint-plugin-react` -> `@stylistic/eslint-plugin-jsx`
   - Framework-agnostic JSX rules
@@ -87,7 +87,7 @@ module.exports = {
 
 ### Approach 2: Migrate to 1-to-1 Plugins
 
-To make the migration easier, we also provide 1-to-1 mapping plugins for each source package. Different from the [single plugin](#approach-1-migrate-to-single-plugin), you need to install 3 different packages with additional prefixes in rules.
+To make the migration easier, we also provide a 1-to-1 mapping for each source package's plugins. Unlike the [single plugin approach](#approach-1-migrate-to-single-plugin), you need to install 3 different packages with additional prefixes in the rules.
 
 #### ESLint Code (JavaScript)
 

--- a/docs/guide/why.md
+++ b/docs/guide/why.md
@@ -4,7 +4,7 @@ This project was initiated as ESLint and `typescript-eslint` teams [decided to d
 
 ## Linters vs. Formatters
 
-You might have seen some discussions discouraging using ESLint to format source code, as Linters and Formatters are tools in different scopes. While we generally agree that ESLint would not be the most efficient tool to do formatting, we see that currently ESLint with auto-fix is still the best tool to do **source code** formatting, as it provides fine-grained control of each rule, having incredible extensibility, and respects the input of the source code.
+You might have seen some discussions discouraging using ESLint to format source code, as Linters and Formatters are tools in different scopes. While we generally agree that ESLint would not be the most efficient tool to do formatting, we see that currently ESLint with auto-fix is still the best tool for **source code** formatting, as it provides fine-grained control of each rule, having incredible extensibility, and respects the input of the source code.
 
 The popular formatters like [Prettier](https://github.com/prettier/prettier) and [dprint](https://dprint.dev/) are great on formatting code. However, the main issue we see is that their ["read-and-reprints"](https://prettier.io/docs/en/) approach **throw away all the stylistic information from the source code**, meaning that we can't preserve the styles that we consider more "human-readable".
 
@@ -14,10 +14,10 @@ Here are two examples that Prettier and dprint would force the code wrap/unwrap 
 
 ![](/images/format-dprint.png)
 
-This behaviour is [mandatory](https://github.com/prettier/prettier/issues/3468) as it's the side-effect for their approach fundamentally.
+This behavior is [mandatory](https://github.com/prettier/prettier/issues/3468) due to the fundamental nature of their approach.
 
-With stylistic rules in ESLint, we are able to achieve similar formatting compatibility while retain the original code style as the authors/teams' intention, and doing the fix in one-go.
+With stylistic rules in ESLint, we are able to achieve similar formatting compatibility while retaining the original code style that reflects the authors/teams' intentions, and apply fixes in one-go.
 
-This project is maintained for those who cares such details and want to have full control of the code style.
+This project is maintained for those who care about such details and want to have full control of the code style.
 
 If you are interested in learning more, we recommend reading [Anthony Fu](https://antfu.me/)'s [*Why I don't use Prettier*](https://antfu.me/posts/why-not-prettier) post.


### PR DESCRIPTION
Thanks for porting these rules. I noticed a few typos and grammar issues that can be improved during the migration.