### PR TITLE
Fix awkward phrase in documentation

### DIFF
--- a/docs/guide/why.md
+++ b/docs/guide/why.md
@@ -18,7 +18,7 @@ Here are two examples that Prettier and dprint would force the code wrap/unwrap 
 
 This behavior is [mandatory](https://github.com/prettier/prettier/issues/3468) due to the fundamental nature of their approach.
 
-With stylistic rules in ESLint, we are able to achieve similar formatting compatibility while retaining the original code style that reflects the authors/teams' intentions, and apply fixes in one-go.
+With stylistic rules in ESLint, we are able to achieve similar formatting compatibility while retaining the original code style that reflects the authors/teams' intentions, and apply fixes in one go.
 
 This project is maintained for those who care about such details and want to have full control of the code style.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: "ESLint Stylistic"
   text: "Stylistic Formatting\nfor ESLint"
-  tagline: Formatting and Linting in one-go, with fully customizable rules
+  tagline: Formatting and Linting in one go, with fully customizable rules
   image:
     src: /logo.svg
     alt: ESLint Stylistic Logo
@@ -25,7 +25,7 @@ features:
     details: Fine-tune the every single rule to fit your needs.
   - title: One-stop
     icon: 👌
-    details: Formatting and Linting in one-go, configure once and auto-fix once.
+    details: Formatting and Linting in one go, configure once and auto-fix once.
   - title: JavaScript & TypeScript
     icon: 📦
     details: Support both JavaScript and TypeScript.


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Change awkward word "one-go" to "one go" on [`/`](https://eslint.style/) and [`/guide/why`](https://eslint.style/guide/why). This sounds more natural in English.

### Linked Issues

None.

### Additional context

N/A
