### PR TITLE
refactor(jsx): migrate jsx-newline to ts

### DIFF
--- a/packages/eslint-plugin-jsx/rules/jsx-newline/jsx-newline.test.ts
+++ b/packages/eslint-plugin-jsx/rules/jsx-newline/jsx-newline.test.ts
@@ -16,11 +16,13 @@ const parserOptions = {
   },
 }
 
+const ruleTester = new RuleTester({ parserOptions })
+
 // ------------------------------------------------------------------------------
 // Tests
 // ------------------------------------------------------------------------------
 
-new RuleTester({ parserOptions }).run('jsx-newline', rule, {
+ruleTester.run('jsx-newline', rule, {
   valid: parsers.all([
     {
       code: `


### PR DESCRIPTION
Part of https://github.com/eslint-stylistic/eslint-stylistic/issues/70

This pull request migrates jsx-newline to TypeScript. 