### PR TITLE
fix(docs): redirect curly to eslint page

### DIFF
--- a/packages/eslint-plugin-js/rules/nonblock-statement-body-position/README.md
+++ b/packages/eslint-plugin-js/rules/nonblock-statement-body-position/README.md
@@ -180,4 +180,4 @@ while (foo)
 
 ## When Not To Use It
 
-If you're not concerned about consistent locations of single-line statements, you should not turn on this rule. You can also disable this rule if you're using the `"all"` option for the [`curly`](curly) rule, because this will disallow single-line statements entirely.
+If you're not concerned about consistent locations of single-line statements, you should not turn on this rule. You can also disable this rule if you're using the `"all"` option for the [`curly`](https://eslint.org/docs/latest/rules/curly) rule, because this will disallow single-line statements entirely.


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This pull request fixes incorrect link for `curly` rule in `nonblock-statement-body-position` rule as `curly` isn't part of `eslint-stylistic`. `curly` will not redirect to the original ESLint rule page.

### Linked Issues

*Reported on Discord*

### Additional context

- [Page in question](https://eslint.style/rules/js/nonblock-statement-body-position)
- [Current `curly` link](https://eslint.style/rules/js/curly)

<!-- e.g. is there anything you'd like reviewers to focus on? -->
