### PR TITLE
fix(ts/no-extra-parens): cover more unnecessary parens case

### DIFF
--- a/packages/eslint-plugin-js/rules/no-extra-parens/no-extra-parens.ts
+++ b/packages/eslint-plugin-js/rules/no-extra-parens/no-extra-parens.ts
@@ -1258,6 +1258,8 @@ export default createRule<MessageIds, RuleOptions>({
         if (right && hasExcessParensWithPrecedence(right, PRECEDENCE_OF_ASSIGNMENT_EXPR))
           report(right)
       },
+
+      // This listener is exposed for TypeScript rule to consume
       TSStringKeyword(node) {
         if (hasExcessParens(node))
           report(node)

--- a/packages/eslint-plugin-js/rules/no-extra-parens/no-extra-parens.ts
+++ b/packages/eslint-plugin-js/rules/no-extra-parens/no-extra-parens.ts
@@ -1258,6 +1258,10 @@ export default createRule<MessageIds, RuleOptions>({
         if (right && hasExcessParensWithPrecedence(right, PRECEDENCE_OF_ASSIGNMENT_EXPR))
           report(right)
       },
+      TSStringKeyword(node) {
+        if (hasExcessParens(node))
+          report(node)
+      },
     }
   },
 })

--- a/packages/eslint-plugin-ts/rules/no-extra-parens/no-extra-parens.test.ts
+++ b/packages/eslint-plugin-ts/rules/no-extra-parens/no-extra-parens.test.ts
@@ -825,5 +825,14 @@ var y = function () {return 1;};
         },
       ],
     },
+    {
+      code: 'const x: (string) = ""',
+      output: 'const x: string = ""',
+      errors: [
+        {
+          messageId: 'unexpected',
+        },
+      ],
+    },
   ],
 })

--- a/packages/eslint-plugin-ts/rules/no-extra-parens/no-extra-parens.test.ts
+++ b/packages/eslint-plugin-ts/rules/no-extra-parens/no-extra-parens.test.ts
@@ -797,5 +797,33 @@ var y = function () {return 1;};
         },
       ],
     },
+    {
+      code: 'const x = (a as string)',
+      output: 'const x = a as string',
+      errors: [
+        {
+          messageId: 'unexpected',
+        },
+      ],
+      options: ['all'],
+    },
+    {
+      code: 'const x = a[(b as string)]',
+      output: 'const x = a[b as string]',
+      errors: [
+        {
+          messageId: 'unexpected',
+        },
+      ],
+    },
+    {
+      code: 'const x = [(b as string)]',
+      output: 'const x = [b as string]',
+      errors: [
+        {
+          messageId: 'unexpected',
+        },
+      ],
+    },
   ],
 })

--- a/vitest.config.unit.ts
+++ b/vitest.config.unit.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config'
+import viteConfig from './vite.config.js'
 
 export default defineConfig({
+  ...viteConfig,
   test: {
     root: './packages',
     globals: true,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fix the uncovered case mentioned in #185.

I added `TSStringKeyword` to `plugin-js` for sharing logic with `plugin-ts`. But it doesn't actually affect the js file.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

close https://github.com/eslint-stylistic/eslint-stylistic/issues/185

### Additional context

I did not fix `const x = (a) as string`.

Since `const x = (a)` is not handled in `plugin-js`, I'm not quite sure if there's any concern with that. Please let me know if you know anything about this, or if you're sure it's just a forgotten override.

---

Are there any other cases that have been found but not fixed by this PR?

<!-- e.g. is there anything you'd like reviewers to focus on? -->
