### PR TITLE
fix: add handler of PropertyDefinition for indent rule

### DIFF
--- a/packages/eslint-plugin-ts/rules/indent/indent.test.ts
+++ b/packages/eslint-plugin-ts/rules/indent/indent.test.ts
@@ -1729,6 +1729,7 @@ age: number = 0;
     @property
         id: string;
 
+
     @property
     isActive: boolean;
     @property bar: boolean;
@@ -1744,6 +1745,7 @@ class Foo {
 
     @property
     id: string;
+
 
     @property
     isActive: boolean;
@@ -1777,7 +1779,7 @@ class Foo {
             expected: '4 spaces',
             actual: 0,
           },
-          line: 13,
+          line: 14,
           column: 1,
         },
       ],

--- a/packages/eslint-plugin-ts/rules/indent/indent.test.ts
+++ b/packages/eslint-plugin-ts/rules/indent/indent.test.ts
@@ -1720,33 +1720,20 @@ declare module "Validation" {
 
     // https://github.com/eslint-stylistic/eslint-stylistic/issues/208
     {
-
-      code: `
-    @Decorator()
-class Foo {}
-      `,
-      output: `
-@Decorator()
-class Foo {}
-      `,
-      errors: [
-        {
-          messageId: 'wrongIndentation',
-          data: {
-            expected: '0 spaces',
-            actual: 4,
-          },
-          line: 2,
-          column: 1,
-        },
-      ],
-    },
-    {
       code: `
 class Foo {
 
     @property
 age: number = 0;
+
+    @property
+        id: string;
+
+    @property
+    isActive: boolean;
+    @property bar: boolean;
+@property baz;
+
 }
       `,
       output: `
@@ -1754,6 +1741,15 @@ class Foo {
 
     @property
     age: number = 0;
+
+    @property
+    id: string;
+
+    @property
+    isActive: boolean;
+    @property bar: boolean;
+    @property baz;
+
 }
       `,
       errors: [
@@ -1764,6 +1760,71 @@ class Foo {
             actual: 0,
           },
           line: 5,
+          column: 1,
+        },
+        {
+          messageId: 'wrongIndentation',
+          data: {
+            expected: '4 spaces',
+            actual: 8,
+          },
+          line: 8,
+          column: 1,
+        },
+        {
+          messageId: 'wrongIndentation',
+          data: {
+            expected: '4 spaces',
+            actual: 0,
+          },
+          line: 13,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+    @a
+@b
+        @c
+        props: any;
+}
+      `,
+      output: `
+class Foo {
+    @a
+    @b
+    @c
+    props: any;
+}
+      `,
+      errors: [
+        {
+          messageId: 'wrongIndentation',
+          data: {
+            expected: '4 spaces',
+            actual: 0,
+          },
+          line: 4,
+          column: 1,
+        },
+        {
+          messageId: 'wrongIndentation',
+          data: {
+            expected: '4 spaces',
+            actual: 8,
+          },
+          line: 5,
+          column: 1,
+        },
+        {
+          messageId: 'wrongIndentation',
+          data: {
+            expected: '4 spaces',
+            actual: 8,
+          },
+          line: 6,
           column: 1,
         },
       ],

--- a/packages/eslint-plugin-ts/rules/indent/indent.test.ts
+++ b/packages/eslint-plugin-ts/rules/indent/indent.test.ts
@@ -750,6 +750,23 @@ const div: JQuery<HTMLElement> = $('<div>')
     {
       code: 'const foo = function<> (): void {}',
     },
+
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/229
+    {
+      code: `
+import { Entity, Column, PrimaryGeneratedColumn } from 'foo';
+
+@Entity()
+export class UserEntity {
+  @PrimaryGeneratedColumn()
+  id: string;
+      
+  @Column()
+  username: string;
+}
+      `,
+      options: [2],
+    },
   ],
   invalid: [
     ...individualNodeTests.invalid,
@@ -1700,6 +1717,8 @@ declare module "Validation" {
         },
       ],
     },
+
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/208
     {
 
       code: `
@@ -1718,6 +1737,33 @@ class Foo {}
             actual: 4,
           },
           line: 2,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+
+    @property
+age: number = 0;
+}
+      `,
+      output: `
+class Foo {
+
+    @property
+    age: number = 0;
+}
+      `,
+      errors: [
+        {
+          messageId: 'wrongIndentation',
+          data: {
+            expected: '4 spaces',
+            actual: 0,
+          },
+          line: 5,
           column: 1,
         },
       ],

--- a/packages/eslint-plugin-ts/rules/indent/indent.ts
+++ b/packages/eslint-plugin-ts/rules/indent/indent.ts
@@ -181,6 +181,8 @@ export default createRule<RuleOptions, MessageIds>({
           rules['*:exit'](node)
       },
 
+      'PropertyDefinition': () => {},
+
       VariableDeclaration(node: Tree.VariableDeclaration) {
         // https://github.com/typescript-eslint/typescript-eslint/issues/441
         if (node.declarations.length === 0)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This pull request solves problem with `indent` rule when dealing with property decorators by adding a handler for `PropertyDefinition`.

### Linked Issues

Closes #208 

### Additional context

Two new test cases are added, from #208 and #229
