### PR TITLE
fix(ts/lines-around-comment): add missing `afterHashbangComment` in schema, fix #75

### DIFF
--- a/packages/eslint-plugin-ts/rules/lines-around-comment/lines-around-comment.test.ts
+++ b/packages/eslint-plugin-ts/rules/lines-around-comment/lines-around-comment.test.ts
@@ -1049,5 +1049,14 @@ interface A {
       ],
       errors: [{ messageId: 'after', type: AST_TOKEN_TYPES.Line, line: 2 }],
     },
+
+    // Hashbang comment
+    {
+      code: '#!foo\nvar a = 1;',
+      output: '#!foo\n\nvar a = 1;',
+      options: [{ afterHashbangComment: true }],
+      // @ts-expect-error -- Shebang is not in the type
+      errors: [{ messageId: 'after', type: 'Shebang' }],
+    },
   ],
 })

--- a/packages/eslint-plugin-ts/rules/lines-around-comment/lines-around-comment.ts
+++ b/packages/eslint-plugin-ts/rules/lines-around-comment/lines-around-comment.ts
@@ -126,6 +126,9 @@ export default createRule<RuleOptions, MessageIds>({
           applyDefaultIgnorePatterns: {
             type: 'boolean',
           },
+          afterHashbangComment: {
+            type: 'boolean',
+          },
         },
         additionalProperties: false,
       },

--- a/packages/eslint-plugin-ts/rules/lines-around-comment/types.d.ts
+++ b/packages/eslint-plugin-ts/rules/lines-around-comment/types.d.ts
@@ -23,6 +23,7 @@ export interface Schema0 {
   allowModuleEnd?: boolean
   ignorePattern?: string
   applyDefaultIgnorePatterns?: boolean
+  afterHashbangComment?: boolean
 }
 
 export type RuleOptions = [Schema0?]


### PR DESCRIPTION
fix #75