### PR TITLE
fix(eslint-plugin): rename config `recommended-legacy` to `recommended-extends`

### DIFF
--- a/docs/guide/config-presets.md
+++ b/docs/guide/config-presets.md
@@ -84,7 +84,7 @@ export default [
 // .eslintrc.js
 module.exports = {
   extends: [
-    'plugin:@stylistic/recommended-legacy'
+    'plugin:@stylistic/recommended-extends'
   ],
   rules: {
     // ...your other rules

--- a/packages/eslint-plugin/configs/index.ts
+++ b/packages/eslint-plugin/configs/index.ts
@@ -3,6 +3,8 @@ import { customize } from './customize'
 
 export type * from './customize'
 
+const recommendedExtends = /* #__PURE__ */ customize({ flat: false })
+
 export const configs = {
   /**
    * Disable all legacy rules from `eslint`, `@typescript-eslint` and `eslint-plugin-react`
@@ -21,5 +23,10 @@ export const configs = {
   /**
    * The default recommended config in Legacy Config Format
    */
-  'recommended-legacy': /* #__PURE__ */ customize({ flat: false }),
+  'recommended-extends': recommendedExtends,
+
+  /**
+   * @deprecated Use `recommended-extends` instead
+   */
+  'recommended-legacy': recommendedExtends,
 }


### PR DESCRIPTION
To avoid confusion with `disable-legacy` as the `legacy` can means "Legacy Rules" and "Legacy Config Format". We use `extends` to differentiate the Flat Config and the legacy config format.