### PR TITLE
fix: revert espree version bump, fix #278

### DIFF
--- a/packages/eslint-plugin-js/package.json
+++ b/packages/eslint-plugin-js/package.json
@@ -115,7 +115,7 @@
     "acorn": "^8.11.3",
     "escape-string-regexp": "^4.0.0",
     "eslint-visitor-keys": "^3.4.3",
-    "espree": "^10.0.0"
+    "espree": "^9.6.1"
   },
   "devDependencies": {
     "@eslint-community/eslint-utils": "^4.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,8 +245,8 @@ importers:
         specifier: ^3.4.3
         version: 3.4.3
       espree:
-        specifier: ^10.0.0
-        version: 10.0.0
+        specifier: ^9.6.1
+        version: 9.6.1
     devDependencies:
       '@eslint-community/eslint-utils':
         specifier: ^4.4.0
@@ -4277,15 +4277,6 @@ packages:
     dependencies:
       tsx: 4.1.0
     dev: true
-
-  /espree@10.0.0:
-    resolution: {integrity: sha512-gdlKrfXQWv/3vubKqeQIiBUoWeknNQVEDpKD7OD3bC53g5EKISTuhcIoA1H1e+zqIuosdKrKuTDMmj8eFfhOnA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    dependencies:
-      acorn: 8.11.3
-      acorn-jsx: 5.3.2(acorn@8.11.3)
-      eslint-visitor-keys: 3.4.3
-    dev: false
 
   /espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}


### PR DESCRIPTION
### Description
The v1.6.0 is not Node 16 compatible due to espree update from v9.6.1 to v10.0.0
So, this PR is reverting the dependency update of this package only.

### Linked Issues
[Issue #278 | Maintain compatibility with Node v16](https://github.com/eslint-stylistic/eslint-stylistic/issues/278)

### Additional context
Requires NODE v16 for testing.

### Result of running `pnpm run test`
![image](https://github.com/eslint-stylistic/eslint-stylistic/assets/19746522/3bb61544-4284-4c58-8484-6fa7de2e653c)
