### PR TITLE
fix(ts/padding-line-between-statements): add new `function-overload` statement type

### DIFF
--- a/packages/eslint-plugin-ts/rules/padding-line-between-statements/README.md
+++ b/packages/eslint-plugin-ts/rules/padding-line-between-statements/README.md
@@ -3,19 +3,22 @@ description: 'Require or disallow padding lines between statements.'
 ---
 
 This rule extends the base [`padding-line-between-statements`](/rules/js/padding-line-between-statements) rule.
+
 It adds support for TypeScript constructs such as `interface` and `type`.
 
 ## Options
 
-In addition to options provided by ESLint, `interface` and `type` can be used as statement types.
+In addition to options provided by ESLint, the following options can be used as statement types:
+
+- `interface`
+- `type`
+- `function-overload`
 
 For example, to add blank lines before interfaces and type definitions:
 
 ```jsonc
 {
-  // Example - Add blank lines before interface and type definitions.
-  "padding-line-between-statements": "off",
-  "@typescript-eslint/padding-line-between-statements": [
+  "@stylistic/padding-line-between-statements": [
     "error",
     {
       "blankLine": "always",
@@ -26,4 +29,17 @@ For example, to add blank lines before interfaces and type definitions:
 }
 ```
 
-**Note:** ESLint `cjs-export` and `cjs-import` statement types are renamed to `exports` and `require` respectively.
+To avoid blank lines between function overloads and the function body:
+
+```jsonc
+{
+  "@stylistic/padding-line-between-statements": [
+    "error",
+    {
+      "blankLine": "never",
+      "prev": "function-overload",
+      "next": "function"
+    }
+  ]
+}
+```

--- a/packages/eslint-plugin-ts/rules/padding-line-between-statements/padding-line-between-statements.test.ts
+++ b/packages/eslint-plugin-ts/rules/padding-line-between-statements/padding-line-between-statements.test.ts
@@ -2808,6 +2808,33 @@ var a = 1
         { blankLine: 'never', prev: '*', next: 'function' },
       ],
     },
+
+    // ----------------------------------------------------------------------
+    // ESLint Stylistic
+    // ----------------------------------------------------------------------
+
+    // Function overloads https://github.com/eslint-stylistic/eslint-stylistic/issues/190
+    {
+      code: [
+        'function foo(): void;',
+        'function foo(param0?: true): boolean;',
+        'function foo(param0?: boolean): boolean {',
+        '  return param0;',
+        '}',
+      ].join('\n'),
+      options: [
+        {
+          blankLine: 'always',
+          prev: ['*'],
+          next: ['multiline-block-like'],
+        },
+        {
+          blankLine: 'never',
+          prev: ['function-overload'],
+          next: ['multiline-block-like'],
+        },
+      ],
+    },
   ],
   invalid: [
     // ----------------------------------------------------------------------

--- a/packages/eslint-plugin-ts/rules/padding-line-between-statements/padding-line-between-statements.ts
+++ b/packages/eslint-plugin-ts/rules/padding-line-between-statements/padding-line-between-statements.ts
@@ -590,7 +590,13 @@ const StatementTypes: Record<string, NodeTestObject> = {
     AST_NODE_TYPES.TSInterfaceDeclaration,
     'interface',
   ),
-  'type': newKeywordTester(AST_NODE_TYPES.TSTypeAliasDeclaration, 'type'),
+  'type': newKeywordTester(
+    AST_NODE_TYPES.TSTypeAliasDeclaration,
+    'type',
+  ),
+  'function-overload': {
+    test: node => node.type === 'TSDeclareFunction',
+  },
 }
 
 export default createRule<Options, MessageIds>({

--- a/packages/eslint-plugin-ts/rules/padding-line-between-statements/types.d.ts
+++ b/packages/eslint-plugin-ts/rules/padding-line-between-statements/types.d.ts
@@ -45,6 +45,7 @@ export type StatementType =
     | 'cjs-import'
     | 'interface'
     | 'type'
+    | 'function-overload'
     )
     | [
       (
@@ -90,6 +91,7 @@ export type StatementType =
         | 'cjs-import'
         | 'interface'
         | 'type'
+        | 'function-overload'
       ),
       ...(
         | '*'
@@ -134,6 +136,7 @@ export type StatementType =
         | 'cjs-import'
         | 'interface'
         | 'type'
+        | 'function-overload'
       )[],
     ]
 export type Schema0 = {


### PR DESCRIPTION
close #190