### PR TITLE
fix(typo): migration.md file

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -217,10 +217,10 @@ export default [
     ],
   }),
   // override the legacy rules
-  StylisticPlugin.configs['disable-legacy'], // [!code ++],
+  StylisticPlugin.configs['disable-legacy'] // [!code ++],
   // your own rules
   {
-    plugin: {
+    plugins: {
       stylistic: StylisticPlugin
     },
     rules: {


### PR DESCRIPTION
### Description
- Fixes a typo by changing the `plugin` section name to `plugins`.
- Remove duplicated comma after  `StylisticPlugin.configs['disable-legacy']`.
