### PR TITLE
docs: unify `incorrect/correct` label for typescript documentation

### DIFF
--- a/packages/eslint-plugin-ts/rules/member-delimiter-style/README.md
+++ b/packages/eslint-plugin-ts/rules/member-delimiter-style/README.md
@@ -103,7 +103,7 @@ Examples of code for this rule with the default config:
 
 <!--tabs-->
 
-### ❌ Incorrect
+::: incorrect
 
 <!-- prettier-ignore -->
 ```ts
@@ -132,7 +132,7 @@ type FooBar = { name: string, greet(): string }
 type FooBar = { name: string; greet(): string; }
 ```
 
-### ✅ Correct
+::: correct
 
 <!-- prettier-ignore -->
 ```ts

--- a/packages/eslint-plugin-ts/rules/space-before-blocks/README.md
+++ b/packages/eslint-plugin-ts/rules/space-before-blocks/README.md
@@ -8,7 +8,7 @@ It adds support for interfaces and enums.
 
 <!-- tabs -->
 
-### ❌ Incorrect
+::: incorrect
 
 ```ts
 enum Breakpoint{
@@ -20,7 +20,7 @@ interface State{
 }
 ```
 
-### ✅ Correct
+::: correct
 
 ```ts
 enum Breakpoint {

--- a/packages/eslint-plugin-ts/rules/type-annotation-spacing/README.md
+++ b/packages/eslint-plugin-ts/rules/type-annotation-spacing/README.md
@@ -38,7 +38,7 @@ This rule aims to enforce specific spacing patterns around type annotations and 
 
 <!--tabs-->
 
-### ❌ Incorrect
+::: incorrect
 
 <!-- prettier-ignore -->
 ```ts
@@ -67,7 +67,7 @@ type Foo = () =>{};
 type Foo = ()=> {};
 ```
 
-### ✅ Correct
+::: correct
 
 <!-- prettier-ignore -->
 ```ts
@@ -92,7 +92,7 @@ type Foo = () => {};
 
 <!--tabs-->
 
-#### ❌ Incorrect
+::: incorrect
 
 <!-- prettier-ignore -->
 ```ts
@@ -121,7 +121,7 @@ type Foo = () =>{};
 type Foo = () => {};
 ```
 
-#### ✅ Correct
+::: correct
 
 <!-- prettier-ignore -->
 ```ts
@@ -144,7 +144,7 @@ type Foo = ()=> {};
 
 <!--tabs-->
 
-#### ❌ Incorrect
+::: incorrect
 
 <!-- prettier-ignore -->
 ```ts
@@ -173,7 +173,7 @@ type Foo = () =>{};
 type Foo = ()=> {};
 ```
 
-#### ✅ Correct
+::: correct
 
 <!-- prettier-ignore -->
 ```ts
@@ -200,7 +200,7 @@ type Foo = () => {};
 
 <!--tabs-->
 
-#### ❌ Incorrect
+::: incorrect
 
 <!-- prettier-ignore -->
 ```ts
@@ -229,7 +229,7 @@ type Foo = ()=> {};
 type Foo = () => {};
 ```
 
-#### ✅ Correct
+::: correct
 
 <!-- prettier-ignore -->
 ```ts
@@ -260,7 +260,7 @@ type Foo = ()=>{};
 
 <!--tabs-->
 
-#### ❌ Incorrect
+::: incorrect
 
 <!-- prettier-ignore -->
 ```ts
@@ -289,7 +289,7 @@ type Foo = () =>{};
 type Foo = ()=> {};
 ```
 
-#### ✅ Correct
+::: correct
 
 <!-- prettier-ignore -->
 ```ts


### PR DESCRIPTION
Typescript documentation used emojis to display incorrect/correct code examples. Now it use the same `::: correct` tag to display the labels in the documentation.

### Description

This PR unifies the label `correct` incorrect` that was displayed on the typescript documentation. Now it uses the same label than the Javascript documentation.

### Additional context

Didn't created an issue for it since it was such a small change but if it's requested. I'll do that. 
