### PR TITLE
fix(configs): member-delimiter-style should use semi delimiters when semi is true, fixes #266

### DIFF
--- a/packages/eslint-plugin/configs/customize.ts
+++ b/packages/eslint-plugin/configs/customize.ts
@@ -159,18 +159,20 @@ export function customize(options: StylisticCustomizeOptions<boolean> = {}): Lin
     '@stylistic/max-statements-per-line': ['error', { max: 1 }],
     '@stylistic/member-delimiter-style': ['error', {
       multiline: {
-        delimiter: 'none',
+        delimiter: semi ? 'semi' : 'none',
+        requireLast: semi,
       },
       multilineDetection: 'brackets',
       overrides: {
         interface: {
           multiline: {
-            delimiter: 'none',
+            delimiter: semi ? 'semi' : 'none',
+            requireLast: semi,
           },
         },
       },
       singleline: {
-        delimiter: 'comma',
+        delimiter: semi ? 'semi' : 'comma',
       },
     }],
     '@stylistic/multiline-ternary': ['error', 'always-multiline'],

--- a/tests/configs/fixtures/output/tab-quotes-semi/typescript.ts
+++ b/tests/configs/fixtures/output/tab-quotes-semi/typescript.ts
@@ -2,8 +2,8 @@ export {};
 
 // Define a TypeScript interface
 interface Person< T = string, K = number > {
-	name: string
-	age: number
+	name: string;
+	age: number;
 }
 
 type Tuple = [ foo: number, bar: String | Boolean];
@@ -43,8 +43,8 @@ log(result);
 
 // Use optional properties in an interface
 interface Car {
-	make: string
-	model?: string
+	make: string;
+	model?: string;
 }
 
 // Create objects using the interface


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixes #266 by adjusting the member-delimiter-style rule to use semicolon delimiters when semi is true.

### Linked Issues

#266 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
