### PR TITLE
feat(type-named-tuple-spacing): new rule

### DIFF
--- a/packages/eslint-plugin-plus/dts/rule-options.d.ts
+++ b/packages/eslint-plugin-plus/dts/rule-options.d.ts
@@ -1,19 +1,19 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-import type { RuleOptions as ExampleRuleOptions } from '../rules/example/types'
+import type { RuleOptions as TypeNamedTupleSpacingRuleOptions } from '../rules/type-named-tuple-spacing/types'
 
 export interface RuleOptions {
   /**
-   * Disallow unnecessary semicolons
-   * @see https://eslint.style/rules/plus/example
+   * Expect space before the type declaration in the named tuple
+   * @see https://eslint.style/rules/plus/type-named-tuple-spacing
    */
-  '@stylistic/plus/example': ExampleRuleOptions
+  '@stylistic/plus/type-named-tuple-spacing': TypeNamedTupleSpacingRuleOptions
 }
 
 export interface UnprefixedRuleOptions {
   /**
-   * Disallow unnecessary semicolons
-   * @see https://eslint.style/rules/plus/example
+   * Expect space before the type declaration in the named tuple
+   * @see https://eslint.style/rules/plus/type-named-tuple-spacing
    */
-  'example': ExampleRuleOptions
+  'type-named-tuple-spacing': TypeNamedTupleSpacingRuleOptions
 }

--- a/packages/eslint-plugin-plus/package.json
+++ b/packages/eslint-plugin-plus/package.json
@@ -24,7 +24,7 @@
     "./rule-options": {
       "types": "./dts/rule-options.d.ts"
     },
-    "./rules/example": "./dist/example.js"
+    "./rules/type-named-tuple-spacing": "./dist/type-named-tuple-spacing.js"
   },
   "main": "./dist/index.js",
   "types": "./dts/index.d.ts",

--- a/packages/eslint-plugin-plus/rules.md
+++ b/packages/eslint-plugin-plus/rules.md
@@ -6,3 +6,4 @@
 
 | Rule ID | Description | Fixable | Recommended |
 | --- | --- | --- | --- |
+| [`@stylistic/plus/type-named-tuple-spacing`](./rules/type-named-tuple-spacing) | Expect space before the type declaration in the named tuple | ✅ |  |

--- a/packages/eslint-plugin-plus/rules/index.ts
+++ b/packages/eslint-plugin-plus/rules/index.ts
@@ -2,5 +2,8 @@
 
 import type { Rules } from '../dts'
 
+import typeNamedTupleSpacing from './type-named-tuple-spacing/type-named-tuple-spacing'
+
 export default {
+  'type-named-tuple-spacing': typeNamedTupleSpacing,
 } as unknown as Rules

--- a/packages/eslint-plugin-plus/rules/type-named-tuple-spacing/README.md
+++ b/packages/eslint-plugin-plus/rules/type-named-tuple-spacing/README.md
@@ -1,0 +1,37 @@
+Expect space before the type declaration in the named tuple.
+
+## Rule Details
+
+Expect space before the type declaration in the named tuple.
+
+## Options
+
+This rule has no options.
+
+Examples of **incorrect** code for this rule:
+
+:::incorrect
+
+```ts
+/*eslint type-named-tuple-spacing: ["error"]*/
+
+type T = [i:number]
+type T = [i?   :number]
+type T = [i:()=>void, j:number]
+```
+
+:::
+
+Examples of **correct** code for this rule:
+
+:::correct
+
+```ts
+/*eslint type-named-tuple-spacing: ["error"]*/
+
+type T = [i: number]
+type T = [i?: number]
+type T = [i: ()=>void, j: number]
+```
+
+:::

