### PR TITLE
refactor(eslint-plugin-js): ESM migration `array-bracket-newline`

### DIFF
--- a/packages/eslint-plugin-js/rules/array-bracket-newline/array-bracket-newline.js
+++ b/packages/eslint-plugin-js/rules/array-bracket-newline/array-bracket-newline.js
@@ -102,8 +102,10 @@ export default {
      */
     function normalizeOptions(options) {
       const value = normalizeOptionValue(options)
+
       return { ArrayExpression: value, ArrayPattern: value }
     }
+
     /**
      * Reports that there shouldn't be a linebreak after the first token
      * @param {ASTNode} node The node to report in the event of an error.
@@ -117,8 +119,10 @@ export default {
         messageId: 'unexpectedOpeningLinebreak',
         fix(fixer) {
           const nextToken = sourceCode.getTokenAfter(token, { includeComments: true })
+
           if (astUtils.isCommentToken(nextToken))
             return null
+
           return fixer.removeRange([token.range[1], nextToken.range[0]])
         },
       })
@@ -137,8 +141,10 @@ export default {
         messageId: 'unexpectedClosingLinebreak',
         fix(fixer) {
           const previousToken = sourceCode.getTokenBefore(token, { includeComments: true })
+
           if (astUtils.isCommentToken(previousToken))
             return null
+
           return fixer.removeRange([previousToken.range[1], token.range[0]])
         },
       })
@@ -193,16 +199,24 @@ export default {
       const lastIncComment = sourceCode.getTokenBefore(closeBracket, { includeComments: true })
       const first = sourceCode.getTokenAfter(openBracket)
       const last = sourceCode.getTokenBefore(closeBracket)
-      const needsLinebreaks = (elements.length >= options.minItems
-        || (options.multiline
+      const needsLinebreaks = (
+        elements.length >= options.minItems
+        || (
+          options.multiline
           && elements.length > 0
-          && firstIncComment.loc.start.line !== lastIncComment.loc.end.line)
-        || (elements.length === 0
+          && firstIncComment.loc.start.line !== lastIncComment.loc.end.line
+        )
+        || (
+          elements.length === 0
           && firstIncComment.type === 'Block'
           && firstIncComment.loc.start.line !== lastIncComment.loc.end.line
-          && firstIncComment === lastIncComment)
-        || (options.consistent
-          && openBracket.loc.end.line !== first.loc.start.line))
+          && firstIncComment === lastIncComment
+        )
+        || (
+          options.consistent
+          && openBracket.loc.end.line !== first.loc.start.line
+        )
+      )
 
       /*
        * Use tokens or comments to check multiline or not.

--- a/packages/eslint-plugin-js/rules/array-bracket-newline/array-bracket-newline.js
+++ b/packages/eslint-plugin-js/rules/array-bracket-newline/array-bracket-newline.js
@@ -10,231 +10,230 @@ import astUtils from '../../utils/ast-utils.js'
 // ------------------------------------------------------------------------------
 
 /** @type {import('eslint').Rule.RuleModule} */
-export const meta = {
-  type: 'layout',
+export default {
+  meta: {
+    type: 'layout',
 
-  docs: {
-    description: 'Enforce linebreaks after opening and before closing array brackets',
-    recommended: false,
-    url: 'https://eslint.style/rules/js/array-bracket-newline',
-  },
-
-  fixable: 'whitespace',
-
-  schema: [
-    {
-      oneOf: [
-        {
-          enum: ['always', 'never', 'consistent'],
-        },
-        {
-          type: 'object',
-          properties: {
-            multiline: {
-              type: 'boolean',
-            },
-            minItems: {
-              type: ['integer', 'null'],
-              minimum: 0,
-            },
-          },
-          additionalProperties: false,
-        },
-      ],
+    docs: {
+      description: 'Enforce linebreaks after opening and before closing array brackets',
+      recommended: false,
+      url: 'https://eslint.style/rules/js/array-bracket-newline',
     },
-  ],
 
-  messages: {
-    unexpectedOpeningLinebreak: 'There should be no linebreak after \'[\'.',
-    unexpectedClosingLinebreak: 'There should be no linebreak before \']\'.',
-    missingOpeningLinebreak: 'A linebreak is required after \'[\'.',
-    missingClosingLinebreak: 'A linebreak is required before \']\'.',
+    fixable: 'whitespace',
+
+    schema: [
+      {
+        oneOf: [
+          {
+            enum: ['always', 'never', 'consistent'],
+          },
+          {
+            type: 'object',
+            properties: {
+              multiline: {
+                type: 'boolean',
+              },
+              minItems: {
+                type: ['integer', 'null'],
+                minimum: 0,
+              },
+            },
+            additionalProperties: false,
+          },
+        ],
+      },
+    ],
+
+    messages: {
+      unexpectedOpeningLinebreak: 'There should be no linebreak after \'[\'.',
+      unexpectedClosingLinebreak: 'There should be no linebreak before \']\'.',
+      missingOpeningLinebreak: 'A linebreak is required after \'[\'.',
+      missingClosingLinebreak: 'A linebreak is required before \']\'.',
+    },
   },
-}
-export function create(context) {
-  const sourceCode = context.sourceCode
 
-  // ----------------------------------------------------------------------
-  // Helpers
-  // ----------------------------------------------------------------------
+  create(context) {
+    const sourceCode = context.sourceCode
 
-  /**
-   * Normalizes a given option value.
-   * @param {string | object | undefined} option An option value to parse.
-   * @returns {{multiline: boolean, minItems: number}} Normalized option object.
-   */
-  function normalizeOptionValue(option) {
-    let consistent = false
-    let multiline = false
-    let minItems = 0
+    // ----------------------------------------------------------------------
+    // Helpers
+    // ----------------------------------------------------------------------
 
-    if (option) {
-      if (option === 'consistent') {
-        consistent = true
-        minItems = Number.POSITIVE_INFINITY
-      }
-      else if (option === 'always' || option.minItems === 0) {
-        minItems = 0
-      }
-      else if (option === 'never') {
-        minItems = Number.POSITIVE_INFINITY
+    /**
+     * Normalizes a given option value.
+     * @param {string | object | undefined} option An option value to parse.
+     * @returns {{multiline: boolean, minItems: number}} Normalized option object.
+     */
+    function normalizeOptionValue(option) {
+      let consistent = false
+      let multiline = false
+      let minItems = 0
+
+      if (option) {
+        if (option === 'consistent') {
+          consistent = true
+          minItems = Number.POSITIVE_INFINITY
+        }
+        else if (option === 'always' || option.minItems === 0) {
+          minItems = 0
+        }
+        else if (option === 'never') {
+          minItems = Number.POSITIVE_INFINITY
+        }
+        else {
+          multiline = Boolean(option.multiline)
+          minItems = option.minItems || Number.POSITIVE_INFINITY
+        }
       }
       else {
-        multiline = Boolean(option.multiline)
-        minItems = option.minItems || Number.POSITIVE_INFINITY
+        consistent = false
+        multiline = true
+        minItems = Number.POSITIVE_INFINITY
+      }
+
+      return { consistent, multiline, minItems }
+    }
+
+    /**
+     * Normalizes a given option value.
+     * @param {string | object | undefined} options An option value to parse.
+     * @returns {{ArrayExpression: {multiline: boolean, minItems: number}, ArrayPattern: {multiline: boolean, minItems: number}}} Normalized option object.
+     */
+    function normalizeOptions(options) {
+      const value = normalizeOptionValue(options)
+      return { ArrayExpression: value, ArrayPattern: value }
+    }
+    /**
+     * Reports that there shouldn't be a linebreak after the first token
+     * @param {ASTNode} node The node to report in the event of an error.
+     * @param {Token} token The token to use for the report.
+     * @returns {void}
+     */
+    function reportNoBeginningLinebreak(node, token) {
+      context.report({
+        node,
+        loc: token.loc,
+        messageId: 'unexpectedOpeningLinebreak',
+        fix(fixer) {
+          const nextToken = sourceCode.getTokenAfter(token, { includeComments: true })
+          if (astUtils.isCommentToken(nextToken))
+            return null
+          return fixer.removeRange([token.range[1], nextToken.range[0]])
+        },
+      })
+    }
+
+    /**
+     * Reports that there shouldn't be a linebreak before the last token
+     * @param {ASTNode} node The node to report in the event of an error.
+     * @param {Token} token The token to use for the report.
+     * @returns {void}
+     */
+    function reportNoEndingLinebreak(node, token) {
+      context.report({
+        node,
+        loc: token.loc,
+        messageId: 'unexpectedClosingLinebreak',
+        fix(fixer) {
+          const previousToken = sourceCode.getTokenBefore(token, { includeComments: true })
+          if (astUtils.isCommentToken(previousToken))
+            return null
+          return fixer.removeRange([previousToken.range[1], token.range[0]])
+        },
+      })
+    }
+
+    /**
+     * Reports that there should be a linebreak after the first token
+     * @param {ASTNode} node The node to report in the event of an error.
+     * @param {Token} token The token to use for the report.
+     * @returns {void}
+     */
+    function reportRequiredBeginningLinebreak(node, token) {
+      context.report({
+        node,
+        loc: token.loc,
+        messageId: 'missingOpeningLinebreak',
+        fix(fixer) {
+          return fixer.insertTextAfter(token, '\n')
+        },
+      })
+    }
+
+    /**
+     * Reports that there should be a linebreak before the last token
+     * @param {ASTNode} node The node to report in the event of an error.
+     * @param {Token} token The token to use for the report.
+     * @returns {void}
+     */
+    function reportRequiredEndingLinebreak(node, token) {
+      context.report({
+        node,
+        loc: token.loc,
+        messageId: 'missingClosingLinebreak',
+        fix(fixer) {
+          return fixer.insertTextBefore(token, '\n')
+        },
+      })
+    }
+
+    /**
+     * Reports a given node if it violated this rule.
+     * @param {ASTNode} node A node to check. This is an ArrayExpression node or an ArrayPattern node.
+     * @returns {void}
+     */
+    function check(node) {
+      const elements = node.elements
+      const normalizedOptions = normalizeOptions(context.options[0])
+      const options = normalizedOptions[node.type]
+      const openBracket = sourceCode.getFirstToken(node)
+      const closeBracket = sourceCode.getLastToken(node)
+      const firstIncComment = sourceCode.getTokenAfter(openBracket, { includeComments: true })
+      const lastIncComment = sourceCode.getTokenBefore(closeBracket, { includeComments: true })
+      const first = sourceCode.getTokenAfter(openBracket)
+      const last = sourceCode.getTokenBefore(closeBracket)
+      const needsLinebreaks = (elements.length >= options.minItems
+        || (options.multiline
+          && elements.length > 0
+          && firstIncComment.loc.start.line !== lastIncComment.loc.end.line)
+        || (elements.length === 0
+          && firstIncComment.type === 'Block'
+          && firstIncComment.loc.start.line !== lastIncComment.loc.end.line
+          && firstIncComment === lastIncComment)
+        || (options.consistent
+          && openBracket.loc.end.line !== first.loc.start.line))
+
+      /*
+       * Use tokens or comments to check multiline or not.
+       * But use only tokens to check whether linebreaks are needed.
+       * This allows:
+       *     var arr = [ // eslint-disable-line foo
+       *         'a'
+       *     ]
+       */
+
+      if (needsLinebreaks) {
+        if (astUtils.isTokenOnSameLine(openBracket, first))
+          reportRequiredBeginningLinebreak(node, openBracket)
+        if (astUtils.isTokenOnSameLine(last, closeBracket))
+          reportRequiredEndingLinebreak(node, closeBracket)
+      }
+      else {
+        if (!astUtils.isTokenOnSameLine(openBracket, first))
+          reportNoBeginningLinebreak(node, openBracket)
+        if (!astUtils.isTokenOnSameLine(last, closeBracket))
+          reportNoEndingLinebreak(node, closeBracket)
       }
     }
-    else {
-      consistent = false
-      multiline = true
-      minItems = Number.POSITIVE_INFINITY
+
+    // ----------------------------------------------------------------------
+    // Public
+    // ----------------------------------------------------------------------
+
+    return {
+      ArrayPattern: check,
+      ArrayExpression: check,
     }
-
-    return { consistent, multiline, minItems }
-  }
-
-  /**
-   * Normalizes a given option value.
-   * @param {string | object | undefined} options An option value to parse.
-   * @returns {{ArrayExpression: {multiline: boolean, minItems: number}, ArrayPattern: {multiline: boolean, minItems: number}}} Normalized option object.
-   */
-  function normalizeOptions(options) {
-    const value = normalizeOptionValue(options)
-    return { ArrayExpression: value, ArrayPattern: value }
-  }
-  /**
-   * Reports that there shouldn't be a linebreak after the first token
-   * @param {ASTNode} node The node to report in the event of an error.
-   * @param {Token} token The token to use for the report.
-   * @returns {void}
-   */
-  function reportNoBeginningLinebreak(node, token) {
-    context.report({
-      node,
-      loc: token.loc,
-      messageId: 'unexpectedOpeningLinebreak',
-      fix(fixer) {
-        const nextToken = sourceCode.getTokenAfter(token, { includeComments: true })
-        if (astUtils.isCommentToken(nextToken))
-          return null
-        return fixer.removeRange([token.range[1], nextToken.range[0]])
-      },
-    })
-  }
-
-  /**
-   * Reports that there shouldn't be a linebreak before the last token
-   * @param {ASTNode} node The node to report in the event of an error.
-   * @param {Token} token The token to use for the report.
-   * @returns {void}
-   */
-  function reportNoEndingLinebreak(node, token) {
-    context.report({
-      node,
-      loc: token.loc,
-      messageId: 'unexpectedClosingLinebreak',
-      fix(fixer) {
-        const previousToken = sourceCode.getTokenBefore(token, { includeComments: true })
-        if (astUtils.isCommentToken(previousToken))
-          return null
-        return fixer.removeRange([previousToken.range[1], token.range[0]])
-      },
-    })
-  }
-
-  /**
-   * Reports that there should be a linebreak after the first token
-   * @param {ASTNode} node The node to report in the event of an error.
-   * @param {Token} token The token to use for the report.
-   * @returns {void}
-   */
-  function reportRequiredBeginningLinebreak(node, token) {
-    context.report({
-      node,
-      loc: token.loc,
-      messageId: 'missingOpeningLinebreak',
-      fix(fixer) {
-        return fixer.insertTextAfter(token, '\n')
-      },
-    })
-  }
-
-  /**
-   * Reports that there should be a linebreak before the last token
-   * @param {ASTNode} node The node to report in the event of an error.
-   * @param {Token} token The token to use for the report.
-   * @returns {void}
-   */
-  function reportRequiredEndingLinebreak(node, token) {
-    context.report({
-      node,
-      loc: token.loc,
-      messageId: 'missingClosingLinebreak',
-      fix(fixer) {
-        return fixer.insertTextBefore(token, '\n')
-      },
-    })
-  }
-
-  /**
-   * Reports a given node if it violated this rule.
-   * @param {ASTNode} node A node to check. This is an ArrayExpression node or an ArrayPattern node.
-   * @returns {void}
-   */
-  function check(node) {
-    const elements = node.elements
-    const normalizedOptions = normalizeOptions(context.options[0])
-    const options = normalizedOptions[node.type]
-    const openBracket = sourceCode.getFirstToken(node)
-    const closeBracket = sourceCode.getLastToken(node)
-    const firstIncComment = sourceCode.getTokenAfter(openBracket, { includeComments: true })
-    const lastIncComment = sourceCode.getTokenBefore(closeBracket, { includeComments: true })
-    const first = sourceCode.getTokenAfter(openBracket)
-    const last = sourceCode.getTokenBefore(closeBracket)
-    const needsLinebreaks = (elements.length >= options.minItems
-            || (options.multiline
-                && elements.length > 0
-                && firstIncComment.loc.start.line !== lastIncComment.loc.end.line)
-            || (elements.length === 0
-                && firstIncComment.type === 'Block'
-                && firstIncComment.loc.start.line !== lastIncComment.loc.end.line
-                && firstIncComment === lastIncComment)
-            || (options.consistent
-                && openBracket.loc.end.line !== first.loc.start.line))
-
-    /*
-     * Use tokens or comments to check multiline or not.
-     * But use only tokens to check whether linebreaks are needed.
-     * This allows:
-     *     var arr = [ // eslint-disable-line foo
-     *         'a'
-     *     ]
-     */
-
-    if (needsLinebreaks) {
-      if (astUtils.isTokenOnSameLine(openBracket, first))
-        reportRequiredBeginningLinebreak(node, openBracket)
-      if (astUtils.isTokenOnSameLine(last, closeBracket))
-        reportRequiredEndingLinebreak(node, closeBracket)
-    }
-    else {
-      if (!astUtils.isTokenOnSameLine(openBracket, first))
-        reportNoBeginningLinebreak(node, openBracket)
-      if (!astUtils.isTokenOnSameLine(last, closeBracket))
-        reportNoEndingLinebreak(node, closeBracket)
-    }
-  }
-
-  // ----------------------------------------------------------------------
-  // Public
-  // ----------------------------------------------------------------------
-
-  return {
-    ArrayPattern: check,
-    ArrayExpression: check,
-  }
-}
-export default {
-  meta,
-  create,
+  },
 }

--- a/packages/eslint-plugin-js/rules/array-bracket-newline/array-bracket-newline.js
+++ b/packages/eslint-plugin-js/rules/array-bracket-newline/array-bracket-newline.js
@@ -3,7 +3,7 @@
  * @author Jan Peer Stöcklmair <https://github.com/JPeer264>
  */
 
-import astUtils from '../../utils/ast-utils.js'
+import astUtils from '../../utils/ast-utils'
 
 // ------------------------------------------------------------------------------
 // Rule Definition

--- a/packages/eslint-plugin-js/rules/array-bracket-newline/array-bracket-newline.js
+++ b/packages/eslint-plugin-js/rules/array-bracket-newline/array-bracket-newline.js
@@ -3,256 +3,238 @@
  * @author Jan Peer Stöcklmair <https://github.com/JPeer264>
  */
 
-'use strict'
-
-const astUtils = require('../../utils/ast-utils')
+import astUtils from '../../utils/ast-utils.js'
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
 
 /** @type {import('eslint').Rule.RuleModule} */
-module.exports = {
-  meta: {
-    type: 'layout',
+export const meta = {
+  type: 'layout',
 
-    docs: {
-      description: 'Enforce linebreaks after opening and before closing array brackets',
-      recommended: false,
-      url: 'https://eslint.style/rules/js/array-bracket-newline',
-    },
-
-    fixable: 'whitespace',
-
-    schema: [
-      {
-        oneOf: [
-          {
-            enum: ['always', 'never', 'consistent'],
-          },
-          {
-            type: 'object',
-            properties: {
-              multiline: {
-                type: 'boolean',
-              },
-              minItems: {
-                type: ['integer', 'null'],
-                minimum: 0,
-              },
-            },
-            additionalProperties: false,
-          },
-        ],
-      },
-    ],
-
-    messages: {
-      unexpectedOpeningLinebreak: 'There should be no linebreak after \'[\'.',
-      unexpectedClosingLinebreak: 'There should be no linebreak before \']\'.',
-      missingOpeningLinebreak: 'A linebreak is required after \'[\'.',
-      missingClosingLinebreak: 'A linebreak is required before \']\'.',
-    },
+  docs: {
+    description: 'Enforce linebreaks after opening and before closing array brackets',
+    recommended: false,
+    url: 'https://eslint.style/rules/js/array-bracket-newline',
   },
 
-  create(context) {
-    const sourceCode = context.sourceCode
+  fixable: 'whitespace',
 
-    // ----------------------------------------------------------------------
-    // Helpers
-    // ----------------------------------------------------------------------
+  schema: [
+    {
+      oneOf: [
+        {
+          enum: ['always', 'never', 'consistent'],
+        },
+        {
+          type: 'object',
+          properties: {
+            multiline: {
+              type: 'boolean',
+            },
+            minItems: {
+              type: ['integer', 'null'],
+              minimum: 0,
+            },
+          },
+          additionalProperties: false,
+        },
+      ],
+    },
+  ],
 
-    /**
-     * Normalizes a given option value.
-     * @param {string | object | undefined} option An option value to parse.
-     * @returns {{multiline: boolean, minItems: number}} Normalized option object.
-     */
-    function normalizeOptionValue(option) {
-      let consistent = false
-      let multiline = false
-      let minItems = 0
+  messages: {
+    unexpectedOpeningLinebreak: 'There should be no linebreak after \'[\'.',
+    unexpectedClosingLinebreak: 'There should be no linebreak before \']\'.',
+    missingOpeningLinebreak: 'A linebreak is required after \'[\'.',
+    missingClosingLinebreak: 'A linebreak is required before \']\'.',
+  },
+}
+export function create(context) {
+  const sourceCode = context.sourceCode
 
-      if (option) {
-        if (option === 'consistent') {
-          consistent = true
-          minItems = Number.POSITIVE_INFINITY
-        }
-        else if (option === 'always' || option.minItems === 0) {
-          minItems = 0
-        }
-        else if (option === 'never') {
-          minItems = Number.POSITIVE_INFINITY
-        }
-        else {
-          multiline = Boolean(option.multiline)
-          minItems = option.minItems || Number.POSITIVE_INFINITY
-        }
-      }
-      else {
-        consistent = false
-        multiline = true
+  // ----------------------------------------------------------------------
+  // Helpers
+  // ----------------------------------------------------------------------
+
+  /**
+   * Normalizes a given option value.
+   * @param {string | object | undefined} option An option value to parse.
+   * @returns {{multiline: boolean, minItems: number}} Normalized option object.
+   */
+  function normalizeOptionValue(option) {
+    let consistent = false
+    let multiline = false
+    let minItems = 0
+
+    if (option) {
+      if (option === 'consistent') {
+        consistent = true
         minItems = Number.POSITIVE_INFINITY
       }
-
-      return { consistent, multiline, minItems }
-    }
-
-    /**
-     * Normalizes a given option value.
-     * @param {string | object | undefined} options An option value to parse.
-     * @returns {{ArrayExpression: {multiline: boolean, minItems: number}, ArrayPattern: {multiline: boolean, minItems: number}}} Normalized option object.
-     */
-    function normalizeOptions(options) {
-      const value = normalizeOptionValue(options)
-
-      return { ArrayExpression: value, ArrayPattern: value }
-    }
-
-    /**
-     * Reports that there shouldn't be a linebreak after the first token
-     * @param {ASTNode} node The node to report in the event of an error.
-     * @param {Token} token The token to use for the report.
-     * @returns {void}
-     */
-    function reportNoBeginningLinebreak(node, token) {
-      context.report({
-        node,
-        loc: token.loc,
-        messageId: 'unexpectedOpeningLinebreak',
-        fix(fixer) {
-          const nextToken = sourceCode.getTokenAfter(token, { includeComments: true })
-
-          if (astUtils.isCommentToken(nextToken))
-            return null
-
-          return fixer.removeRange([token.range[1], nextToken.range[0]])
-        },
-      })
-    }
-
-    /**
-     * Reports that there shouldn't be a linebreak before the last token
-     * @param {ASTNode} node The node to report in the event of an error.
-     * @param {Token} token The token to use for the report.
-     * @returns {void}
-     */
-    function reportNoEndingLinebreak(node, token) {
-      context.report({
-        node,
-        loc: token.loc,
-        messageId: 'unexpectedClosingLinebreak',
-        fix(fixer) {
-          const previousToken = sourceCode.getTokenBefore(token, { includeComments: true })
-
-          if (astUtils.isCommentToken(previousToken))
-            return null
-
-          return fixer.removeRange([previousToken.range[1], token.range[0]])
-        },
-      })
-    }
-
-    /**
-     * Reports that there should be a linebreak after the first token
-     * @param {ASTNode} node The node to report in the event of an error.
-     * @param {Token} token The token to use for the report.
-     * @returns {void}
-     */
-    function reportRequiredBeginningLinebreak(node, token) {
-      context.report({
-        node,
-        loc: token.loc,
-        messageId: 'missingOpeningLinebreak',
-        fix(fixer) {
-          return fixer.insertTextAfter(token, '\n')
-        },
-      })
-    }
-
-    /**
-     * Reports that there should be a linebreak before the last token
-     * @param {ASTNode} node The node to report in the event of an error.
-     * @param {Token} token The token to use for the report.
-     * @returns {void}
-     */
-    function reportRequiredEndingLinebreak(node, token) {
-      context.report({
-        node,
-        loc: token.loc,
-        messageId: 'missingClosingLinebreak',
-        fix(fixer) {
-          return fixer.insertTextBefore(token, '\n')
-        },
-      })
-    }
-
-    /**
-     * Reports a given node if it violated this rule.
-     * @param {ASTNode} node A node to check. This is an ArrayExpression node or an ArrayPattern node.
-     * @returns {void}
-     */
-    function check(node) {
-      const elements = node.elements
-      const normalizedOptions = normalizeOptions(context.options[0])
-      const options = normalizedOptions[node.type]
-      const openBracket = sourceCode.getFirstToken(node)
-      const closeBracket = sourceCode.getLastToken(node)
-      const firstIncComment = sourceCode.getTokenAfter(openBracket, { includeComments: true })
-      const lastIncComment = sourceCode.getTokenBefore(closeBracket, { includeComments: true })
-      const first = sourceCode.getTokenAfter(openBracket)
-      const last = sourceCode.getTokenBefore(closeBracket)
-
-      const needsLinebreaks = (
-        elements.length >= options.minItems
-                || (
-                  options.multiline
-                    && elements.length > 0
-                    && firstIncComment.loc.start.line !== lastIncComment.loc.end.line
-                )
-                || (
-                  elements.length === 0
-                    && firstIncComment.type === 'Block'
-                    && firstIncComment.loc.start.line !== lastIncComment.loc.end.line
-                    && firstIncComment === lastIncComment
-                )
-                || (
-                  options.consistent
-                    && openBracket.loc.end.line !== first.loc.start.line
-                )
-      )
-
-      /*
-             * Use tokens or comments to check multiline or not.
-             * But use only tokens to check whether linebreaks are needed.
-             * This allows:
-             *     var arr = [ // eslint-disable-line foo
-             *         'a'
-             *     ]
-             */
-
-      if (needsLinebreaks) {
-        if (astUtils.isTokenOnSameLine(openBracket, first))
-          reportRequiredBeginningLinebreak(node, openBracket)
-
-        if (astUtils.isTokenOnSameLine(last, closeBracket))
-          reportRequiredEndingLinebreak(node, closeBracket)
+      else if (option === 'always' || option.minItems === 0) {
+        minItems = 0
+      }
+      else if (option === 'never') {
+        minItems = Number.POSITIVE_INFINITY
       }
       else {
-        if (!astUtils.isTokenOnSameLine(openBracket, first))
-          reportNoBeginningLinebreak(node, openBracket)
-
-        if (!astUtils.isTokenOnSameLine(last, closeBracket))
-          reportNoEndingLinebreak(node, closeBracket)
+        multiline = Boolean(option.multiline)
+        minItems = option.minItems || Number.POSITIVE_INFINITY
       }
     }
-
-    // ----------------------------------------------------------------------
-    // Public
-    // ----------------------------------------------------------------------
-
-    return {
-      ArrayPattern: check,
-      ArrayExpression: check,
+    else {
+      consistent = false
+      multiline = true
+      minItems = Number.POSITIVE_INFINITY
     }
-  },
+
+    return { consistent, multiline, minItems }
+  }
+
+  /**
+   * Normalizes a given option value.
+   * @param {string | object | undefined} options An option value to parse.
+   * @returns {{ArrayExpression: {multiline: boolean, minItems: number}, ArrayPattern: {multiline: boolean, minItems: number}}} Normalized option object.
+   */
+  function normalizeOptions(options) {
+    const value = normalizeOptionValue(options)
+    return { ArrayExpression: value, ArrayPattern: value }
+  }
+  /**
+   * Reports that there shouldn't be a linebreak after the first token
+   * @param {ASTNode} node The node to report in the event of an error.
+   * @param {Token} token The token to use for the report.
+   * @returns {void}
+   */
+  function reportNoBeginningLinebreak(node, token) {
+    context.report({
+      node,
+      loc: token.loc,
+      messageId: 'unexpectedOpeningLinebreak',
+      fix(fixer) {
+        const nextToken = sourceCode.getTokenAfter(token, { includeComments: true })
+        if (astUtils.isCommentToken(nextToken))
+          return null
+        return fixer.removeRange([token.range[1], nextToken.range[0]])
+      },
+    })
+  }
+
+  /**
+   * Reports that there shouldn't be a linebreak before the last token
+   * @param {ASTNode} node The node to report in the event of an error.
+   * @param {Token} token The token to use for the report.
+   * @returns {void}
+   */
+  function reportNoEndingLinebreak(node, token) {
+    context.report({
+      node,
+      loc: token.loc,
+      messageId: 'unexpectedClosingLinebreak',
+      fix(fixer) {
+        const previousToken = sourceCode.getTokenBefore(token, { includeComments: true })
+        if (astUtils.isCommentToken(previousToken))
+          return null
+        return fixer.removeRange([previousToken.range[1], token.range[0]])
+      },
+    })
+  }
+
+  /**
+   * Reports that there should be a linebreak after the first token
+   * @param {ASTNode} node The node to report in the event of an error.
+   * @param {Token} token The token to use for the report.
+   * @returns {void}
+   */
+  function reportRequiredBeginningLinebreak(node, token) {
+    context.report({
+      node,
+      loc: token.loc,
+      messageId: 'missingOpeningLinebreak',
+      fix(fixer) {
+        return fixer.insertTextAfter(token, '\n')
+      },
+    })
+  }
+
+  /**
+   * Reports that there should be a linebreak before the last token
+   * @param {ASTNode} node The node to report in the event of an error.
+   * @param {Token} token The token to use for the report.
+   * @returns {void}
+   */
+  function reportRequiredEndingLinebreak(node, token) {
+    context.report({
+      node,
+      loc: token.loc,
+      messageId: 'missingClosingLinebreak',
+      fix(fixer) {
+        return fixer.insertTextBefore(token, '\n')
+      },
+    })
+  }
+
+  /**
+   * Reports a given node if it violated this rule.
+   * @param {ASTNode} node A node to check. This is an ArrayExpression node or an ArrayPattern node.
+   * @returns {void}
+   */
+  function check(node) {
+    const elements = node.elements
+    const normalizedOptions = normalizeOptions(context.options[0])
+    const options = normalizedOptions[node.type]
+    const openBracket = sourceCode.getFirstToken(node)
+    const closeBracket = sourceCode.getLastToken(node)
+    const firstIncComment = sourceCode.getTokenAfter(openBracket, { includeComments: true })
+    const lastIncComment = sourceCode.getTokenBefore(closeBracket, { includeComments: true })
+    const first = sourceCode.getTokenAfter(openBracket)
+    const last = sourceCode.getTokenBefore(closeBracket)
+    const needsLinebreaks = (elements.length >= options.minItems
+            || (options.multiline
+                && elements.length > 0
+                && firstIncComment.loc.start.line !== lastIncComment.loc.end.line)
+            || (elements.length === 0
+                && firstIncComment.type === 'Block'
+                && firstIncComment.loc.start.line !== lastIncComment.loc.end.line
+                && firstIncComment === lastIncComment)
+            || (options.consistent
+                && openBracket.loc.end.line !== first.loc.start.line))
+
+    /*
+     * Use tokens or comments to check multiline or not.
+     * But use only tokens to check whether linebreaks are needed.
+     * This allows:
+     *     var arr = [ // eslint-disable-line foo
+     *         'a'
+     *     ]
+     */
+
+    if (needsLinebreaks) {
+      if (astUtils.isTokenOnSameLine(openBracket, first))
+        reportRequiredBeginningLinebreak(node, openBracket)
+      if (astUtils.isTokenOnSameLine(last, closeBracket))
+        reportRequiredEndingLinebreak(node, closeBracket)
+    }
+    else {
+      if (!astUtils.isTokenOnSameLine(openBracket, first))
+        reportNoBeginningLinebreak(node, openBracket)
+      if (!astUtils.isTokenOnSameLine(last, closeBracket))
+        reportNoEndingLinebreak(node, closeBracket)
+    }
+  }
+
+  // ----------------------------------------------------------------------
+  // Public
+  // ----------------------------------------------------------------------
+
+  return {
+    ArrayPattern: check,
+    ArrayExpression: check,
+  }
+}
+export default {
+  meta,
+  create,
 }

--- a/packages/eslint-plugin-js/rules/array-bracket-newline/array-bracket-newline.test.js
+++ b/packages/eslint-plugin-js/rules/array-bracket-newline/array-bracket-newline.test.js
@@ -3,14 +3,12 @@
  * @author Jan Peer Stöcklmair <https://github.com/JPeer264>
  */
 
-'use strict'
-
 // ------------------------------------------------------------------------------
 // Requirements
 // ------------------------------------------------------------------------------
 
-const { RuleTester } = require('eslint')
-const rule = require('./array-bracket-newline')
+import { RuleTester } from 'eslint'
+import rule from './array-bracket-newline.js'
 
 // ------------------------------------------------------------------------------
 // Tests
@@ -23,9 +21,9 @@ ruleTester.run('array-bracket-newline', rule, {
   valid: [
 
     /*
-         * ArrayExpression
-         * "default" { multiline: true }
-         */
+     * ArrayExpression
+     * "default" { multiline: true }
+     */
     'var foo = [];',
     'var foo = [1];',
     'var foo = /* any comment */[1];',
@@ -500,9 +498,9 @@ ruleTester.run('array-bracket-newline', rule, {
     },
 
     /*
-         * ArrayExpression
-         * "always"
-         */
+     * ArrayExpression
+     * "always"
+     */
     {
       code: 'var foo = [[1,2]]',
       output: 'var foo = [\n[\n1,2\n]\n]',
@@ -1581,9 +1579,9 @@ ruleTester.run('array-bracket-newline', rule, {
     },
 
     /*
-         * extra test cases
-         * "always"
-         */
+     * extra test cases
+     * "always"
+     */
     {
       code: 'var foo = [\n1, 2];',
       output: 'var foo = [\n1, 2\n];',


### PR DESCRIPTION
Related to: #51 

## What changed?
Migrates to ESM for the rule `array-bracket-newline` under eslint-plugin-js