### PR TITLE
fix(plus): type error on `RuleMode`

### DIFF
--- a/packages/eslint-plugin-plus/dts/index.d.ts
+++ b/packages/eslint-plugin-plus/dts/index.d.ts
@@ -1,10 +1,10 @@
-import type { ESLint, Linter } from 'eslint'
+import type { Linter, Rule } from 'eslint'
 import type { UnprefixedRuleOptions } from './rule-options'
 
 export type * from './rule-options'
 
 export type Rules = {
-  [K in keyof UnprefixedRuleOptions]: ESLint.RuleModule
+  [K in keyof UnprefixedRuleOptions]: Rule.RuleModule
 }
 
 declare const plugin: {


### PR DESCRIPTION
### Description

In #276 , one of the many TypeScript build errors is:

```sh
node_modules/@stylistic/eslint-plugin-plus/dts/index.d.ts:7:46 - error TS2694: Namespace '"/home/projects/pariwrqko.github/node_modules/@types/eslint/index".ESLint' has no exported member 'RuleModule'.

7   [K in keyof UnprefixedRuleOptions]: ESLint.RuleModule
                                               ~~~~~~~~~~
```

This is because in the `dts/index.d.ts` file of eslint-plugin-plus, there is [this line](https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin-plus/dts/index.d.ts#L7):

```ts
  [K in keyof UnprefixedRuleOptions]: ESLint.RuleModule
```

In all of the other `dts/index.d.ts` files, that line looks like this:

```ts
  [K in keyof UnprefixedRuleOptions]: Rule.RuleModule
```

See the equivalent lines in [eslint-plugin-js](https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin-js/dts/index.d.ts#L7), [eslint-plugin-jsx](https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin-jsx/dts/index.d.ts#L7), [eslint-plugin-ts](https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin-ts/dts/index.d.ts#L7), and [eslint-plugin](https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin/dts/index.ts#L9).

### Linked Issues

#276 (This PR does NOT close this issue - it only addresses 1 of the 6 different build errors in that issue.)

-----
<a href="https://stackblitz.com/~/github/JstnMcBrd/eslint-stylistic/tree/mcb%2Ffix-types"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github/JstnMcBrd/eslint-stylistic/tree/mcb%2Ffix-types)._