### PR TITLE
docs: add config as comments within documentations examples

### DIFF
--- a/packages/eslint-plugin-ts/rules/member-delimiter-style/README.md
+++ b/packages/eslint-plugin-ts/rules/member-delimiter-style/README.md
@@ -107,6 +107,8 @@ Examples of code for this rule with the default config:
 
 <!-- prettier-ignore -->
 ```ts
+/*eslint @stylistic/ts/member-delimiter-style: "error"*/
+
 // missing semicolon delimiter
 interface Foo {
     name: string
@@ -136,6 +138,8 @@ type FooBar = { name: string; greet(): string; }
 
 <!-- prettier-ignore -->
 ```ts
+/*eslint @stylistic/ts/member-delimiter-style: "error"*/
+
 interface Foo {
     name: string;
     greet(): string;

--- a/packages/eslint-plugin-ts/rules/space-before-blocks/README.md
+++ b/packages/eslint-plugin-ts/rules/space-before-blocks/README.md
@@ -11,6 +11,8 @@ It adds support for interfaces and enums.
 ::: incorrect
 
 ```ts
+/*eslint @stylistic/ts/space-before-blocks: "error"*/
+
 enum Breakpoint{
   Large, Medium;
 }
@@ -23,6 +25,8 @@ interface State{
 ::: correct
 
 ```ts
+/*eslint @stylistic/ts/space-before-blocks: "error"*/
+
 enum Breakpoint {
   Large, Medium;
 }

--- a/packages/eslint-plugin-ts/rules/type-annotation-spacing/README.md
+++ b/packages/eslint-plugin-ts/rules/type-annotation-spacing/README.md
@@ -42,6 +42,8 @@ This rule aims to enforce specific spacing patterns around type annotations and 
 
 <!-- prettier-ignore -->
 ```ts
+/*eslint @stylistic/ts/type-annotation-spacing: "error"*/
+
 let foo:string = "bar";
 let foo :string = "bar";
 let foo : string = "bar";
@@ -71,6 +73,8 @@ type Foo = ()=> {};
 
 <!-- prettier-ignore -->
 ```ts
+/*eslint @stylistic/ts/type-annotation-spacing: "error"*/
+
 let foo: string = "bar";
 
 function foo(): string {}
@@ -86,9 +90,7 @@ type Foo = () => {};
 
 ### after
 
-```json
-{ "before": false, "after": true }
-```
+Examples of **incorrect** code for this rule with the `{ "before": false, "after": true }` option:
 
 <!--tabs-->
 
@@ -96,6 +98,8 @@ type Foo = () => {};
 
 <!-- prettier-ignore -->
 ```ts
+/*eslint @stylistic/ts/type-annotation-spacing: ["error", { "before": false, "after": true }]*/
+
 let foo:string = "bar";
 let foo :string = "bar";
 let foo : string = "bar";
@@ -121,10 +125,14 @@ type Foo = () =>{};
 type Foo = () => {};
 ```
 
+Examples of **correct** code for this rule with the `{ "before": false, "after": true }` option:
+
 ::: correct
 
 <!-- prettier-ignore -->
 ```ts
+/*eslint @stylistic/ts/type-annotation-spacing: ["error", { "before": false, "after": true }]*/
+
 let foo: string = "bar";
 
 function foo(): string {}
@@ -138,9 +146,7 @@ type Foo = ()=> {};
 
 ### before
 
-```json
-{ "before": true, "after": true }
-```
+Examples of **incorrect** code for this rule with the `{ "before": true, "after": true }` option:
 
 <!--tabs-->
 
@@ -148,6 +154,8 @@ type Foo = ()=> {};
 
 <!-- prettier-ignore -->
 ```ts
+/*eslint @stylistic/ts/type-annotation-spacing: ["error", { "before": true, "after": true }]*/
+
 let foo: string = "bar";
 let foo:string = "bar";
 let foo :string = "bar";
@@ -173,10 +181,14 @@ type Foo = () =>{};
 type Foo = ()=> {};
 ```
 
+Examples of **correct** code for this rule with the `{ "before": true, "after": true }` option:
+
 ::: correct
 
 <!-- prettier-ignore -->
 ```ts
+/*eslint @stylistic/ts/type-annotation-spacing: ["error", { "before": true, "after": true }]*/
+
 let foo : string = "bar";
 
 function foo() : string {}
@@ -190,13 +202,7 @@ type Foo = () => {};
 
 ### overrides - colon
 
-```json
-{
-  "before": false,
-  "after": false,
-  "overrides": { "colon": { "before": true, "after": true } }
-}
-```
+Examples of **incorrect** code for this rule with the `{ "before": false, "after": false, "overrides": { "colon": { "before": true, "after": true } } }` option:
 
 <!--tabs-->
 
@@ -204,6 +210,8 @@ type Foo = () => {};
 
 <!-- prettier-ignore -->
 ```ts
+/*eslint @stylistic/ts/type-annotation-spacing: ["error", { "before": false, "after": false, "overrides": { "colon": { "before": true, "after": true } } }]*/
+
 let foo: string = "bar";
 let foo:string = "bar";
 let foo :string = "bar";
@@ -229,10 +237,14 @@ type Foo = ()=> {};
 type Foo = () => {};
 ```
 
+Examples of **correct** code for this rule with the `{ "before": false, "after": false, "overrides": { "colon": { "before": true, "after": true } } }` option:
+
 ::: correct
 
 <!-- prettier-ignore -->
 ```ts
+/*eslint @stylistic/ts/type-annotation-spacing: ["error", { "before": false, "after": false, "overrides": { "colon": { "before": true, "after": true } } }]*/
+
 let foo : string = "bar";
 
 function foo() : string {}
@@ -250,13 +262,7 @@ type Foo = ()=>{};
 
 ### overrides - arrow
 
-```json
-{
-  "before": false,
-  "after": false,
-  "overrides": { "arrow": { "before": true, "after": true } }
-}
-```
+Examples of **incorrect** code for this rule with the `{ "before": false, "after": false, "overrides": { "arrow": { "before": true, "after": true } } }` option:
 
 <!--tabs-->
 
@@ -264,6 +270,8 @@ type Foo = ()=>{};
 
 <!-- prettier-ignore -->
 ```ts
+/*eslint @stylistic/ts/type-annotation-spacing: ["error", { "before": false, "after": false, "overrides": { "arrow": { "before": true, "after": true } } }]*/
+
 let foo: string = "bar";
 let foo : string = "bar";
 let foo :string = "bar";
@@ -289,10 +297,14 @@ type Foo = () =>{};
 type Foo = ()=> {};
 ```
 
+Examples of **correct** code for this rule with the `{ "before": false, "after": false, "overrides": { "arrow": { "before": true, "after": true } } }` option:
+
 ::: correct
 
 <!-- prettier-ignore -->
 ```ts
+/*eslint @stylistic/ts/type-annotation-spacing: ["error", { "before": false, "after": false, "overrides": { "arrow": { "before": true, "after": true } } }]*/
+
 let foo:string = "bar";
 
 function foo():string {}


### PR DESCRIPTION
### Description

The Javascript documentation has at the start of the code sample a comment line that activates the rule with a specific config. 
I founded it very useful, but was suprised to not see it for the Typescript documentation.
This PR adds it for the Typescript documentation. Also changed a bit of the text in the front of some correct/incorrect examples to be more like the Javascript one (e.g. https://eslint.style/rules/js/lines-around-comment).