### PR TITLE
fix(padding-line-between-statements): recognize ExportAllDeclaration nodes

### DIFF
--- a/packages/eslint-plugin-js/rules/padding-line-between-statements/padding-line-between-statements.test.ts
+++ b/packages/eslint-plugin-js/rules/padding-line-between-statements/padding-line-between-statements.test.ts
@@ -730,14 +730,6 @@ ruleTester.run('padding-line-between-statements', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
     {
-      code: 'var a = 0; export * from "foo"\n\nbar()',
-      options: [
-        { blankLine: 'never', prev: '*', next: '*' },
-        { blankLine: 'always', prev: 'export', next: '*' },
-      ],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
       code: 'exports.foo=1\nfoo()',
       options: [
         { blankLine: 'never', prev: '*', next: '*' },
@@ -747,6 +739,15 @@ ruleTester.run('padding-line-between-statements', rule, {
     },
     {
       code: 'module.exports={}\nfoo()',
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'export', next: '*' },
+      ],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    // https://github.com/eslint-stylistic/eslint-stylistic/pull/257
+    {
+      code: 'var a = 0; export * from "foo"\n\nbar()',
       options: [
         { blankLine: 'never', prev: '*', next: '*' },
         { blankLine: 'always', prev: 'export', next: '*' },

--- a/packages/eslint-plugin-js/rules/padding-line-between-statements/padding-line-between-statements.test.ts
+++ b/packages/eslint-plugin-js/rules/padding-line-between-statements/padding-line-between-statements.test.ts
@@ -730,6 +730,14 @@ ruleTester.run('padding-line-between-statements', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
     {
+      code: 'var a = 0; export * from "foo"\n\nbar()',
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'export', next: '*' },
+      ],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
       code: 'exports.foo=1\nfoo()',
       options: [
         { blankLine: 'never', prev: '*', next: '*' },
@@ -3565,6 +3573,15 @@ ruleTester.run('padding-line-between-statements', rule, {
     {
       code: 'var a = 0;export {a}\nfoo()',
       output: 'var a = 0;export {a}\n\nfoo()',
+      options: [
+        { blankLine: 'always', prev: 'export', next: '*' },
+      ],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{ messageId: 'expectedBlankLine' }],
+    },
+    {
+      code: 'var a = 0;export * from "foo"\nbar()',
+      output: 'var a = 0;export * from "foo"\n\nbar()',
       options: [
         { blankLine: 'always', prev: 'export', next: '*' },
       ],

--- a/packages/eslint-plugin-js/rules/padding-line-between-statements/padding-line-between-statements.test.ts
+++ b/packages/eslint-plugin-js/rules/padding-line-between-statements/padding-line-between-statements.test.ts
@@ -3580,6 +3580,7 @@ ruleTester.run('padding-line-between-statements', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{ messageId: 'expectedBlankLine' }],
     },
+    // https://github.com/eslint-stylistic/eslint-stylistic/pull/257
     {
       code: 'var a = 0;export * from "foo"\nbar()',
       output: 'var a = 0;export * from "foo"\n\nbar()',

--- a/packages/eslint-plugin-ts/rules/padding-line-between-statements/padding-line-between-statements.test.ts
+++ b/packages/eslint-plugin-ts/rules/padding-line-between-statements/padding-line-between-statements.test.ts
@@ -3539,6 +3539,7 @@ var a = 1
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{ messageId: 'expectedBlankLine' }],
     },
+    // https://github.com/eslint-stylistic/eslint-stylistic/pull/257
     {
       code: 'var a = 0;export * from "foo"\nbar()',
       output: 'var a = 0;export * from "foo"\n\nbar()',

--- a/packages/eslint-plugin-ts/rules/padding-line-between-statements/padding-line-between-statements.test.ts
+++ b/packages/eslint-plugin-ts/rules/padding-line-between-statements/padding-line-between-statements.test.ts
@@ -748,6 +748,14 @@ ruleTester.run('padding-line-between-statements', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
     {
+      code: 'var a = 0; export * from "foo"\n\nbar()',
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'export', next: '*' },
+      ],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
       code: 'exports.foo=1\nfoo()',
       options: [
         { blankLine: 'never', prev: '*', next: '*' },
@@ -3526,6 +3534,13 @@ var a = 1
     {
       code: 'var a = 0;export {a}\nfoo()',
       output: 'var a = 0;export {a}\n\nfoo()',
+      options: [{ blankLine: 'always', prev: 'export', next: '*' }],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{ messageId: 'expectedBlankLine' }],
+    },
+    {
+      code: 'var a = 0;export * from "foo"\nbar()',
+      output: 'var a = 0;export * from "foo"\n\nbar()',
       options: [{ blankLine: 'always', prev: 'export', next: '*' }],
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{ messageId: 'expectedBlankLine' }],

--- a/packages/eslint-plugin-ts/rules/padding-line-between-statements/padding-line-between-statements.test.ts
+++ b/packages/eslint-plugin-ts/rules/padding-line-between-statements/padding-line-between-statements.test.ts
@@ -748,14 +748,6 @@ ruleTester.run('padding-line-between-statements', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
     {
-      code: 'var a = 0; export * from "foo"\n\nbar()',
-      options: [
-        { blankLine: 'never', prev: '*', next: '*' },
-        { blankLine: 'always', prev: 'export', next: '*' },
-      ],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
       code: 'exports.foo=1\nfoo()',
       options: [
         { blankLine: 'never', prev: '*', next: '*' },
@@ -765,6 +757,15 @@ ruleTester.run('padding-line-between-statements', rule, {
     },
     {
       code: 'module.exports={}\nfoo()',
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'export', next: '*' },
+      ],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    // https://github.com/eslint-stylistic/eslint-stylistic/pull/257
+    {
+      code: 'var a = 0; export * from "foo"\n\nbar()',
       options: [
         { blankLine: 'never', prev: '*', next: '*' },
         { blankLine: 'always', prev: 'export', next: '*' },

--- a/packages/eslint-plugin-ts/rules/padding-line-between-statements/padding-line-between-statements.ts
+++ b/packages/eslint-plugin-ts/rules/padding-line-between-statements/padding-line-between-statements.ts
@@ -547,6 +547,7 @@ const StatementTypes: Record<string, NodeTestObject> = {
   'do': newKeywordTester(AST_NODE_TYPES.DoWhileStatement, 'do'),
   'export': newKeywordTester(
     [
+      AST_NODE_TYPES.ExportAllDeclaration,
       AST_NODE_TYPES.ExportDefaultDeclaration,
       AST_NODE_TYPES.ExportNamedDeclaration,
     ],


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR adds [`ExportAllDeclaration`](https://github.com/estree/estree/blob/master/es2015.md#exportalldeclaration) to the list of `export` node types handled by the `padding-line-between-statements` rule. This change effectively aligns the `eslint-plugin-ts` implementation with the (already consistent) implementation of the rule in `eslint-plugin-js`.

An example of code affected by this change:

```js
/*
  eslint @stylistic/ts/padding-line-between-statements: [
  "error",
  { blankLine: 'never', prev: 'export', next: 'export' }]
*/

export * from "foo";

export * as bar from "bar";
```

This will start to produce an error once the change is applied, like `@stylistic/js/padding-line-between-statements` already does.

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
