### PR TITLE
feat(multiline-ternary): add ignoreJSX option

### DIFF
--- a/packages/eslint-plugin-js/rules/multiline-ternary/README.md
+++ b/packages/eslint-plugin-js/rules/multiline-ternary/README.md
@@ -38,6 +38,7 @@ This rule has a string option:
 - `"always"` (default) enforces newlines between the operands of a ternary expression.
 - `"always-multiline"` enforces newlines between the operands of a ternary expression if the expression spans multiple lines.
 - `"never"` disallows newlines between the operands of a ternary expression.
+- `"ignoreJSX": true` Ignore the ternary operator in JSX. Defaults to `false`.
 
 ### always
 

--- a/packages/eslint-plugin-js/rules/multiline-ternary/multiline-ternary.test.ts
+++ b/packages/eslint-plugin-js/rules/multiline-ternary/multiline-ternary.test.ts
@@ -38,6 +38,15 @@ ruleTester.run('multiline-ternary', rule, {
     { code: '(a) \n? (b)\n: (c)', options: ['always'] },
     { code: '((a)) \n? ((b))\n: ((c))', options: ['always'] },
     { code: '((a)) ?\n ((b)):\n ((c))', options: ['always'] },
+    {
+      code: `
+        <>
+          {a ? <div /> : <div />}
+        </>
+      `,
+      options: ['always', { ignoreJSX: true }],
+      parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } },
+    },
 
     // "always-multiline"
     { code: 'a\n? b\n: c', options: ['always-multiline'] },
@@ -74,6 +83,16 @@ ruleTester.run('multiline-ternary', rule, {
     { code: 'a ? b : ((c))', options: ['always-multiline'] },
     { code: '(a) ? (b) : (c)', options: ['always-multiline'] },
     { code: '((a)) ? ((b)) : ((c))', options: ['always-multiline'] },
+    {
+      code: `
+        <>
+          {a ? 
+            <div /> : <div />}
+        </>
+      `,
+      options: ['always-multiline', { ignoreJSX: true }],
+      parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } },
+    },
 
     // "never"
     { code: 'a ? b : c', options: ['never'] },
@@ -99,6 +118,17 @@ ruleTester.run('multiline-ternary', rule, {
     { code: 'a ? b : (\n(c))', options: ['never'] },
     { code: '(a\n) ? (\nb\n) : (\nc)', options: ['never'] },
     { code: '((a)\n) ? (\n(b)\n) : (\n(c))', options: ['never'] },
+    {
+      code: `
+        <>
+          {a 
+            ? <div /> 
+            : <div />}
+        </>
+      `,
+      options: ['never', { ignoreJSX: true }],
+      parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } },
+    },
   ],
 
   invalid: [

--- a/packages/eslint-plugin-js/rules/multiline-ternary/multiline-ternary.ts
+++ b/packages/eslint-plugin-js/rules/multiline-ternary/multiline-ternary.ts
@@ -21,6 +21,15 @@ export default createRule<MessageIds, RuleOptions>({
         type: 'string',
         enum: ['always', 'always-multiline', 'never'],
       },
+      {
+        type: 'object',
+        properties: {
+          ignoreJSX: {
+            type: 'boolean',
+            default: false,
+          },
+        },
+      },
     ],
 
     messages: {
@@ -35,9 +44,9 @@ export default createRule<MessageIds, RuleOptions>({
 
   create(context) {
     const sourceCode = context.sourceCode
-    const option = context.options[0]
-    const multiline = option !== 'never'
-    const allowSingleLine = option === 'always-multiline'
+    const multiline = context.options[0] !== 'never'
+    const allowSingleLine = context.options[0] === 'always-multiline'
+    const IGNORE_JSX = context.options[1] && context.options[1].ignoreJSX
 
     return {
       ConditionalExpression(node) {
@@ -54,6 +63,13 @@ export default createRule<MessageIds, RuleOptions>({
         const areConsequentAndAlternateOnSameLine = isTokenOnSameLine(lastTokenOfConsequent, firstTokenOfAlternate)
 
         const hasComments = !!sourceCode.getCommentsInside(node).length
+
+        if (IGNORE_JSX) {
+          if (node.parent.type === 'JSXElement'
+            || node.parent.type === 'JSXFragment'
+            || node.parent.type === 'JSXExpressionContainer')
+            return null
+        }
 
         if (!multiline) {
           if (!areTestAndConsequentOnSameLine) {

--- a/packages/eslint-plugin-js/rules/multiline-ternary/types.d.ts
+++ b/packages/eslint-plugin-js/rules/multiline-ternary/types.d.ts
@@ -2,5 +2,9 @@
 
 export type Schema0 = 'always' | 'always-multiline' | 'never'
 
-export type RuleOptions = [Schema0?]
+export interface Schema1 {
+  ignoreJSX: boolean
+}
+
+export type RuleOptions = [Schema0?, Schema1?]
 export type MessageIds = 'expectedTestCons' | 'expectedConsAlt' | 'unexpectedTestCons' | 'unexpectedConsAlt'


### PR DESCRIPTION
### Description
Add the ignoreJSX option to a multi-line rule.
I want to apply different rules based on parentheses within JSX.

**e.g.**
**_singleline without parentheses_**

> long
```jsx
{a
  ? <div>blah blah</div>
  : <div>blah blah</div>}
```

> short
```jsx
{a ? <div /> : <div />}
```

**_multiline with parentheses_**
```jsx
{a ? (
  <div />
) : (
  <div />
)}
```

**_a mix of single and multilines_**
```jsx
{a ? (
  <div />
) : 0}
```

### Linked Issues
N/A
