### PR TITLE
feat(configs): add new options to customize config to assist with migrating from Prettier

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -20,6 +20,7 @@ const GUIDES: DefaultTheme.NavItemWithLink[] = [
   { text: 'Why', link: '/guide/why' },
   { text: 'Shared Configs', link: '/guide/config-presets' },
   { text: 'Migration', link: '/guide/migration' },
+  { text: 'Migration from Prettier', link: '/guide/migration-from-prettier' },
   { text: 'FAQ', link: '/guide/faq' },
 ]
 

--- a/docs/guide/migration-from-prettier.md
+++ b/docs/guide/migration-from-prettier.md
@@ -1,0 +1,165 @@
+# Migrating from Prettier
+
+Migrating from using Prettier for code formatting to using this project is extremely straightforward, and this page will walk you through the process of getting set up. For more information as to why you might use this package in place of Prettier, refer to [Why](/guide/why).
+
+The first step is to follow the [Getting Started](/guide/getting-started) guide. This will walk you through the process of getting setup to use this package, as well as adding it to your config.
+
+## Options
+
+### Supported Options
+
+The following Prettier options are supported:
+
+- `arrowParens`
+  - default: `false`
+  - supported values:
+    - `true`: always use parenthesis around arrow functions
+    - `false`: avoid parenthesis around arrow functions
+- `bracketSpacing` (use option `blockSpacing`)
+  - default: `true`
+  - supported values:
+    - `true`: always use spaces
+    - `false`: never use spaces
+- `endOfLine` (see [printWidth and endOfLine](#printwidth-and-endofline))
+- `printWidth` (see [printWidth and endOfLine](#printwidth-and-endofline))
+- `quoteProps`
+  - default: `'consistent-as-needed'`
+  - supported values:
+    - `'always'`: always quote object properties, whether required or not
+    - `'as-needed'`: only quote object properties that require quotes
+    - `'consistent-as-needed'`: only quote object properties that require quotes, but if any property in the object requires quotes, all properties require quotes
+    - `'consistent'`: if one property is quoted, whether required or not, all properties must be quoted
+- `quotes`
+  - default: `'single'`
+  - supported values: `'single'` `'double'`
+- `semi`
+  - default `false`
+  - supported values:
+    - `true`: require semicolons
+    - `false`: don't require semicolons
+- `tabWidth` and `useTabs` (use option `indent`)
+  - default `2`
+  - supported values:
+    - `<number>`: the number of spaces to use for tabs, cannot be combined with hard tabs
+    - `'tab'`: use hard tabs instead of spaces, cannot be combined with a number of spaces
+- `trailingCommas` (use option `commaDangle`)
+  - default: `'always-multiline'`
+  - supported values:
+    - `'never'`: never allow or require trailing commas
+    - `'always'`: always require trailing commas
+    - `'always-multiline'`: always require trailing commas for multiline statements (i.e. object definitions)
+    - `'only-multiline'`: only allow trailing commas for multiline statements
+
+### Unsupported Options
+
+The following Prettier options are not supported (at this time):
+
+- `bracketSameLine`
+- `htmlWhitespaceSensitivity`
+- `jsxSingleQuote`
+- `singleAttributePerLine`
+
+The following Prettier options are not supported because they relate to Prettier's parser system:
+
+- `embeddedLanguageFormatting`
+- `insertPragma`
+- `overrides`
+- `parser`
+- `plugins`
+- `range`
+- `requirePragma`
+
+## Configuration
+
+Using the default options listed above will produce a config roughly equivalent to the following Prettier config
+
+```json
+{
+  "arrowParens": "avoid",
+  "bracketSpacing": true,
+  "quoteProps": "consistent",
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingCommas": "es5",
+  "useTabs": false
+}
+```
+
+### printWidth and endOfLine
+
+To setup `printWidth` and `endOfLine`, you need to configure them manually because they are not included in the configuration factory. Thankfully, this is pretty simple.
+
+For `printWidth` the eslint-stylistic rule [`max-len`](/rules/js/max-len) is used, and for `endOfLine` the appropriate rule is [`linebreak-style`](/rules/js/linebreak-style). Below is an example of how you can configure these rules
+
+::: code-group
+
+```js [Flat Config]
+// eslint.config.js
+import stylistic from '@stylistic/eslint-plugin'
+
+// using the default values
+const stylisticConfig = stylistic.configs.customize()
+
+// assuming unix line endings
+stylisticConfig.rules['@stylistic/linebreak-style'] = ['error', 'unix']
+
+// assuming a max length of 80 characters
+stylisticConfig.rules['@stylistic/max-len'] = ['error', { code: 80 }]
+
+export default [stylisticConfig]
+```
+
+```js [Legacy Config]
+const stylistic = require('@stylistic/eslint-plugin')
+
+// using the default values
+const customized = stylistic.configs.customize()
+
+module.exports = {
+  plugins: ['@stylistic'],
+  rules: {
+    ...customized.rules,
+
+    // assuming unix line endings
+    '@stylistic/linebreak-style': ['error', 'unix']
+
+    // assuming max length of 80 characters
+    '@stylistic/max-len': ['error', { code: 80 }]
+  }
+}
+```
+
+:::
+
+The above configs would both be roughly equivalent to the following Prettier configuration:
+
+```json
+{
+  "arrowParens": "avoid",
+  "bracketSpacing": true,
+  "endOfLine": "lf",
+  "printWidth": 80,
+  "quoteProps": "consistent",
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingCommas": "es5",
+  "useTabs": false
+}
+```
+
+### Further steps
+
+Once you have configured this package to handle the formatting of your source code, it may be necessary to tell Prettier to ignore your source files (assuming you still need Prettier for other things, such as markdown or JSON). This can be accomplished in a few ways.
+
+First, you could configure Prettier to require pragmas, and simply not put pragmas into your source code. Alternatively, you can use a `.prettierignore` file to ignore your source code. Assuming you have a React project using TypeScript, your `.prettierignore` file may contain the following:
+
+```txt
+**/*.js
+**/*.jsx
+**/*.ts
+**/*.tsx
+```
+
+Ultimately, what is listed above is merely a suggestion; and you can tackle the problem however you see fit, including just not using Prettier at all.

--- a/packages/eslint-plugin/configs/customize.ts
+++ b/packages/eslint-plugin/configs/customize.ts
@@ -35,6 +35,31 @@ export interface StylisticCustomizeOptions<Flat extends boolean = true> {
    * @default true
    */
   jsx?: boolean
+  /**
+   * When to enable arrow parenthesis
+   * @default false
+   */
+  arrowParens?: boolean
+  /**
+   * Which brace style to use
+   * @default 'stroustrup'
+   */
+  braceStyle?: '1tbs' | 'stroustrup' | 'allman'
+  /**
+   * Whether to require spaces around braces
+   * @default true
+   */
+  blockSpacing?: boolean
+  /**
+   * When to enable prop quoting
+   * @default 'consistent-as-needed'
+   */
+  quoteProps?: 'always' | 'as-needed' | 'consistent' | 'consistent-as-needed'
+  /**
+   * When to enable comma dangles
+   * @default 'always-multiline'
+   */
+  commaDangle?: 'never' | 'always' | 'always-multiline' | 'only-multiline'
 }
 
 type Rules = Partial<{
@@ -48,21 +73,26 @@ export function customize(options: StylisticCustomizeOptions<false>): Linter.Bas
 export function customize(options?: StylisticCustomizeOptions<true>): Linter.FlatConfig
 export function customize(options: StylisticCustomizeOptions<boolean> = {}): Linter.FlatConfig | Linter.BaseConfig {
   const {
+    arrowParens = false,
+    blockSpacing = true,
+    braceStyle = 'stroustrup',
+    commaDangle = 'always-multiline',
     flat = true,
     indent = 2,
     jsx = true,
     pluginName = '@stylistic',
+    quoteProps = 'consistent-as-needed',
     quotes = 'single',
     semi = false,
   } = options
 
   let rules: Rules = {
     '@stylistic/array-bracket-spacing': ['error', 'never'],
-    '@stylistic/arrow-parens': ['error', 'as-needed', { requireForBlockBody: true }],
+    '@stylistic/arrow-parens': ['error', arrowParens ? 'always' : 'as-needed', { requireForBlockBody: true }],
     '@stylistic/arrow-spacing': ['error', { after: true, before: true }],
-    '@stylistic/block-spacing': ['error', 'always'],
-    '@stylistic/brace-style': ['error', 'stroustrup', { allowSingleLine: true }],
-    '@stylistic/comma-dangle': ['error', 'always-multiline'],
+    '@stylistic/block-spacing': ['error', blockSpacing ? 'always' : 'never'],
+    '@stylistic/brace-style': ['error', braceStyle, { allowSingleLine: true }],
+    '@stylistic/comma-dangle': ['error', commaDangle],
     '@stylistic/comma-spacing': ['error', { after: true, before: false }],
     '@stylistic/comma-style': ['error', 'last'],
     '@stylistic/computed-property-spacing': ['error', 'never', { enforceForClassMembers: true }],
@@ -150,7 +180,7 @@ export function customize(options: StylisticCustomizeOptions<boolean> = {}): Lin
     '@stylistic/object-curly-spacing': ['error', 'always'],
     '@stylistic/operator-linebreak': ['error', 'before'],
     '@stylistic/padded-blocks': ['error', { blocks: 'never', classes: 'never', switches: 'never' }],
-    '@stylistic/quote-props': ['error', 'consistent-as-needed'],
+    '@stylistic/quote-props': ['error', quoteProps],
     '@stylistic/quotes': ['error', quotes, { allowTemplateLiterals: true, avoidEscape: false }],
     '@stylistic/rest-spread-spacing': ['error', 'never'],
     '@stylistic/semi': ['error', semi ? 'always' : 'never'],


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR adds support for more Prettier options to the customize config to allow users to transition from using Prettier to using eslint-stylistic. In total, 4 new options where added to the customize config.

This PR also adds documentation for users coming from Prettier on using stylistic-eslint as a substitute for Prettier.

### Options already present

- `indent` (this covers Prettier's `tabWidth` and `useTabs`)
- `quotes`
- `semi`

### Options added

- `arrowParens`
- `blockSpacing` (roughly equivalent to Prettier's `bracketSpacing`)
- `quoteProps`
- `commaDangle` (equivalent to Prettier's `trailingCommas`)

### Options not added

#### Because JSX

I am not really a JSX developer (I'm more of a svelte guy), so I didn't mess with anything relating to JSX. This includes the options listed below:

- `jsxSingleQuote`
- `bracketSameLine`
- `htmlWhitespaceSensitivity`
- `singleAttributePerLine`

#### Because parsing

The following options weren't added either because they serve no purpose under ESLint; they simply defeat the purpose of linting to begin with; or ESLint already has an equivalent built-in

- `range`
- `parser`
- `requirePragma`
- `insertPragma`
- `embeddedLanguageFormatting`

#### Because covered by another rule not in config

- `endOfLine` (covered by `linebreak-style`)
- `printWidth` (covered by `max-len`)
- `proseWrap` (also covered by `max-len`)

### Linked Issues

#218 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I apologize if my documentation if overly verbose, I am just a fan of clear, highly explanatory documentation. Also, I did my best to match the tone of the rest of the documentation site to hopefully make it less obvious that someone else wrote it.

The big issue at the moment, as referenced during the discussion in #218, is adding 4 options too many? Also, it should be noted that there are 4 more options still not covered (as of right now). Ultimately, I leave that issue in the hands of the maintainers at this point. Also, feel free to squash and commit when the time comes, I just followed conventional commits and updated the title to reflect the conventional commit standard as well.
