### PR TITLE
fix(indent): correctly identify opening brace on enum declaration

### DIFF
--- a/packages/eslint-plugin-js/rules/indent/indent.ts
+++ b/packages/eslint-plugin-js/rules/indent/indent.ts
@@ -1048,7 +1048,7 @@ export default createRule<MessageIds, RuleOptions>({
       },
 
       'ObjectExpression, ObjectPattern': function (node: Tree.ObjectExpression | Tree.ObjectPattern) {
-        const openingCurly = sourceCode.getFirstToken(node)!
+        const openingCurly = sourceCode.getFirstToken(node, isOpeningBraceToken)!
         const closingCurly = sourceCode.getTokenAfter(
           node.properties.length ? node.properties[node.properties.length - 1] : openingCurly,
           isClosingBraceToken,

--- a/packages/eslint-plugin-ts/rules/indent/indent.test.ts
+++ b/packages/eslint-plugin-ts/rules/indent/indent.test.ts
@@ -185,6 +185,13 @@ enum Foo {
     baz = 1,
 }
             `,
+            `
+enum Foo
+{
+    bar = 1,
+    baz = 1,
+}
+            `,
     ],
   },
   {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Enumerations are converted to use the base indent `'ObjectExpression, ObjectPattern'` rule, which assumes the first token to be an opening bracket. Passing the available `isOpeningBraceToken` assertion method makes sure it takes the first token it can find that is actually an opening bracket. This mainly fixes cases for people using brace rules that put the opening brace on a newline (i.e., 'allman').

### Linked Issues

fix: #52 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
