### PR TITLE
Enforce the use of indent rule from the js rule set

### DIFF
--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -7,5 +7,6 @@ export default {
     ...js.rules,
     ...jsx.rules,
     ...ts.rules,
+    indent: js.rules.indent,
   },
 }


### PR DESCRIPTION
Considering that the `indent` rule for `ts` is broken (https://github.com/typescript-eslint/typescript-eslint/issues/1824), I suggest using the rule from `js` in the general default config until the broken rule is fixed or removed from the package.
related: https://github.com/eslint-stylistic/eslint-stylistic/issues/46 https://github.com/eslint-stylistic/eslint-stylistic/issues/52