### PR TITLE
refactor(eslint-plugin-jsx): Update jsx rules

### DIFF
--- a/packages/eslint-plugin-jsx/rules/jsx-child-element-spacing/jsx-child-element-spacing.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-child-element-spacing/jsx-child-element-spacing.js
@@ -1,5 +1,5 @@
-const docsUrl = require('../../util/docsUrl')
-const report = require('../../util/report')
+import docsUrl from '../../util/docsUrl'
+import report from '../../util/report'
 
 // This list is taken from https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements
 
@@ -42,7 +42,7 @@ const messages = {
   spacingBeforeNext: 'Ambiguous spacing before next element {{element}}',
 }
 
-module.exports = {
+export default {
   meta: {
     docs: {
       description: 'Enforce or disallow spaces inside of curly braces in JSX attributes and expressions',

--- a/packages/eslint-plugin-jsx/rules/jsx-child-element-spacing/jsx-child-element-spacing.test.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-child-element-spacing/jsx-child-element-spacing.test.js
@@ -1,8 +1,6 @@
-'use strict'
-
-const RuleTester = require('eslint').RuleTester
-const parsers = require('../../tests/helpers/parsers')
-const rule = require('./jsx-child-element-spacing')
+import { RuleTester } from 'eslint'
+import parsers from '../../tests/helpers/parsers'
+import rule from './jsx-child-element-spacing'
 
 const parserOptions = {
   sourceType: 'module',

--- a/packages/eslint-plugin-jsx/rules/jsx-closing-bracket-location/jsx-closing-bracket-location.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-closing-bracket-location/jsx-closing-bracket-location.js
@@ -3,11 +3,10 @@
  * @author Yannick Croissant
  */
 
-'use strict'
+import docsUrl from '../../util/docsUrl'
+import report from '../../util/report'
 
 const has = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
-const docsUrl = require('../../util/docsUrl')
-const report = require('../../util/report')
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -17,7 +16,7 @@ const messages = {
   bracketLocation: 'The closing bracket must be {{location}}{{details}}',
 }
 
-module.exports = {
+export default {
   meta: {
     docs: {
       description: 'Enforce closing bracket location in JSX',

--- a/packages/eslint-plugin-jsx/rules/jsx-closing-bracket-location/jsx-closing-bracket-location.test.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-closing-bracket-location/jsx-closing-bracket-location.test.js
@@ -3,15 +3,9 @@
  * @author Yannick Croissant
  */
 
-'use strict'
-
-// ------------------------------------------------------------------------------
-// Requirements
-// ------------------------------------------------------------------------------
-
-const RuleTester = require('eslint').RuleTester
-const parsers = require('../../tests/helpers/parsers')
-const rule = require('./jsx-closing-bracket-location')
+import { RuleTester } from 'eslint'
+import parsers from '../../tests/helpers/parsers'
+import rule from './jsx-closing-bracket-location'
 
 const parserOptions = {
   ecmaVersion: 2018,

--- a/packages/eslint-plugin-jsx/rules/jsx-closing-tag-location/jsx-closing-tag-location.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-closing-tag-location/jsx-closing-tag-location.js
@@ -3,11 +3,9 @@
  * @author Ross Solomon
  */
 
-'use strict'
-
-const astUtil = require('../../util/ast')
-const docsUrl = require('../../util/docsUrl')
-const report = require('../../util/report')
+import astUtil from '../../util/ast'
+import docsUrl from '../../util/docsUrl'
+import report from '../../util/report'
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -18,7 +16,7 @@ const messages = {
   matchIndent: 'Expected closing tag to match indentation of opening.',
 }
 
-module.exports = {
+export default {
   meta: {
     docs: {
       description: 'Enforce closing tag location for multiline JSX',

--- a/packages/eslint-plugin-jsx/rules/jsx-closing-tag-location/jsx-closing-tag-location.test.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-closing-tag-location/jsx-closing-tag-location.test.js
@@ -3,15 +3,9 @@
  * @author Ross Solomon
  */
 
-'use strict'
-
-// ------------------------------------------------------------------------------
-// Requirements
-// ------------------------------------------------------------------------------
-
-const RuleTester = require('eslint').RuleTester
-const parsers = require('../../tests/helpers/parsers')
-const rule = require('./jsx-closing-tag-location')
+import { RuleTester } from 'eslint'
+import parsers from '../../tests/helpers/parsers'
+import rule from './jsx-closing-tag-location'
 
 const parserOptions = {
   sourceType: 'module',

--- a/packages/eslint-plugin-jsx/rules/jsx-curly-brace-presence/jsx-curly-brace-presence.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-curly-brace-presence/jsx-curly-brace-presence.js
@@ -4,13 +4,11 @@
  * @author Simon Lydell
  */
 
-'use strict'
+import docsUrl from '../../util/docsUrl'
+import jsxUtil from '../../util/jsx'
+import report from '../../util/report'
 
 const arrayIncludes = (arr, value) => arr.includes(value)
-
-const docsUrl = require('../../util/docsUrl')
-const jsxUtil = require('../../util/jsx')
-const report = require('../../util/report')
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -36,7 +34,7 @@ const messages = {
   missingCurly: 'Need to wrap this literal in a JSX expression.',
 }
 
-module.exports = {
+export default {
   meta: {
     docs: {
       description: 'Disallow unnecessary JSX expressions when literals alone are sufficient or enforce JSX expressions on literals in JSX children or attributes',

--- a/packages/eslint-plugin-jsx/rules/jsx-curly-brace-presence/jsx-curly-brace-presence.test.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-curly-brace-presence/jsx-curly-brace-presence.test.js
@@ -3,19 +3,13 @@
  * @author Jacky Ho
  */
 
-'use strict'
-
 // For better readability on tests involving quotes
 
-// ------------------------------------------------------------------------------
-// Requirements
-// ------------------------------------------------------------------------------
-
-const RuleTester = require('eslint').RuleTester
-const semver = require('semver')
-const eslintPkg = require('eslint/package.json')
-const parsers = require('../../tests/helpers/parsers')
-const rule = require('./jsx-curly-brace-presence')
+import { RuleTester } from 'eslint'
+import semver from 'semver'
+import eslintPkg from 'eslint/package.json'
+import parsers from '../../tests/helpers/parsers'
+import rule from './jsx-curly-brace-presence'
 
 const parserOptions = {
   sourceType: 'module',

--- a/packages/eslint-plugin-jsx/rules/jsx-curly-newline/jsx-curly-newline.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-curly-newline/jsx-curly-newline.js
@@ -2,10 +2,8 @@
  * @fileoverview enforce consistent line breaks inside jsx curly
  */
 
-'use strict'
-
-const docsUrl = require('../../util/docsUrl')
-const report = require('../../util/report')
+import docsUrl from '../../util/docsUrl'
+import report from '../../util/report'
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -41,7 +39,7 @@ const messages = {
   unexpectedAfter: 'Unexpected newline after \'{\'.',
 }
 
-module.exports = {
+export default {
   meta: {
     type: 'layout',
 

--- a/packages/eslint-plugin-jsx/rules/jsx-curly-newline/jsx-curly-newline.test.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-curly-newline/jsx-curly-newline.test.js
@@ -2,15 +2,9 @@
  * @fileoverview enforce consistent line breaks inside jsx curly
  */
 
-'use strict'
-
-// ------------------------------------------------------------------------------
-// Requirements
-// ------------------------------------------------------------------------------
-
-const RuleTester = require('eslint').RuleTester
-const parsers = require('../../tests/helpers/parsers')
-const rule = require('./jsx-curly-newline')
+import { RuleTester } from 'eslint'
+import parsers from '../../tests/helpers/parsers'
+import rule from './jsx-curly-newline'
 
 const parserOptions = {
   ecmaVersion: 2018,

--- a/packages/eslint-plugin-jsx/rules/jsx-curly-spacing/jsx-curly-spacing.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-curly-spacing/jsx-curly-spacing.js
@@ -9,11 +9,10 @@
  * @author Erik Wendel
  */
 
-'use strict'
+import docsUrl from '../../util/docsUrl'
+import report from '../../util/report'
 
 const has = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
-const docsUrl = require('../../util/docsUrl')
-const report = require('../../util/report')
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -34,7 +33,7 @@ const messages = {
   spaceNeededBefore: 'A space is required before \'{{token}}\'',
 }
 
-module.exports = {
+export default {
   meta: {
     docs: {
       description: 'Enforce or disallow spaces inside of curly braces in JSX attributes and expressions',

--- a/packages/eslint-plugin-jsx/rules/jsx-curly-spacing/jsx-curly-spacing.test.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-curly-spacing/jsx-curly-spacing.test.js
@@ -4,15 +4,9 @@
  * @author Erik Wendel
  */
 
-'use strict'
-
-// ------------------------------------------------------------------------------
-// Requirements
-// ------------------------------------------------------------------------------
-
-const RuleTester = require('eslint').RuleTester
-const parsers = require('../../tests/helpers/parsers')
-const rule = require('./jsx-curly-spacing')
+import { RuleTester } from 'eslint'
+import parsers from '../../tests/helpers/parsers'
+import rule from './jsx-curly-spacing'
 
 const parserOptions = {
   ecmaVersion: 2018,

--- a/packages/eslint-plugin-jsx/rules/jsx-equals-spacing/jsx-equals-spacing.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-equals-spacing/jsx-equals-spacing.js
@@ -3,10 +3,8 @@
  * @author ryym
  */
 
-'use strict'
-
-const docsUrl = require('../../util/docsUrl')
-const report = require('../../util/report')
+import docsUrl from '../../util/docsUrl'
+import report from '../../util/report'
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -19,7 +17,7 @@ const messages = {
   needSpaceAfter: 'A space is required after \'=\'',
 }
 
-module.exports = {
+export default {
   meta: {
     docs: {
       description: 'Enforce or disallow spaces around equal signs in JSX attributes',

--- a/packages/eslint-plugin-jsx/rules/jsx-equals-spacing/jsx-equals-spacing.test.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-equals-spacing/jsx-equals-spacing.test.js
@@ -3,15 +3,9 @@
  * @author ryym
  */
 
-'use strict'
-
-// ------------------------------------------------------------------------------
-// Requirements
-// ------------------------------------------------------------------------------
-
-const RuleTester = require('eslint').RuleTester
-const parsers = require('../../tests/helpers/parsers')
-const rule = require('./jsx-equals-spacing')
+import { RuleTester } from 'eslint'
+import parsers from '../../tests/helpers/parsers'
+import rule from './jsx-equals-spacing'
 
 const parserOptions = {
   ecmaVersion: 2018,

--- a/packages/eslint-plugin-jsx/rules/jsx-first-prop-new-line/jsx-first-prop-new-line.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-first-prop-new-line/jsx-first-prop-new-line.js
@@ -3,10 +3,8 @@
  * @author Joachim Seminck
  */
 
-'use strict'
-
-const docsUrl = require('../../util/docsUrl')
-const report = require('../../util/report')
+import docsUrl from '../../util/docsUrl'
+import report from '../../util/report'
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -17,7 +15,7 @@ const messages = {
   propOnSameLine: 'Property should be placed on the same line as the component declaration',
 }
 
-module.exports = {
+export default {
   meta: {
     docs: {
       description: 'Enforce proper position of the first property in JSX',

--- a/packages/eslint-plugin-jsx/rules/jsx-first-prop-new-line/jsx-first-prop-new-line.test.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-first-prop-new-line/jsx-first-prop-new-line.test.js
@@ -3,15 +3,9 @@
  * @author Joachim Seminck
  */
 
-'use strict'
-
-// -----------------------------------------------------------------------------
-// Requirements
-// -----------------------------------------------------------------------------
-
-const RuleTester = require('eslint').RuleTester
-const parsers = require('../../tests/helpers/parsers')
-const rule = require('./jsx-first-prop-new-line')
+import { RuleTester } from 'eslint'
+import parsers from '../../tests/helpers/parsers'
+import rule from './jsx-first-prop-new-line'
 
 const parserOptions = {
   ecmaVersion: 2018,

--- a/packages/eslint-plugin-jsx/rules/jsx-indent-props/jsx-indent-props.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-indent-props/jsx-indent-props.js
@@ -30,11 +30,9 @@
  THE SOFTWARE.
  */
 
-'use strict'
-
-const astUtil = require('../../util/ast')
-const docsUrl = require('../../util/docsUrl')
-const reportC = require('../../util/report')
+import astUtil from '../../util/ast'
+import docsUrl from '../../util/docsUrl'
+import reportC from '../../util/report'
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -44,7 +42,7 @@ const messages = {
   wrongIndent: 'Expected indentation of {{needed}} {{type}} {{characters}} but found {{gotten}}.',
 }
 
-module.exports = {
+export default {
   meta: {
     docs: {
       description: 'Enforce props indentation in JSX',

--- a/packages/eslint-plugin-jsx/rules/jsx-indent-props/jsx-indent-props.test.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-indent-props/jsx-indent-props.test.js
@@ -3,15 +3,9 @@
  * @author Yannick Croissant
  */
 
-'use strict'
-
-// ------------------------------------------------------------------------------
-// Requirements
-// ------------------------------------------------------------------------------
-
-const RuleTester = require('eslint').RuleTester
-const parsers = require('../../tests/helpers/parsers')
-const rule = require('./jsx-indent-props')
+import { RuleTester } from 'eslint'
+import parsers from '../../tests/helpers/parsers'
+import rule from './jsx-indent-props'
 
 const parserOptions = {
   ecmaVersion: 2018,

--- a/packages/eslint-plugin-jsx/rules/jsx-indent/jsx-indent.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-indent/jsx-indent.js
@@ -30,14 +30,12 @@
  THE SOFTWARE.
  */
 
-'use strict'
+import astUtil from '../../util/ast'
+import docsUrl from '../../util/docsUrl'
+import reportC from '../../util/report'
+import jsxUtil from '../../util/jsx'
 
 const matchAll = (s, v) => s.matchAll(v)
-
-const astUtil = require('../../util/ast')
-const docsUrl = require('../../util/docsUrl')
-const reportC = require('../../util/report')
-const jsxUtil = require('../../util/jsx')
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -47,7 +45,7 @@ const messages = {
   wrongIndent: 'Expected indentation of {{needed}} {{type}} {{characters}} but found {{gotten}}.',
 }
 
-module.exports = {
+export default {
   meta: {
     docs: {
       description: 'Enforce JSX indentation',

--- a/packages/eslint-plugin-jsx/rules/jsx-indent/jsx-indent.test.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-indent/jsx-indent.test.js
@@ -3,17 +3,11 @@
  * @author Yannick Croissant
  */
 
-'use strict'
-
-// ------------------------------------------------------------------------------
-// Requirements
-// ------------------------------------------------------------------------------
-
-const RuleTester = require('eslint').RuleTester
-const semver = require('semver')
-const eslintVersion = require('eslint/package.json').version
-const parsers = require('../../tests/helpers/parsers')
-const rule = require('./jsx-indent')
+import { RuleTester } from 'eslint'
+import semver from 'semver'
+import { version as eslintVersion } from 'eslint/package.json'
+import parsers from '../../tests/helpers/parsers'
+import rule from './jsx-indent'
 
 const parserOptions = {
   ecmaVersion: 2018,

--- a/packages/eslint-plugin-jsx/rules/jsx-max-props-per-line/jsx-max-props-per-line.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-max-props-per-line/jsx-max-props-per-line.js
@@ -3,10 +3,8 @@
  * @author Yannick Croissant
  */
 
-'use strict'
-
-const docsUrl = require('../../util/docsUrl')
-const report = require('../../util/report')
+import docsUrl from '../../util/docsUrl'
+import report from '../../util/report'
 
 function getPropName(context, propNode) {
   if (propNode.type === 'JSXSpreadAttribute')
@@ -23,7 +21,7 @@ const messages = {
   newLine: 'Prop `{{prop}}` must be placed on a new line',
 }
 
-module.exports = {
+export default {
   meta: {
     docs: {
       description: 'Enforce maximum of props on a single line in JSX',

--- a/packages/eslint-plugin-jsx/rules/jsx-max-props-per-line/jsx-max-props-per-line.test.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-max-props-per-line/jsx-max-props-per-line.test.js
@@ -3,15 +3,9 @@
  * @author Yannick Croissant
  */
 
-'use strict'
-
-// ------------------------------------------------------------------------------
-// Requirements
-// ------------------------------------------------------------------------------
-
-const RuleTester = require('eslint').RuleTester
-const parsers = require('../../tests/helpers/parsers')
-const rule = require('./jsx-max-props-per-line')
+import { RuleTester } from 'eslint'
+import parsers from '../../tests/helpers/parsers'
+import rule from './jsx-max-props-per-line'
 
 const parserOptions = {
   ecmaVersion: 2018,

--- a/packages/eslint-plugin-jsx/rules/jsx-newline/jsx-newline.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-newline/jsx-newline.js
@@ -4,10 +4,8 @@
  * @author Joseph Stiles
  */
 
-'use strict'
-
-const docsUrl = require('../../util/docsUrl')
-const report = require('../../util/report')
+import docsUrl from '../../util/docsUrl'
+import report from '../../util/report'
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -23,7 +21,7 @@ function isMultilined(node) {
   return node && node.loc.start.line !== node.loc.end.line
 }
 
-module.exports = {
+export default {
   meta: {
     docs: {
       description: 'Require or prevent a new line after jsx elements and expressions.',

--- a/packages/eslint-plugin-jsx/rules/jsx-newline/jsx-newline.test.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-newline/jsx-newline.test.js
@@ -4,15 +4,9 @@
  * @author Joseph Stiles
  */
 
-'use strict'
-
-// ------------------------------------------------------------------------------
-// Requirements
-// ------------------------------------------------------------------------------
-
-const RuleTester = require('eslint').RuleTester
-const parsers = require('../../tests/helpers/parsers')
-const rule = require('./jsx-newline')
+import { RuleTester } from 'eslint'
+import parsers from '../../tests/helpers/parsers'
+import rule from './jsx-newline'
 
 const parserOptions = {
   ecmaVersion: 2018,

--- a/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.js
@@ -3,11 +3,9 @@
  * @author Mark Ivan Allen <Vydia.com>
  */
 
-'use strict'
-
-const docsUrl = require('../../util/docsUrl')
-const jsxUtil = require('../../util/jsx')
-const report = require('../../util/report')
+import docsUrl from '../../util/docsUrl'
+import jsxUtil from '../../util/jsx'
+import report from '../../util/report'
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -21,7 +19,7 @@ const messages = {
   moveToNewLine: '`{{descriptor}}` must be placed on a new line',
 }
 
-module.exports = {
+export default {
   meta: {
     docs: {
       description: 'Require one JSX element per line',

--- a/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.test.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.test.js
@@ -3,15 +3,9 @@
  * @author Mark Ivan Allen <Vydia.com>
  */
 
-'use strict'
-
-// ------------------------------------------------------------------------------
-// Requirements
-// ------------------------------------------------------------------------------
-
-const RuleTester = require('eslint').RuleTester
-const parsers = require('../../tests/helpers/parsers')
-const rule = require('./jsx-one-expression-per-line')
+import { RuleTester } from 'eslint'
+import parsers from '../../tests/helpers/parsers'
+import rule from './jsx-one-expression-per-line'
 
 const parserOptions = {
   ecmaVersion: 2018,

--- a/packages/eslint-plugin-jsx/rules/jsx-props-no-multi-spaces/jsx-props-no-multi-spaces.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-props-no-multi-spaces/jsx-props-no-multi-spaces.js
@@ -3,10 +3,8 @@
  * @author Adrian Moennich
  */
 
-'use strict'
-
-const docsUrl = require('../../util/docsUrl')
-const report = require('../../util/report')
+import docsUrl from '../../util/docsUrl'
+import report from '../../util/report'
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -17,7 +15,7 @@ const messages = {
   onlyOneSpace: 'Expected only one space between “{{prop1}}” and “{{prop2}}”',
 }
 
-module.exports = {
+export default {
   meta: {
     docs: {
       description: 'Disallow multiple spaces between inline JSX props',

--- a/packages/eslint-plugin-jsx/rules/jsx-props-no-multi-spaces/jsx-props-no-multi-spaces.test.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-props-no-multi-spaces/jsx-props-no-multi-spaces.test.js
@@ -3,17 +3,11 @@
  * @author Adrian Moennich
  */
 
-'use strict'
-
-// ------------------------------------------------------------------------------
-// Requirements
-// ------------------------------------------------------------------------------
-
-const RuleTester = require('eslint').RuleTester
-const semver = require('semver')
-const eslintPkg = require('eslint/package.json')
-const parsers = require('../../tests/helpers/parsers')
-const rule = require('./jsx-props-no-multi-spaces')
+import { RuleTester } from 'eslint'
+import semver from 'semver'
+import eslintPkg from 'eslint/package.json'
+import parsers from '../../tests/helpers/parsers'
+import rule from './jsx-props-no-multi-spaces'
 
 const parserOptions = {
   ecmaVersion: 2018,

--- a/packages/eslint-plugin-jsx/rules/jsx-self-closing-comp/jsx-self-closing-comp.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-self-closing-comp/jsx-self-closing-comp.js
@@ -3,11 +3,9 @@
  * @author Yannick Croissant
  */
 
-'use strict'
-
-const docsUrl = require('../../util/docsUrl')
-const jsxUtil = require('../../util/jsx')
-const report = require('../../util/report')
+import docsUrl from '../../util/docsUrl'
+import jsxUtil from '../../util/jsx'
+import report from '../../util/report'
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -19,7 +17,7 @@ const messages = {
   notSelfClosing: 'Empty components are self-closing',
 }
 
-module.exports = {
+export default {
   meta: {
     docs: {
       description: 'Disallow extra closing tags for components without children',

--- a/packages/eslint-plugin-jsx/rules/jsx-self-closing-comp/jsx-self-closing-comp.test.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-self-closing-comp/jsx-self-closing-comp.test.js
@@ -3,15 +3,9 @@
  * @author Yannick Croissant
  */
 
-'use strict'
-
-// ------------------------------------------------------------------------------
-// Requirements
-// ------------------------------------------------------------------------------
-
-const RuleTester = require('eslint').RuleTester
-const parsers = require('../../tests/helpers/parsers')
-const rule = require('./jsx-self-closing-comp')
+import { RuleTester } from 'eslint'
+import parsers from '../../tests/helpers/parsers'
+import rule from './jsx-self-closing-comp'
 
 const parserOptions = {
   ecmaVersion: 2018,

--- a/packages/eslint-plugin-jsx/rules/jsx-sort-props/jsx-sort-props.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-sort-props/jsx-sort-props.js
@@ -3,14 +3,12 @@
  * @author Ilya Volodin, Yannick Croissant
  */
 
-'use strict'
+import docsUrl from '../../util/docsUrl'
+import jsxUtil from '../../util/jsx'
+import report from '../../util/report'
 
 const includes = (arr, value) => arr.includes(value)
 const toSorted = (arr, compareFn) => [...arr].sort(compareFn)
-
-const docsUrl = require('../../util/docsUrl')
-const jsxUtil = require('../../util/jsx')
-const report = require('../../util/report')
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -336,7 +334,7 @@ function reportNodeAttribute(nodeAttribute, errorType, node, context, reservedLi
   })
 }
 
-module.exports = {
+export default {
   meta: {
     docs: {
       description: 'Enforce props alphabetical sorting',

--- a/packages/eslint-plugin-jsx/rules/jsx-sort-props/jsx-sort-props.test.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-sort-props/jsx-sort-props.test.js
@@ -3,17 +3,11 @@
  * @author Yannick Croissant
  */
 
-'use strict'
-
-// -----------------------------------------------------------------------------
-// Requirements
-// -----------------------------------------------------------------------------
-
-const RuleTester = require('eslint').RuleTester
-const semver = require('semver')
-const eslintPkg = require('eslint/package.json')
-const parsers = require('../../tests/helpers/parsers')
-const rule = require('./jsx-sort-props')
+import { RuleTester } from 'eslint'
+import semver from 'semver'
+import eslintPkg from 'eslint/package.json'
+import parsers from '../../tests/helpers/parsers'
+import rule from './jsx-sort-props'
 
 const parserOptions = {
   ecmaVersion: 2018,

--- a/packages/eslint-plugin-jsx/rules/jsx-tag-spacing/jsx-tag-spacing.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-tag-spacing/jsx-tag-spacing.js
@@ -3,11 +3,9 @@
  * @author Diogo Franco (Kovensky)
  */
 
-'use strict'
-
-const getTokenBeforeClosingBracket = require('../../util/getTokenBeforeClosingBracket')
-const docsUrl = require('../../util/docsUrl')
-const report = require('../../util/report')
+import getTokenBeforeClosingBracket from '../../util/getTokenBeforeClosingBracket'
+import docsUrl from '../../util/docsUrl'
+import report from '../../util/report'
 
 const messages = {
   selfCloseSlashNoSpace: 'Whitespace is forbidden between `/` and `>`; write `/>`',
@@ -259,7 +257,7 @@ const optionDefaults = {
   beforeClosing: 'allow',
 }
 
-module.exports = {
+export default {
   meta: {
     docs: {
       description: 'Enforce whitespace in and around the JSX opening and closing brackets',

--- a/packages/eslint-plugin-jsx/rules/jsx-tag-spacing/jsx-tag-spacing.test.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-tag-spacing/jsx-tag-spacing.test.js
@@ -3,15 +3,9 @@
  * @author Diogo Franco (Kovensky)
  */
 
-'use strict'
-
-// -----------------------------------------------------------------------------
-// Requirements
-// -----------------------------------------------------------------------------
-
-const RuleTester = require('eslint').RuleTester
-const parsers = require('../../tests/helpers/parsers')
-const rule = require('./jsx-tag-spacing')
+import { RuleTester } from 'eslint'
+import parsers from '../../tests/helpers/parsers'
+import rule from './jsx-tag-spacing'
 
 const parserOptions = {
   ecmaVersion: 2018,

--- a/packages/eslint-plugin-jsx/rules/jsx-wrap-multilines/jsx-wrap-multilines.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-wrap-multilines/jsx-wrap-multilines.js
@@ -3,13 +3,12 @@
  * @author Yannick Croissant
  */
 
-'use strict'
+import docsUrl from '../../util/docsUrl'
+import jsxUtil from '../../util/jsx'
+import reportC from '../../util/report'
+import { isParenthesized } from '../../util/ast'
 
 const has = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
-const docsUrl = require('../../util/docsUrl')
-const jsxUtil = require('../../util/jsx')
-const reportC = require('../../util/report')
-const isParenthesized = require('../../util/ast').isParenthesized
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -34,7 +33,7 @@ const messages = {
   parensOnNewLines: 'Parentheses around JSX should be on separate lines',
 }
 
-module.exports = {
+export default {
   meta: {
     docs: {
       description: 'Disallow missing parentheses around multiline JSX',

--- a/packages/eslint-plugin-jsx/rules/jsx-wrap-multilines/jsx-wrap-multilines.test.js
+++ b/packages/eslint-plugin-jsx/rules/jsx-wrap-multilines/jsx-wrap-multilines.test.js
@@ -3,15 +3,9 @@
  * @author Yannick Croissant
  */
 
-'use strict'
-
-// ------------------------------------------------------------------------------
-// Requirements
-// ------------------------------------------------------------------------------
-
-const RuleTester = require('eslint').RuleTester
-const parsers = require('../../tests/helpers/parsers')
-const rule = require('./jsx-wrap-multilines')
+import { RuleTester } from 'eslint'
+import parsers from '../../tests/helpers/parsers'
+import rule from './jsx-wrap-multilines'
 
 const parserOptions = {
   ecmaVersion: 2018,


### PR DESCRIPTION
Related to: #51 #58 

## What changed?

Migrates to ESM for rules related to `eslint-plugin-jsx`

Utils are left untouched