### PR TITLE
allow backtick literals, but forbid backtick import assertions

### DIFF
--- a/packages/eslint-plugin-ts/rules/quotes/quotes.test.ts
+++ b/packages/eslint-plugin-ts/rules/quotes/quotes.test.ts
@@ -44,7 +44,7 @@ ruleTester.run('quotes', rule, {
     {
       code: `
         class A {
-          public prop: IProps['prop'];
+          public prop: IProps[\`prop\`];
         }
       `,
       options: ['backtick'],
@@ -303,11 +303,11 @@ ruleTester.run('quotes', rule, {
 
     // `backtick` should not warn import/export sources.
     {
-      code: 'import "a"; import \'b\';',
+      code: 'import "a" assert { type: "json" }; import \'b\' assert { type: \'json\' };',
       options: ['backtick'],
     },
     {
-      code: 'import a from "a"; import b from \'b\';',
+      code: 'import a from "a" assert { type: "json" }; import b from \'b\' assert { type: \'json\' };',
       options: ['backtick'],
     },
     {

--- a/packages/eslint-plugin-ts/rules/quotes/quotes.ts
+++ b/packages/eslint-plugin-ts/rules/quotes/quotes.ts
@@ -39,7 +39,7 @@ export default createRule<RuleOptions, MessageIds>({
         case AST_NODE_TYPES.TSMethodSignature:
         case AST_NODE_TYPES.TSPropertySignature:
         case AST_NODE_TYPES.TSModuleDeclaration:
-        case AST_NODE_TYPES.TSLiteralType:
+        case AST_NODE_TYPES.ImportAttribute:
         case AST_NODE_TYPES.TSExternalModuleReference:
           return true
 


### PR DESCRIPTION
This PR fixes two issues with the `quotes` rule in TypeScript, both of which occur when the rule is set to `backticks`.

They can be separated into separate PRs if necessary.

1. At the time that the `@typescript-eslint/quotes` rule was originally created, [TypeScript did not support backticks for `LiteralType`s](https://github.com/typescript-eslint/typescript-eslint/issues/756). However, since that time, TypeScript has [added support for this](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html). This rule was never updated accordingly — it skipped linting `LiteralType`s when the rule's option was set to `backticks`. This PR now changes strings in `LiteralType`s to backticks.

2. [Node.js](https://nodejs.org/dist/latest-v20.x/docs/api/esm.html#import-attributes) and [TypeScript](https://devblogs.microsoft.com/typescript/announcing-typescript-5-3/#import-attributes) recently added support for import attributes. When this rule's option is set to `backticks`, it wrongly changes quotes to backticks in import attributes, which is a syntax error. It now skips linting quotes inside `ImportAttribute`s.