### PR TITLE
`ts/lines-between-class-members`: does not apply to interface members

### DIFF
--- a/packages/eslint-plugin-ts/rules/lines-between-class-members/lines-between-class-members.test.ts
+++ b/packages/eslint-plugin-ts/rules/lines-between-class-members/lines-between-class-members.test.ts
@@ -129,6 +129,25 @@ abstract bar(a: string, b: string): void;
       `,
       options: ['always'],
     },
+    {
+      code: `
+interface foo {
+bar(): void;
+
+baz(): void;
+};
+      `,
+      options: ['always'],
+    },
+    {
+      code: `
+interface foo {
+bar(): void;
+baz(): void;
+};
+      `,
+      options: ['never'],
+    },
   ],
   invalid: [
     {
@@ -328,6 +347,48 @@ qux() { }
         {
           messageId: 'never',
         },
+        {
+          messageId: 'never',
+        },
+      ],
+    },
+    {
+      code: `
+interface foo {
+bar(): void;
+baz(): void;
+};
+      `,
+      output: `
+interface foo {
+bar(): void;
+
+baz(): void;
+};
+      `,
+      options: ['always'],
+      errors: [
+        {
+          messageId: 'always',
+        },
+      ],
+    },
+    {
+      code: `
+interface foo {
+bar(): void;
+
+baz(): void;
+};
+      `,
+      output: `
+interface foo {
+bar(): void;
+baz(): void;
+};
+      `,
+      options: ['never'],
+      errors: [
         {
           messageId: 'never',
         },


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

PR with failing test for issue https://github.com/eslint-community/eslint-stylistic/issues/353.
The `ts/lines-between-class-members` rule does not apply to interface members.

Given this config:
```json
{
  "rules": {
    "@stylistic/ts/lines-between-class-members": "error"
  }
}
```

This will be reported:
```ts
class A {
  a: string;
  b: string; // Expected blank line between class members.
}
```

But not this:
```ts
interface A {
  a: string;
  b: string;
}
```

### Linked Issues
https://github.com/eslint-community/eslint-stylistic/issues/353

### Additional context
It does not look particularly difficult to fix (see https://github.com/ygrandgirard/eslint-stylistic/compare/main...ygrandgirard:eslint-stylistic:bugfix/lines-between-interface-members) though I am not sure about the typing. If you are ok, I can create another PR with my fix.

<!-- e.g. is there anything you'd like reviewers to focus on? -->