--- a/packages/eslint-plugin-plus/rules/type-named-tuple-spacing/type-named-tuple-spacing.test.ts
+++ b/packages/eslint-plugin-plus/rules/type-named-tuple-spacing/type-named-tuple-spacing.test.ts
@@ -1,0 +1,100 @@
+import { RuleTester } from '@typescript-eslint/rule-tester'
+import rule from './type-named-tuple-spacing'
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+})
+
+ruleTester.run('type-named-tuple-spacing', rule, {
+  valid: [
+    'type T = [i: number]',
+    'type T = [i?: number]',
+    'type T = [i: number, j: number]',
+    'type T = [i: number, j: () => string]',
+    `const emit = defineEmits<{
+      change: [id: number]
+      update: [value: string]
+    }>()`,
+  ],
+  invalid: [
+    {
+      code: 'type T = [i:number]',
+      output: 'type T = [i: number]',
+      errors: [{ messageId: 'expectedSpaceAfter' }],
+    },
+    {
+      code: 'type T = [i:  number]',
+      output: 'type T = [i: number]',
+      errors: [{ messageId: 'expectedSpaceAfter' }],
+    },
+    {
+      code: 'type T = [i?:number]',
+      output: 'type T = [i?: number]',
+      errors: [{ messageId: 'expectedSpaceAfter' }],
+    },
+    {
+      code: 'type T = [i?   :number]',
+      output: 'type T = [i?: number]',
+      errors: [{ messageId: 'unexpectedSpaceBetween' }, { messageId: 'expectedSpaceAfter' }],
+    },
+    {
+      code: 'type T = [i : number]',
+      output: 'type T = [i: number]',
+      errors: [{ messageId: 'unexpectedSpaceBefore' }],
+    },
+    {
+      code: 'type T = [i  : number]',
+      output: 'type T = [i: number]',
+      errors: [{ messageId: 'unexpectedSpaceBefore' }],
+    },
+    {
+      code: 'type T = [i  ?  : number]',
+      output: 'type T = [i?: number]',
+      errors: [{ messageId: 'unexpectedSpaceBetween' }, { messageId: 'unexpectedSpaceBefore' }],
+    },
+    {
+      code: 'type T = [i:number, j:number]',
+      output: 'type T = [i: number, j: number]',
+      errors: [{ messageId: 'expectedSpaceAfter' }, { messageId: 'expectedSpaceAfter' }],
+    },
+    {
+      code: 'type T = [i:()=>void, j:number]',
+      output: 'type T = [i: ()=>void, j: number]',
+      errors: [{ messageId: 'expectedSpaceAfter' }, { messageId: 'expectedSpaceAfter' }],
+    },
+    {
+      code: `
+        const emit = defineEmits<{
+          change: [id:number]
+          update: [value:string]
+        }>()
+        `,
+      output: `
+        const emit = defineEmits<{
+          change: [id: number]
+          update: [value: string]
+        }>()
+        `,
+      errors: [{ messageId: 'expectedSpaceAfter' }, { messageId: 'expectedSpaceAfter' }],
+    },
+    {
+      code: `
+        const emit = defineEmits<{
+          change: [id? :number]
+          update: [value:string]
+        }>()
+        `,
+      output: `
+        const emit = defineEmits<{
+          change: [id?: number]
+          update: [value: string]
+        }>()
+        `,
+      errors: [
+        { messageId: 'unexpectedSpaceBetween' },
+        { messageId: 'expectedSpaceAfter' },
+        { messageId: 'expectedSpaceAfter' },
+      ],
+    },
+  ],
+})

