### PR TITLE
docs(no-mixed-operators): clarify rule behavior for parameter 'groups'

### DIFF
--- a/packages/eslint-plugin-js/rules/no-mixed-operators/README.md
+++ b/packages/eslint-plugin-js/rules/no-mixed-operators/README.md
@@ -87,7 +87,8 @@ var foo = (a + b) * c;
 
 This rule has 2 options.
 
-- `groups` (`string[][]`) - specifies operator groups to be checked. The `groups` option is a list of groups, and a group is a list of binary operators. Default operator groups are defined as arithmetic, bitwise, comparison, logical, and relational operators. Note: Ternary operator(?:) can be part of any group and by default is allowed to be mixed with other operators.
+- `groups` (`string[][]`) - specifies operator groups to be checked. The `groups` option is a list of groups, and a group is a list of binary operators. Default operator groups are defined as _arithmetic_, _bitwise_, _comparison_, _logical_, and _relational_ operators.\
+  Note: Coalesce operator (`"??"`) and Ternary operator (`"?:"`) are not part of any group in the default configuration and therfore are allowed to be mixed with all other operators.
 
 - `allowSamePrecedence` (`boolean`) - specifies whether to allow mixed operators if they are of equal precedence. Default is `true`.
 
@@ -99,14 +100,15 @@ The following operators can be used in `groups` option:
 - Bitwise Operators: `"&"`, `"|"`, `"^"`, `"~"`, `"<<"`, `">>"`, `">>>"`
 - Comparison Operators: `"=="`, `"!="`, `"==="`, `"!=="`, `">"`, `">="`, `"<"`, `"<="`
 - Logical Operators: `"&&"`, `"||"`
-- Coalesce Operator: `"??"`
 - Relational Operators: `"in"`, `"instanceof"`
-- Ternary Operator: `?:`
+- Coalesce Operator: `"??"`
+- Ternary Operator: `"?:"`
 
+The rule checks each configured group separately - warnings or errors are only triggered if operators within the same group are mixed (without using parentheses).
+Inter-group usage is not checked.
 Now, consider the following group configuration: `{"groups": [["&", "|", "^", "~", "<<", ">>", ">>>"], ["&&", "||"]]}`.
 There are 2 groups specified in this configuration: bitwise operators and logical operators.
-This rule checks if the operators belong to the same group only.
-In this case, this rule checks if bitwise operators and logical operators are mixed, but ignores all other operators.
+In this case, this rule checks if bitwise operators are mixed with bitwise operators, and if logical operators are mixed with logical operators, but ignores all other operators.
 
 Examples of **incorrect** code for this rule with `{"groups": [["&", "|", "^", "~", "<<", ">>", ">>>"], ["&&", "||"]]}` option:
 
@@ -180,7 +182,7 @@ Examples of **correct** code for this rule with `{"allowSamePrecedence": true}` 
 ```js
 /*eslint no-mixed-operators: ["error", {"allowSamePrecedence": true}]*/
 
-// + and - have the same precedence.
+// + and - belong to the same default group; they have the same precedence.
 var foo = a + b - c;
 ```
 
@@ -193,7 +195,7 @@ Examples of **incorrect** code for this rule with `{"allowSamePrecedence": false
 ```js
 /*eslint no-mixed-operators: ["error", {"allowSamePrecedence": false}]*/
 
-// + and - have the same precedence.
+// + and - belong to the same default group; they have the same precedence.
 var foo = a + b - c;
 ```
 
@@ -206,7 +208,7 @@ Examples of **correct** code for this rule with `{"allowSamePrecedence": false}`
 ```js
 /*eslint no-mixed-operators: ["error", {"allowSamePrecedence": false}]*/
 
-// + and - have the same precedence.
+// + and - belong to the same default group; they have the same precedence.
 var foo = (a + b) - c;
 ```
 

--- a/packages/eslint-plugin-js/rules/no-mixed-operators/README.md
+++ b/packages/eslint-plugin-js/rules/no-mixed-operators/README.md
@@ -88,7 +88,7 @@ var foo = (a + b) * c;
 This rule has 2 options.
 
 - `groups` (`string[][]`) - specifies operator groups to be checked. The `groups` option is a list of groups, and a group is a list of binary operators. Default operator groups are defined as _arithmetic_, _bitwise_, _comparison_, _logical_, and _relational_ operators.\
-  Note: Coalesce operator (`"??"`) and Ternary operator (`"?:"`) are not part of any group in the default configuration and therfore are allowed to be mixed with all other operators.
+  Note: Coalesce operator (`"??"`) and Ternary operator (`"?:"`) are not part of any group in the default configuration and therefore are allowed to be mixed with all other operators.
 
 - `allowSamePrecedence` (`boolean`) - specifies whether to allow mixed operators if they are of equal precedence. Default is `true`.
 


### PR DESCRIPTION
### Description

This merge request proposes changes to the documentation page https://eslint.style/rules/js/no-mixed-operators

The current explanation of the rule parameter `groups` is ambiguous w.r.t. what is considered to be 'mixed operators': it is easily misconstrued to mean 'operators of different groups are mixed'.
This merge request proposes a different wording.

It also contains minor changes intended to increase consistency (formatting of operators, order of groups) and one rendering issue (the first occurence of the ternary operator in the current doc is rendered as a smiley because the colon and paren are not formatted as code)

This change is motivated by [my struggle](https://github.com/eslint/eslint/discussions/18201) I had recently while adding and configuring the rule for my project. I misunderstood the documentation. So did my colleagues.

### Linked Issues

https://github.com/eslint/eslint/discussions/18201

### Additional context

This proposal modifies the documentation page https://eslint.style/rules/js/no-mixed-operators

The old documentation page of the (now deprecated) eslint rule was identical; I have currently not planned to propagate this update back to the legacy documentation https://eslint.org/docs/latest/rules/no-mixed-operators

