### PR TITLE
Update indent-binary-ops.test.ts

### DIFF
--- a/packages/eslint-plugin-plus/rules/indent-binary-ops/indent-binary-ops.test.ts
+++ b/packages/eslint-plugin-plus/rules/indent-binary-ops/indent-binary-ops.test.ts
@@ -24,6 +24,18 @@ ruleTester.run('indent-binary-ops', rule, {
         | A
         | B
     `,
+    {
+      code: unIndent`
+    it('should not suggest signup when disabled', (): void => {
+      const mockError = new FirebaseError(
+        'auth/user-not-found',
+        'User not found. The account may have been deleted. Please try other addresses or authentication methods that you may have used to'
+                + ' create your account.',
+      );
+    });
+    `,
+      options: [8],
+    },
   ],
   invalid: [],
 })
@@ -124,13 +136,13 @@ it('snapshots', async () => {
 
   expect(
     fix(unIndent`
-    type Foo = 
+    type Foo =
     | A | C
       | B
     `),
   ).toMatchInlineSnapshot(
     `
-    "type Foo = 
+    "type Foo =
       | A | C
       | B"
   `,
@@ -156,15 +168,15 @@ it('snapshots', async () => {
 
   expect(
     fix(unIndent`
-    type T = 
-    a 
-    | b 
+    type T =
+    a
+    | b
       | c`),
   ).toMatchInlineSnapshot(
     `
-    "type T = 
-      a 
-      | b 
+    "type T =
+      a
+      | b
       | c"
   `,
   )
@@ -198,7 +210,7 @@ it('snapshots', async () => {
   expect(
     fix(unIndent`
     type Foo = Merge<
-        A 
+        A
       & B
         & C
     >
@@ -206,7 +218,7 @@ it('snapshots', async () => {
   ).toMatchInlineSnapshot(
     `
     "type Foo = Merge<
-      A 
+      A
       & B
       & C
     >"


### PR DESCRIPTION
Not sure if I've done this correctly. I told it to indent 8 spaces, but it says it wants 4. I tried `options: [` 1 through 8`]` before I gave up. It always said "Expected indentation of 4 spaces"

```
 FAIL  eslint-plugin-plus/rules/indent-binary-ops/indent-binary-ops.test.ts > indent-binary-ops > valid > it('should not suggest signup when disabled', (): void => {
  const mockError = new FirebaseError(
    'auth/user-not-found',
    'User not found. The account may have been deleted. Please try other addresses or authentication methods that you may have used to'
            + ' create your account.',
  );
});
AssertionError: Should have no errors but had 1: [
  {
    ruleId: 'indent-binary-ops',
    severity: 2,
    message: 'Expected indentation of 4 spaces',
    line: 5,
    column: 1,
    nodeType: null,
    messageId: 'wrongIndentation',
    endLine: 5,
    endColumn: 13,
    fix: { range: [Array], text: '    ' }
  }
]

- Expected
+ Received

- 0
+ 1
```
Related #226

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
