### PR TITLE
fix(ts/indent): indentation of multiline type parameter instantiations

### DIFF
--- a/packages/eslint-plugin-ts/rules/indent/indent.test.ts
+++ b/packages/eslint-plugin-ts/rules/indent/indent.test.ts
@@ -1125,6 +1125,7 @@ const foo : Foo<{
         },
       ],
     },
+    // https://github.com/eslint-stylistic/eslint-stylistic/pull/256
     {
       code: `
 type FooAlias = Foo<

--- a/packages/eslint-plugin-ts/rules/indent/indent.test.ts
+++ b/packages/eslint-plugin-ts/rules/indent/indent.test.ts
@@ -1127,6 +1127,40 @@ const foo : Foo<{
     },
     {
       code: `
+type FooAlias = Foo<
+Bar,
+Baz
+>
+      `,
+      output: `
+type FooAlias = Foo<
+    Bar,
+    Baz
+>
+      `,
+      errors: [
+        {
+          messageId: 'wrongIndentation',
+          data: {
+            expected: '4 spaces',
+            actual: 0,
+          },
+          line: 3,
+          column: 1,
+        },
+        {
+          messageId: 'wrongIndentation',
+          data: {
+            expected: '4 spaces',
+            actual: 0,
+          },
+          line: 4,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: `
 type T = {
 bar : string,
 age : number,

--- a/packages/eslint-plugin-ts/rules/indent/indent.ts
+++ b/packages/eslint-plugin-ts/rules/indent/indent.ts
@@ -477,6 +477,29 @@ export default createRule<RuleOptions, MessageIds>({
           loc: node.loc,
         })
       },
+
+      TSTypeParameterInstantiation(node: Tree.TSTypeParameterInstantiation) {
+        if (!node.params.length)
+          return
+
+        const [name, ...attributes] = node.params
+
+        // JSX is about the closest we can get because the angle brackets
+        // it's not perfect but it works!
+        return rules.JSXOpeningElement({
+          type: AST_NODE_TYPES.JSXOpeningElement,
+          selfClosing: false,
+          name: name as any,
+          attributes: attributes as any,
+          typeArguments: undefined,
+          typeParameters: undefined,
+
+          // location data
+          parent: node.parent,
+          range: node.range,
+          loc: node.loc,
+        })
+      },
     })
   },
 })


### PR DESCRIPTION
The typescript indentation rule produces an error about this code:

```ts
type FooAlias = Foo<
    Bar,
    Baz
>;
```

complaining that the expected indentation of line 2 and 3 would be 0.

This PR fixes the issue, to handle type parameter instantiations exactly in the same way as type parameter declarations.