### PR TITLE
feat(type-generic-spacing): new rule

### DIFF
--- a/packages/eslint-plugin-plus/dts/rule-options.d.ts
+++ b/packages/eslint-plugin-plus/dts/rule-options.d.ts
@@ -1,19 +1,19 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-import type { RuleOptions as ExampleRuleOptions } from '../rules/example/types'
+import type { RuleOptions as TypeGenericSpacingRuleOptions } from '../rules/type-generic-spacing/types'
 
 export interface RuleOptions {
   /**
-   * Disallow unnecessary semicolons
-   * @see https://eslint.style/rules/plus/example
+   * Enforces consistent spacing inside TypeScript type generics
+   * @see https://eslint.style/rules/plus/type-generic-spacing
    */
-  '@stylistic/plus/example': ExampleRuleOptions
+  '@stylistic/plus/type-generic-spacing': TypeGenericSpacingRuleOptions
 }
 
 export interface UnprefixedRuleOptions {
   /**
-   * Disallow unnecessary semicolons
-   * @see https://eslint.style/rules/plus/example
+   * Enforces consistent spacing inside TypeScript type generics
+   * @see https://eslint.style/rules/plus/type-generic-spacing
    */
-  'example': ExampleRuleOptions
+  'type-generic-spacing': TypeGenericSpacingRuleOptions
 }

--- a/packages/eslint-plugin-plus/package.json
+++ b/packages/eslint-plugin-plus/package.json
@@ -24,7 +24,7 @@
     "./rule-options": {
       "types": "./dts/rule-options.d.ts"
     },
-    "./rules/example": "./dist/example.js"
+    "./rules/type-generic-spacing": "./dist/type-generic-spacing.js"
   },
   "main": "./dist/index.js",
   "types": "./dts/index.d.ts",

--- a/packages/eslint-plugin-plus/rules.md
+++ b/packages/eslint-plugin-plus/rules.md
@@ -6,3 +6,4 @@
 
 | Rule ID | Description | Fixable | Recommended |
 | --- | --- | --- | --- |
+| [`@stylistic/plus/type-generic-spacing`](./rules/type-generic-spacing) | Enforces consistent spacing inside TypeScript type generics | ✅ |  |

--- a/packages/eslint-plugin-plus/rules/index.ts
+++ b/packages/eslint-plugin-plus/rules/index.ts
@@ -2,5 +2,8 @@
 
 import type { Rules } from '../dts'
 
+import typeGenericSpacing from './type-generic-spacing/type-generic-spacing'
+
 export default {
+  'type-generic-spacing': typeGenericSpacing,
 } as unknown as Rules

--- a/packages/eslint-plugin-plus/rules/type-generic-spacing/README.md
+++ b/packages/eslint-plugin-plus/rules/type-generic-spacing/README.md
@@ -1,0 +1,43 @@
+Enforces consistent spacing inside TypeScript type generics.
+
+## Rule Details
+
+This rule enforces consistent spacing inside TypeScript type generics.
+
+## Options
+
+This rule has no options.
+
+Examples of **incorrect** code for this rule:
+
+:::incorrect
+
+```ts
+/*eslint type-generic-spacing: ["error"]*/
+
+type Foo<T=true> = T
+type Foo<T,K> = T
+
+interface Log {
+  foo <T>(name: T): void
+}
+```
+
+:::
+
+Examples of **correct** code for this rule:
+
+:::correct
+
+```ts
+/*eslint type-generic-spacing: ["error"]*/
+
+type Foo<T = true> = T
+type Foo<T, K> = T
+
+interface Log {
+  foo<T>(name: T): void
+}
+```
+
+:::

--- a/packages/eslint-plugin-plus/rules/type-generic-spacing/type-generic-spacing.test.ts
+++ b/packages/eslint-plugin-plus/rules/type-generic-spacing/type-generic-spacing.test.ts
@@ -1,0 +1,49 @@
+import { RuleTester } from '@typescript-eslint/rule-tester'
+import rule from './type-generic-spacing'
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+})
+
+ruleTester.run('type-generic-spacing', rule, {
+  valid: [
+    'type Foo<T = true> = T',
+    'type Foo<T extends true = true> = T',
+    `
+    type Foo<
+      T = true,
+      K = false
+    > = T
+    `,
+    `function foo<
+      T
+    >() {}`,
+    'const foo = <T>(name: T) => name',
+    `interface Log {
+      foo<T>(name: T): void
+    }`,
+    `interface Log {
+    <T>(name: T): void
+  }`,
+  `interface Foo {
+    foo?: <T>(name: T) => void
+  }`,
+  `type Foo<\r\nT = true,\r\nK = false,\r\n> = T`,
+  `const toSortedImplementation = Array.prototype.toSorted || function <T>(name: T): void {}`,
+  ],
+  invalid: ([
+    ['type Foo<T=true> = T', 'type Foo<T = true> = T'],
+    ['type Foo<T,K> = T', 'type Foo<T, K> = T'],
+    ['type Foo<T=false,K=1|2> = T', 'type Foo<T = false, K = 1|2> = T', 3],
+    ['function foo <T>() {}', 'function foo<T>() {}'],
+    [`interface Log {
+    foo <T>(name: T): void
+  }`, `interface Log {
+    foo<T>(name: T): void
+  }`],
+  ] as const).map(i => ({
+    code: i[0],
+    output: i[1],
+    errors: Array.from({ length: i[2] || 1 }, () => ({ messageId: 'genericSpacingMismatch' })),
+  })),
+})

