### PR TITLE
feat(spaced-comment): ignore typescript triple-slash directive

### DIFF
--- a/packages/eslint-plugin-js/rules/spaced-comment/spaced-comment.test.ts
+++ b/packages/eslint-plugin-js/rules/spaced-comment/spaced-comment.test.ts
@@ -341,6 +341,20 @@ ruleTester.run('spaced-comment', rule, {
       code: '/***/', // "*" is a marker by default
       options: ['always'],
     },
+
+    // ignore typescript triple-slash directive
+    {
+      code: '/// <reference types="node" />',
+      options: ['always'],
+    },
+    {
+      code: '/// <reference path="path/to/file" />',
+      options: ['always'],
+    },
+    {
+      code: '/// <amd-module name="moduleName" />',
+      options: ['always'],
+    },
   ],
 
   invalid: [

--- a/packages/eslint-plugin-js/rules/spaced-comment/spaced-comment.ts
+++ b/packages/eslint-plugin-js/rules/spaced-comment/spaced-comment.ts
@@ -332,6 +332,10 @@ export default createRule<MessageIds, RuleOptions>({
       if (node.value.length === 0 || rule.markers.has(node.value))
         return
 
+      // Ignores typescript triple-slash directive.
+      if (type === 'line' && (node.value.startsWith('/ <reference') || node.value.startsWith('/ <amd')))
+        return
+
       const beginMatch = rule.beginRegex.exec(node.value)
       const endMatch = rule.endRegex.exec(node.value)
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

With `/// <reference types="node" />`, The rule report: "Expected space or tab after '//' in comment  @stylistic/spaced-comment"

Triple-Slash Directives should not be checked. This PR fix it.

### Linked Issues

#289 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
