### PR TITLE
fix: type error on `UnprefixedRuleOptions`

### DIFF
--- a/packages/eslint-plugin/dts/rule-options.d.ts
+++ b/packages/eslint-plugin/dts/rule-options.d.ts
@@ -3,7 +3,7 @@ import type { UnprefixedRuleOptions as JSX } from '@stylistic/eslint-plugin-jsx'
 import type { UnprefixedRuleOptions as TS } from '@stylistic/eslint-plugin-ts'
 import type { UnprefixedRuleOptions as PLUS } from '@stylistic/eslint-plugin-plus'
 
-export type UnprefixedRuleOptions = {} & JS & JSX & TS & PLUS
+export type UnprefixedRuleOptions = JS & JSX & TS & PLUS
 
 export type RuleOptions = {
   [K in keyof UnprefixedRuleOptions as `@stylistic/${K}`]: UnprefixedRuleOptions[K]

--- a/packages/eslint-plugin/dts/rule-options.d.ts
+++ b/packages/eslint-plugin/dts/rule-options.d.ts
@@ -3,7 +3,7 @@ import type { UnprefixedRuleOptions as JSX } from '@stylistic/eslint-plugin-jsx'
 import type { UnprefixedRuleOptions as TS } from '@stylistic/eslint-plugin-ts'
 import type { UnprefixedRuleOptions as PLUS } from '@stylistic/eslint-plugin-plus'
 
-export interface UnprefixedRuleOptions extends JS, JSX, TS, PLUS {}
+export type UnprefixedRuleOptions = {} & JS & JSX & TS & PLUS
 
 export type RuleOptions = {
   [K in keyof UnprefixedRuleOptions as `@stylistic/${K}`]: UnprefixedRuleOptions[K]


### PR DESCRIPTION
### Description

In #276, there are many types errors about how `UnprefixedRuleOptions` is extended:

```sh
node_modules/@stylistic/eslint-plugin/dist/dts/rule-options.d.ts:6:11 - error TS2320: Interface 'UnprefixedRuleOptions' cannot simultaneously extend types 'UnprefixedRuleOptions' and 'UnprefixedRuleOptions'.
  Named property ''comma-dangle'' of types 'UnprefixedRuleOptions' and 'UnprefixedRuleOptions' are not identical.

6 interface UnprefixedRuleOptions extends UnprefixedRuleOptions$1, UnprefixedRuleOptions$2, UnprefixedRuleOptions$3, UnprefixedRuleOptions$4 {}
            ~~~~~~~~~~~~~~~~~~~~~

node_modules/@stylistic/eslint-plugin/dist/dts/rule-options.d.ts:6:11 - error TS2320: Interface 'UnprefixedRuleOptions' cannot simultaneously extend types 'UnprefixedRuleOptions' and 'UnprefixedRuleOptions'.
  Named property ''keyword-spacing'' of types 'UnprefixedRuleOptions' and 'UnprefixedRuleOptions' are not identical.

6 interface UnprefixedRuleOptions extends UnprefixedRuleOptions$1, UnprefixedRuleOptions$2, UnprefixedRuleOptions$3, UnprefixedRuleOptions$4 {}
            ~~~~~~~~~~~~~~~~~~~~~

node_modules/@stylistic/eslint-plugin/dist/dts/rule-options.d.ts:6:11 - error TS2320: Interface 'UnprefixedRuleOptions' cannot simultaneously extend types 'UnprefixedRuleOptions' and 'UnprefixedRuleOptions'.
  Named property ''lines-around-comment'' of types 'UnprefixedRuleOptions' and 'UnprefixedRuleOptions' are not identical.

6 interface UnprefixedRuleOptions extends UnprefixedRuleOptions$1, UnprefixedRuleOptions$2, UnprefixedRuleOptions$3, UnprefixedRuleOptions$4 {}
            ~~~~~~~~~~~~~~~~~~~~~

node_modules/@stylistic/eslint-plugin/dist/dts/rule-options.d.ts:6:11 - error TS2320: Interface 'UnprefixedRuleOptions' cannot simultaneously extend types 'UnprefixedRuleOptions' and 'UnprefixedRuleOptions'.
  Named property ''lines-between-class-members'' of types 'UnprefixedRuleOptions' and 'UnprefixedRuleOptions' are not identical.

6 interface UnprefixedRuleOptions extends UnprefixedRuleOptions$1, UnprefixedRuleOptions$2, UnprefixedRuleOptions$3, UnprefixedRuleOptions$4 {}
            ~~~~~~~~~~~~~~~~~~~~~

node_modules/@stylistic/eslint-plugin/dist/dts/rule-options.d.ts:6:11 - error TS2320: Interface 'UnprefixedRuleOptions' cannot simultaneously extend types 'UnprefixedRuleOptions' and 'UnprefixedRuleOptions'.
  Named property ''padding-line-between-statements'' of types 'UnprefixedRuleOptions' and 'UnprefixedRuleOptions' are not identical.

6 interface UnprefixedRuleOptions extends UnprefixedRuleOptions$1, UnprefixedRuleOptions$2, UnprefixedRuleOptions$3, UnprefixedRuleOptions$4 {}
            ~~~~~~~~~~~~~~~~~~~~~
```

This is because in [`eslint-plugin/dts/rule-options.d.ts`](https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin/dts/rule-options.d.ts#L6), there is the following line:

```ts
export interface UnprefixedRuleOptions extends JS, JSX, TS, PLUS {}
```

Unfortunately, there are many conflicts between the `JS`, `JSX`, `TS`, and `PLUS` interfaces, with identically-named rules with different rule option types.

For example, the `'comma-dangle'` property of `UnprefixedRuleOptions` in [`eslint-plugin-js`](https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin-js/rules/comma-dangle/types.d.ts#L3) is

```ts
type RuleOptions = [] | [Value | {
    arrays?: ValueWithIgnore
    objects?: ValueWithIgnore
    imports?: ValueWithIgnore
    exports?: ValueWithIgnore
    functions?: ValueWithIgnore
}]
```

But in contrast, the `'comma-dangle'` property of `UnprefixedRuleOptions` in [`eslint-plugin-ts`](https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin-ts/rules/comma-dangle/types.d.ts#L3) is

```ts
type RuleOptions = [] | [Value | {
    arrays?: ValueWithIgnore
    objects?: ValueWithIgnore
    imports?: ValueWithIgnore
    exports?: ValueWithIgnore
    functions?: ValueWithIgnore
    enums?: ValueWithIgnore
    generics?: ValueWithIgnore
    tuples?: ValueWithIgnore
}]
```

For some reason, TypeScript does not know how to reconcile these differences when extending the interface.

However, the type error disappears if you make `UnprefixedRuleOptions` a `type` instead of an `interface` and extend the other interfaces that way.

```ts
export type UnprefixedRuleOptions = JS & JSX & TS & PLUS
```

To be honest, I am not entirely sure why this works, but it does. I did some research into type extension with `types` and `interfaces`, and I am fairly confident that using `type ... & ...` gives equivalent results to using `interface ... extends ...`, so this change should be compatible.

### Linked Issues

#276 (If this PR works, then that should solve the last of the type errors of this issue)

-----
<a href="https://stackblitz.com/~/github/JstnMcBrd/eslint-stylistic/tree/mcb%2Ffix-types"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github/JstnMcBrd/eslint-stylistic/tree/mcb%2Ffix-types)._