--- a/packages/eslint-plugin-plus/rules/type-generic-spacing/type-generic-spacing.ts
+++ b/packages/eslint-plugin-plus/rules/type-generic-spacing/type-generic-spacing.ts
@@ -1,0 +1,92 @@
+import { createRule } from '../../utils/createRule'
+import type { MessageIds, RuleOptions } from './types'
+
+const PRESERVE_PREFIX_SPACE_BEFORE_GENERIC = new Set([
+  'TSCallSignatureDeclaration',
+  'ArrowFunctionExpression',
+  'TSFunctionType',
+  'FunctionExpression',
+])
+
+export default createRule<RuleOptions, MessageIds>({
+  name: 'type-generic-spacing',
+  meta: {
+    type: 'layout',
+    docs: {
+      description: 'Enforces consistent spacing inside TypeScript type generics',
+      recommended: 'stylistic',
+    },
+    fixable: 'whitespace',
+    schema: [],
+    messages: {
+      genericSpacingMismatch: 'Generic spaces mismatch',
+    },
+  },
+  defaultOptions: [],
+  create: (context) => {
+    const sourceCode = context.sourceCode
+
+    return {
+      TSTypeParameterDeclaration: (node) => {
+        if (!PRESERVE_PREFIX_SPACE_BEFORE_GENERIC.has(node.parent.type)) {
+          const pre = sourceCode.text.slice(0, node.range[0])
+          const preSpace = pre.match(/(\s+)$/)?.[0]
+          // strip space before <T>
+          if (preSpace && preSpace.length) {
+            context.report({
+              node,
+              messageId: 'genericSpacingMismatch',
+              *fix(fixer) {
+                yield fixer.replaceTextRange([node.range[0] - preSpace.length, node.range[0]], '')
+              },
+            })
+          }
+        }
+
+        // add space between <T,K>
+        const params = node.params
+        for (let i = 1; i < params.length; i++) {
+          const prev = params[i - 1]
+          const current = params[i]
+          const from = prev.range[1]
+          const to = current.range[0]
+          const span = sourceCode.text.slice(from, to)
+          if (span !== ', ' && !span.match(/,\s*\r?\n/)) {
+            context.report({
+              *fix(fixer) {
+                yield fixer.replaceTextRange([from, to], ', ')
+              },
+              loc: {
+                start: prev.loc.end,
+                end: current.loc.start,
+              },
+              messageId: 'genericSpacingMismatch',
+              node,
+            })
+          }
+        }
+      },
+      // add space around = in type Foo<T = true>
+      TSTypeParameter: (node) => {
+        if (!node.default)
+          return
+        const endNode = node.constraint || node.name
+        const from = endNode.range[1]
+        const to = node.default.range[0]
+        if (sourceCode.text.slice(from, to) !== ' = ') {
+          context.report({
+            *fix(fixer) {
+              yield fixer.replaceTextRange([from, to], ' = ')
+            },
+            loc: {
+              start: endNode.loc.end,
+              end: node.default.loc.start,
+            },
+            messageId: 'genericSpacingMismatch',
+            node,
+          })
+        }
+      },
+    }
+  },
+})

--- a/packages/eslint-plugin-plus/rules/type-generic-spacing/types.d.ts
+++ b/packages/eslint-plugin-plus/rules/type-generic-spacing/types.d.ts
@@ -1,0 +1,4 @@
+/* GENERATED, DO NOT EDIT DIRECTLY */
+
+export type RuleOptions = []
+export type MessageIds = 'genericSpacingMismatch'

--- a/packages/metadata/src/metadata.ts
+++ b/packages/metadata/src/metadata.ts
@@ -1143,7 +1143,21 @@ export const packages: Readonly<PackageInfo[]> = Object.freeze([
     "shortId": "plus",
     "pkgId": "@stylistic/plus",
     "path": "packages/eslint-plugin-plus",
-    "rules": []
+    "rules": [
+      {
+        "name": "type-generic-spacing",
+        "ruleId": "@stylistic/plus/type-generic-spacing",
+        "originalId": "",
+        "entry": "packages/eslint-plugin-plus/rules/type-generic-spacing/type-generic-spacing.ts",
+        "docsEntry": "packages/eslint-plugin-plus/rules/type-generic-spacing/README.md",
+        "meta": {
+          "fixable": "whitespace",
+          "docs": {
+            "description": "Enforces consistent spacing inside TypeScript type generics"
+          }
+        }
+      }
+    ]
   },
   {
     "name": "@stylistic/eslint-plugin-ts",


### PR DESCRIPTION
This PR introduced a new rule, `type-generic-spacing`, ported from https://github.com/antfu/eslint-plugin-antfu/blob/main/src/rules/generic-spacing.ts

The spacing checking for generics was missing in `ts-eslint`:
- fix https://github.com/typescript-eslint/typescript-eslint/issues/4433