### PR TITLE
docs: fix `function-call-spacing` docs

### DIFF
--- a/packages/eslint-plugin-js/rules/function-call-argument-newline/README.md
+++ b/packages/eslint-plugin-js/rules/function-call-argument-newline/README.md
@@ -3,7 +3,7 @@ title: function-call-argument-newline
 rule_type: layout
 related_rules:
 - function-paren-newline
-- func-call-spacing
+- function-call-spacing
 - object-property-newline
 - array-element-newline
 ---

--- a/packages/eslint-plugin-js/rules/function-call-spacing/README.md
+++ b/packages/eslint-plugin-js/rules/function-call-spacing/README.md
@@ -38,7 +38,7 @@ Examples of **incorrect** code for this rule with the default `"never"` option:
 ::: incorrect
 
 ```js
-/*eslint func-call-spacing: ["error", "never"]*/
+/*eslint function-call-spacing: ["error", "never"]*/
 
 fn ();
 
@@ -53,7 +53,7 @@ Examples of **correct** code for this rule with the default `"never"` option:
 ::: correct
 
 ```js
-/*eslint func-call-spacing: ["error", "never"]*/
+/*eslint function-call-spacing: ["error", "never"]*/
 
 fn();
 ```
@@ -67,7 +67,7 @@ Examples of **incorrect** code for this rule with the `"always"` option:
 ::: incorrect
 
 ```js
-/*eslint func-call-spacing: ["error", "always"]*/
+/*eslint function-call-spacing: ["error", "always"]*/
 
 fn();
 
@@ -82,7 +82,7 @@ Examples of **correct** code for this rule with the `"always"` option:
 ::: correct
 
 ```js
-/*eslint func-call-spacing: ["error", "always"]*/
+/*eslint function-call-spacing: ["error", "always"]*/
 
 fn ();
 ```
@@ -98,7 +98,7 @@ Examples of **incorrect** code for this rule with `allowNewlines` option enabled
 ::: incorrect
 
 ```js
-/*eslint func-call-spacing: ["error", "always", { "allowNewlines": true }]*/
+/*eslint function-call-spacing: ["error", "always", { "allowNewlines": true }]*/
 
 fn();
 ```
@@ -110,7 +110,7 @@ Examples of **correct** code for this rule with the `allowNewlines` option enabl
 ::: correct
 
 ```js
-/*eslint func-call-spacing: ["error", "always", { "allowNewlines": true }]*/
+/*eslint function-call-spacing: ["error", "always", { "allowNewlines": true }]*/
 
 fn (); // Newlines are never required.
 

--- a/packages/eslint-plugin-js/rules/function-call-spacing/function-call-spacing.js
+++ b/packages/eslint-plugin-js/rules/function-call-spacing/function-call-spacing.js
@@ -16,7 +16,7 @@ export default {
 
     docs: {
       description: 'Require or disallow spacing between function identifiers and their invocations',
-      url: 'https://eslint.style/rules/js/func-call-spacing',
+      url: 'https://eslint.style/rules/js/function-call-spacing',
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin-js/rules/keyword-spacing/README.md
+++ b/packages/eslint-plugin-js/rules/keyword-spacing/README.md
@@ -206,7 +206,7 @@ let obj1 = {
     foo:function() {}
 };
 
-// Avoid conflict with `func-call-spacing`
+// Avoid conflict with `function-call-spacing`
 class A extends B {
     constructor() {
         super();

--- a/packages/eslint-plugin-ts/rules/function-call-spacing/README.md
+++ b/packages/eslint-plugin-ts/rules/function-call-spacing/README.md
@@ -3,5 +3,5 @@ description: 'Require or disallow spacing between function identifiers and their
 ---
 
 
-This rule extends the base [`func-call-spacing`](/rules/js/func-call-spacing) rule.
+This rule extends the base [`function-call-spacing`](/rules/js/function-call-spacing) rule.
 It adds support for generic type parameters on function calls.


### PR DESCRIPTION
This PR fixes the documentation for `function-call-spacing`.