### PR TITLE
feat(jsx-one-expression-per-line): add `spaceMode` option (#241)

### DIFF
--- a/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.test.ts
+++ b/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.test.ts
@@ -1558,5 +1558,31 @@ Go to page 2
       ],
       parserOptions,
     },
+    {
+      code: `
+        <div>
+          literal <div /> second literal
+        </div>
+      `,
+      options: [{ spaceMode: 'html' }],
+      output: `
+        <div>
+          literal&nbsp;
+<div />
+&nbsp;second literal
+        </div>
+      `,
+      errors: [
+        {
+          messageId: 'moveToNewLine',
+          data: { descriptor: 'div' },
+        },
+        {
+          messageId: 'moveToNewLine',
+          data: { descriptor: ' second literal        ' },
+        },
+      ],
+      parserOptions,
+    },
   ),
 })

--- a/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.ts
+++ b/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.ts
@@ -11,6 +11,7 @@ import type { MessageIds, RuleOptions } from './types'
 
 const optionDefaults = {
   allow: 'none',
+  spaceMode: 'js',
 }
 
 const messages = {
@@ -39,6 +40,10 @@ export default createRule<MessageIds, RuleOptions>({
           allow: {
             type: 'string',
             enum: ['none', 'literal', 'single-child'],
+          },
+          spaceMode: {
+            type: 'string',
+            enum: ['js', 'html'],
           },
         },
         default: optionDefaults,
@@ -212,8 +217,16 @@ export default createRule<MessageIds, RuleOptions>({
         const descriptor = details.descriptor
         const source = details.source.replace(/(^ +| +(?=\n)*$)/g, '')
 
-        const leadingSpaceString = details.leadingSpace ? '\n{\' \'}' : ''
-        const trailingSpaceString = details.trailingSpace ? '{\' \'}\n' : ''
+        const leadingSpaceString = details.leadingSpace
+          ? options.spaceMode === 'js'
+            ? '\n{\' \'}'
+            : '&nbsp;'
+          : ''
+        const trailingSpaceString = details.trailingSpace
+          ? options.spaceMode === 'js'
+            ? '{\' \'}\n'
+            : '\n&nbsp;'
+          : ''
         const leadingNewLineString = details.leadingNewLine ? '\n' : ''
         const trailingNewLineString = details.trailingNewLine ? '\n' : ''
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Adds the `spaceMode` option to `jsx-one-expression-per-line` which uses the HTML `&nbsp;` entity instead of JSX `{' '}`

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
#241

### Additional context
> [!important]
> This PR is not ready and requires assistance

There are a few issues:
- I wasn't able to generate the `types.d.ts` file (I couldn't figure out how)
- The test is only replacing the text for the first offending source and not the second offending source. I'm not sure why
- There's an issue with how this rule parses sources. If you look at the test I added, the first literal has a space preceding the embedded div. When this rule runs, it treats the preceding space as part of the first literal (which doesn't get targeted because it's not a violation) and thus ignores it. For proper fixing, the rule would have to _replace_ that space with `&nbsp;` and then add a newline, however, there's no way for me to do that and simply adding `&nbsp;` and then a newline creates two spaces. I'm not sure how to resolve this issue
  - In fact, this is an issue with the rule itself even without these changes as the fix keeps that space and then adds a newline with `{' '}` as well. (Which, again, is two spaces)

<!-- e.g. is there anything you'd like reviewers to focus on? -->