--- a/packages/eslint-plugin-plus/rules/type-named-tuple-spacing/type-named-tuple-spacing.ts
+++ b/packages/eslint-plugin-plus/rules/type-named-tuple-spacing/type-named-tuple-spacing.ts
@@ -1,0 +1,80 @@
+import { createRule } from '../../utils/createRule'
+import type { MessageIds, RuleOptions } from './types'
+
+const tupleRe = /^([\w_$]+)(\s*)(\?\s*)?:(\s*)(.*)$/
+
+export default createRule<RuleOptions, MessageIds>({
+  name: 'type-named-tuple-spacing',
+  meta: {
+    type: 'layout',
+    docs: {
+      description: 'Expect space before the type declaration in the named tuple',
+      recommended: 'stylistic',
+    },
+    fixable: 'whitespace',
+    schema: [],
+    messages: {
+      expectedSpaceAfter: 'Expected a space after the \':\'.',
+      unexpectedSpaceBetween: 'Unexpected space between \'?\' and the \':\'.',
+      unexpectedSpaceBefore: 'Unexpected space before the \':\'.',
+    },
+  },
+  defaultOptions: [],
+  create: (context) => {
+    const sourceCode = context.getSourceCode()
+    return {
+      TSNamedTupleMember: (node: any) => {
+        const code = sourceCode.text.slice(node.range[0], node.range[1])
+
+        const match = code.match(tupleRe)
+        if (!match)
+          return
+
+        const labelName = node.label.name
+        const spaceBeforeColon = match[2]
+        const optionalMark = match[3]
+        const spacesAfterColon = match[4]
+        const elementType = match[5]
+
+        function getReplaceValue() {
+          let ret = labelName
+          if (node.optional)
+            ret += '?'
+          ret += ': '
+          ret += elementType
+          return ret
+        }
+
+        if (optionalMark?.length > 1) {
+          context.report({
+            node,
+            messageId: 'unexpectedSpaceBetween',
+            *fix(fixer) {
+              yield fixer.replaceTextRange(node.range, code.replace(tupleRe, getReplaceValue()))
+            },
+          })
+        }
+
+        if (spaceBeforeColon?.length) {
+          context.report({
+            node,
+            messageId: 'unexpectedSpaceBefore',
+            *fix(fixer) {
+              yield fixer.replaceTextRange(node.range, code.replace(tupleRe, getReplaceValue()))
+            },
+          })
+        }
+
+        if (spacesAfterColon != null && spacesAfterColon.length !== 1) {
+          context.report({
+            node,
+            messageId: 'expectedSpaceAfter',
+            *fix(fixer) {
+              yield fixer.replaceTextRange(node.range, code.replace(tupleRe, getReplaceValue()))
+            },
+          })
+        }
+      },
+    }
+  },
+})

--- a/packages/eslint-plugin-plus/rules/type-named-tuple-spacing/types.d.ts
+++ b/packages/eslint-plugin-plus/rules/type-named-tuple-spacing/types.d.ts
@@ -1,0 +1,4 @@
+/* GENERATED, DO NOT EDIT DIRECTLY */
+
+export type RuleOptions = []
+export type MessageIds = 'expectedSpaceAfter' | 'unexpectedSpaceBetween' | 'unexpectedSpaceBefore'

--- a/packages/metadata/src/metadata.ts
+++ b/packages/metadata/src/metadata.ts
@@ -1143,7 +1143,21 @@ export const packages: Readonly<PackageInfo[]> = Object.freeze([
     "shortId": "plus",
     "pkgId": "@stylistic/plus",
     "path": "packages/eslint-plugin-plus",
-    "rules": []
+    "rules": [
+      {
+        "name": "type-named-tuple-spacing",
+        "ruleId": "@stylistic/plus/type-named-tuple-spacing",
+        "originalId": "",
+        "entry": "packages/eslint-plugin-plus/rules/type-named-tuple-spacing/type-named-tuple-spacing.ts",
+        "docsEntry": "packages/eslint-plugin-plus/rules/type-named-tuple-spacing/README.md",
+        "meta": {
+          "fixable": "whitespace",
+          "docs": {
+            "description": "Expect space before the type declaration in the named tuple"
+          }
+        }
+      }
+    ]
   },
   {
     "name": "@stylistic/eslint-plugin-ts",


### PR DESCRIPTION
This PR introduces a new rule `type-named-tuple-spacing`, ported from https://github.com/antfu/eslint-plugin-antfu/blob/main/src/rules/named-tuple-spacing.ts

Related issue in `ts-eslint`:
- https://github.com/typescript-eslint/typescript-eslint/issues/51