### PR TITLE
docs: specify the Node engine and ESLint version requirement

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -18,6 +18,13 @@ According to [`typescript-eslint`'s definition](https://typescript-eslint.io/lin
 
 For ESLint Stylistic, our primary focus is on the **formatting** and **stylistic** rules inherited from `eslint` and `typescript-eslint`. We will maintain some stylistic rules; however, not all will be included. Their inclusion depends on whether the upstream projects choose to retain them. We welcome new rules proposed by the community for the future when we move into the maintenance phase and develop the infrastructure to introduce experimental rules. For more details, track the [Project Progress](/contribute/project-progress).
 
+## What's the requirements for ESLint Stylistic?
+
+Since majority of the rules are migreated from ESLint v8 and `typescript-eslint` v6, we inherit the same requirements:
+
+- Node.js >=v16.0.0
+- ESLint >=v8.0.0
+
 ## How to auto-format on save?
 
 ##### VS Code

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -20,7 +20,7 @@ For ESLint Stylistic, our primary focus is on the **formatting** and **stylistic
 
 ## What's the requirements for ESLint Stylistic?
 
-Since majority of the rules are migreated from ESLint v8 and `typescript-eslint` v6, we inherit the same requirements:
+Since majority of the rules are migrated from ESLint v8 and `typescript-eslint` v6, we inherit the same requirements:
 
 - Node.js >=v16.0.0
 - ESLint >=v8.0.0

--- a/packages/eslint-plugin-js/package.json
+++ b/packages/eslint-plugin-js/package.json
@@ -100,6 +100,9 @@
     "dts",
     "rules/**/*.d.ts"
   ],
+  "engines": {
+    "node": "^16.0.0 || >=18.0.0"
+  },
   "scripts": {
     "build": "rimraf dist && rollup --config=rollup.config.mts --configPlugin=rollup-plugin-esbuild",
     "dev": "rollup --config=rollup.config.mts --configPlugin=rollup-plugin-esbuild --watch",

--- a/packages/eslint-plugin-js/package.json
+++ b/packages/eslint-plugin-js/package.json
@@ -108,6 +108,9 @@
     "dev": "rollup --config=rollup.config.mts --configPlugin=rollup-plugin-esbuild --watch",
     "prepublishOnly": "pnpm build"
   },
+  "peerDependencies": {
+    "eslint": ">=8.0.0"
+  },
   "dependencies": {
     "acorn": "^8.11.2",
     "escape-string-regexp": "^4.0.0",

--- a/packages/eslint-plugin-jsx/package.json
+++ b/packages/eslint-plugin-jsx/package.json
@@ -58,6 +58,9 @@
     "dev": "rollup --config=rollup.config.mts --configPlugin=rollup-plugin-esbuild --watch",
     "prepublishOnly": "pnpm build"
   },
+  "peerDependencies": {
+    "eslint": ">=8.0.0"
+  },
   "dependencies": {
     "@stylistic/eslint-plugin-js": "workspace:^",
     "estraverse": "^5.3.0"

--- a/packages/eslint-plugin-jsx/package.json
+++ b/packages/eslint-plugin-jsx/package.json
@@ -50,6 +50,9 @@
     "dts",
     "rules/**/*.d.ts"
   ],
+  "engines": {
+    "node": "^16.0.0 || >=18.0.0"
+  },
   "scripts": {
     "build": "rimraf dist && rollup --config=rollup.config.mts --configPlugin=rollup-plugin-esbuild",
     "dev": "rollup --config=rollup.config.mts --configPlugin=rollup-plugin-esbuild --watch",

--- a/packages/eslint-plugin-migrate/package.json
+++ b/packages/eslint-plugin-migrate/package.json
@@ -17,6 +17,9 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": "^16.0.0 || >=18.0.0"
+  },
   "scripts": {
     "build": "unbuild",
     "stub": "unbuild --stub",

--- a/packages/eslint-plugin-ts/package.json
+++ b/packages/eslint-plugin-ts/package.json
@@ -54,6 +54,9 @@
     "dts",
     "rules/**/*.d.ts"
   ],
+  "engines": {
+    "node": "^16.0.0 || >=18.0.0"
+  },
   "scripts": {
     "build": "rimraf dist && rollup --config=rollup.config.mts --configPlugin=rollup-plugin-esbuild",
     "dev": "rollup --config=rollup.config.mts --configPlugin=rollup-plugin-esbuild --watch",

--- a/packages/eslint-plugin-ts/package.json
+++ b/packages/eslint-plugin-ts/package.json
@@ -63,7 +63,7 @@
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {
-    "eslint": "*"
+    "eslint": ">=8.0.0"
   },
   "dependencies": {
     "@stylistic/eslint-plugin-js": "workspace:*",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -39,7 +39,7 @@
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {
-    "eslint": "*"
+    "eslint": ">=8.0.0"
   },
   "dependencies": {
     "@stylistic/eslint-plugin-js": "workspace:*",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -30,6 +30,9 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": "^16.0.0 || >=18.0.0"
+  },
   "scripts": {
     "build": "rimraf dist && rollup --config=rollup.config.mts --configPlugin=rollup-plugin-esbuild",
     "dev": "rollup --config=rollup.config.mts --configPlugin=rollup-plugin-esbuild --watch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,7 +187,7 @@ importers:
         specifier: workspace:*
         version: link:../eslint-plugin-ts
       eslint:
-        specifier: '*'
+        specifier: '>=8.0.0'
         version: 8.53.0
 
   packages/eslint-plugin-js:
@@ -198,6 +198,9 @@ importers:
       escape-string-regexp:
         specifier: ^4.0.0
         version: 4.0.0
+      eslint:
+        specifier: '>=8.0.0'
+        version: 8.53.0
       eslint-visitor-keys:
         specifier: ^3.4.3
         version: 3.4.3
@@ -270,7 +273,7 @@ importers:
         specifier: ^6.11.0
         version: 6.11.0(eslint@8.53.0)(typescript@5.2.2)
       eslint:
-        specifier: '*'
+        specifier: '>=8.0.0'
         version: 8.53.0
       graphemer:
         specifier: ^1.4.0


### PR DESCRIPTION
We inherited those requirements from the source projects. This PR makes it clear to users.