### PR TITLE
Remove duplicate rule (`func-call-spacing` vs `function-call-spacing`) in `all` configs

### DIFF
--- a/packages/eslint-plugin-jsx/rules/jsx-self-closing-comp/jsx-self-closing-comp.ts
+++ b/packages/eslint-plugin-jsx/rules/jsx-self-closing-comp/jsx-self-closing-comp.ts
@@ -22,7 +22,7 @@ export default createRule<MessageIds, RuleOptions>({
     docs: {
       description: 'Disallow extra closing tags for components without children',
       // category: 'Stylistic Issues',
-      url: docsUrl('self-closing-comp'),
+      url: docsUrl('jsx-self-closing-comp'),
     },
     fixable: 'code',
 

--- a/packages/shared/configs-all.ts
+++ b/packages/shared/configs-all.ts
@@ -13,7 +13,7 @@ export function createAllConfigs<T extends { rules: Record<string, any> }>(
   const rules = Object.fromEntries(
     Object
       .entries(plugin.rules)
-      .filter(([key, { meta }]) => key !== meta.docs.url.split('/').pop())
+      .filter(([key, { meta }]) => key === meta.docs.url.split('/').pop())
       .map(([key]) => [`${name}/${key}`, 2]),
   )
 

--- a/packages/shared/configs-all.ts
+++ b/packages/shared/configs-all.ts
@@ -11,7 +11,10 @@ export function createAllConfigs<T extends { rules: Record<string, any> }>(
   flat: boolean,
 ) {
   const rules = Object.fromEntries(
-    Object.keys(plugin.rules).map(key => [`${name}/${key}`, 2]),
+    Object
+      .entries(plugin.rules)
+      .filter(([key, { meta }]) => key !== meta.docs.url.split('/').pop())
+      .map(([key]) => [`${name}/${key}`, 2]),
   )
 
   if (flat) {


### PR DESCRIPTION
### Description

The `createAllConfigs` function did not properly account for duplicate rules with the same name — it caused such rules to be turned on twice. This PR fixes that — the `func-call-spacing` rule is now no longer included in the `all` configs since its canonical name is `function-call-spacing`.

Additionally, this change highlighted that the `jsx-self-closing-comp`'s rule URL was incorrect, which I have fixed.

Let me know if there are any unit tests that you would like me to create or update — I did not find any tests validating this part of the repo.