### PR TITLE
fix typo in config-presets.md

### DIFF
--- a/docs/guide/config-presets.md
+++ b/docs/guide/config-presets.md
@@ -106,7 +106,7 @@ module.exports = {
 
 :::
 
-## Enable All Avaible Rules
+## Enable All Available Rules
 
 If you want to enable all rules with their default options (not recommended), we also provide a config for that:
 


### PR DESCRIPTION
### Description

There's a type on the page https://eslint.style/guide/config-presets. Fixed a typo  'Avaible' to 'Available'