### PR TITLE
fix(ts/padding-line-between-statements): support `cjs-import` and `cjs-export` statement type, fix #53

### DIFF
--- a/packages/eslint-plugin-ts/rules/padding-line-between-statements/padding-line-between-statements.test.ts
+++ b/packages/eslint-plugin-ts/rules/padding-line-between-statements/padding-line-between-statements.test.ts
@@ -5124,5 +5124,13 @@ declare namespace Types {
       options: [{ blankLine: 'always', prev: '*', next: 'block-like' }],
       errors: [{ messageId: 'expectedBlankLine' }],
     },
+
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/53
+    {
+      code: `const path = require('node:path');\nmodule.exports = {};`,
+      output: `const path = require('node:path');\n\nmodule.exports = {};`,
+      options: [{ blankLine: 'always', prev: 'cjs-import', next: 'cjs-export' }],
+      errors: [{ messageId: 'expectedBlankLine' }],
+    },
   ],
 })

--- a/packages/eslint-plugin-ts/rules/padding-line-between-statements/padding-line-between-statements.ts
+++ b/packages/eslint-plugin-ts/rules/padding-line-between-statements/padding-line-between-statements.ts
@@ -13,6 +13,9 @@ import {
   createRule,
 } from '../../utils'
 
+const CJS_EXPORT = /^(?:module\s*\.\s*)?exports(?:\s*\.|\s*\[|$)/u
+const CJS_IMPORT = /^require\(/u
+
 /**
  * This rule is a replica of padding-line-between-statements.
  *
@@ -569,6 +572,18 @@ const StatementTypes: Record<string, NodeTestObject> = {
     'while',
   ),
   'with': newKeywordTester(AST_NODE_TYPES.WithStatement, 'with'),
+
+  'cjs-export': {
+    test: (node, sourceCode) => node.type === 'ExpressionStatement'
+    && node.expression.type === 'AssignmentExpression'
+    && CJS_EXPORT.test(sourceCode.getText(node.expression.left)),
+  },
+  'cjs-import': {
+    test: (node, sourceCode) => node.type === 'VariableDeclaration'
+    && node.declarations.length > 0
+    && Boolean(node.declarations[0].init)
+    && CJS_IMPORT.test(sourceCode.getText(node.declarations[0].init!)),
+  },
 
   // Additional Typescript constructs
   'interface': newKeywordTester(

--- a/packages/eslint-plugin-ts/rules/padding-line-between-statements/types.d.ts
+++ b/packages/eslint-plugin-ts/rules/padding-line-between-statements/types.d.ts
@@ -41,6 +41,8 @@ export type StatementType =
     | 'var'
     | 'while'
     | 'with'
+    | 'cjs-export'
+    | 'cjs-import'
     | 'interface'
     | 'type'
     )
@@ -84,6 +86,8 @@ export type StatementType =
         | 'var'
         | 'while'
         | 'with'
+        | 'cjs-export'
+        | 'cjs-import'
         | 'interface'
         | 'type'
       ),
@@ -126,6 +130,8 @@ export type StatementType =
         | 'var'
         | 'while'
         | 'with'
+        | 'cjs-export'
+        | 'cjs-import'
         | 'interface'
         | 'type'
       )[],


### PR DESCRIPTION
fix #53