### PR TITLE
fix(jsx-indent): conflict between indent and jsx-indent

### DIFF
--- a/packages/eslint-plugin-jsx/rules/jsx-indent/jsx-indent.test.ts
+++ b/packages/eslint-plugin-jsx/rules/jsx-indent/jsx-indent.test.ts
@@ -1170,6 +1170,36 @@ const Component = () => (
       `,
       options: [2],
     },
+    {
+      options: [2, { checkAttributes: true, indentLogicalExpressions: true }],
+      code: `
+      <>
+        <div
+          foo={
+            condition
+              ? [
+                'bar'
+              ]
+              : [
+                'baz',
+                'qux'
+              ]
+          }
+        />
+        <div
+          style={
+            true
+              ? {
+                  color: 'red',
+                }
+              : {
+                  height: 1,
+                }
+          }
+        />
+      </>
+      `,
+    },
   ),
 
   invalid: invalids(
@@ -2713,99 +2743,6 @@ const Component = () => (
           messageId: 'wrongIndent',
           data: {
             needed: 12,
-            type: 'space',
-            characters: 'characters',
-            gotten: 8,
-          },
-        },
-      ],
-    },
-    {
-      code: `
-      <div
-        style={
-                  { color: 'red' }
-        }
-      />
-      `,
-      output: `
-      <div
-        style={
-          { color: 'red' }
-        }
-      />
-      `,
-      errors: [
-        {
-          messageId: 'wrongIndent',
-          data: {
-            needed: 10,
-            type: 'space',
-            characters: 'characters',
-            gotten: 18,
-          },
-        },
-      ],
-    },
-    {
-      code: `
-      <div
-        style={
-          { color: 'red' }
-}
-      />
-      `,
-      output: `
-      <div
-        style={
-          { color: 'red' }
-        }
-      />
-      `,
-      errors: [
-        {
-          messageId: 'wrongIndent',
-          data: {
-            needed: 10,
-            type: 'space',
-            characters: 'characters',
-            gotten: 0,
-          },
-        },
-      ],
-    },
-    {
-      code: `
-      <div
-        style={
-          true
-            ? {
-                color: 'red',
-              }
-            : {
-                height: 1,
-        }
-        }
-      />
-      `,
-      output: `
-      <div
-        style={
-          true
-            ? {
-                color: 'red',
-              }
-            : {
-                height: 1,
-              }
-        }
-      />
-      `,
-      errors: [
-        {
-          messageId: 'wrongIndent',
-          data: {
-            needed: 14,
             type: 'space',
             characters: 'characters',
             gotten: 8,

--- a/packages/eslint-plugin-jsx/rules/jsx-indent/jsx-indent.test.ts
+++ b/packages/eslint-plugin-jsx/rules/jsx-indent/jsx-indent.test.ts
@@ -2720,6 +2720,99 @@ const Component = () => (
         },
       ],
     },
+    {
+      code: `
+      <div
+        style={
+                  { color: 'red' }
+        }
+      />
+      `,
+      output: `
+      <div
+        style={
+          { color: 'red' }
+        }
+      />
+      `,
+      errors: [
+        {
+          messageId: 'wrongIndent',
+          data: {
+            needed: 10,
+            type: 'space',
+            characters: 'characters',
+            gotten: 18,
+          },
+        },
+      ],
+    },
+    {
+      code: `
+      <div
+        style={
+          { color: 'red' }
+}
+      />
+      `,
+      output: `
+      <div
+        style={
+          { color: 'red' }
+        }
+      />
+      `,
+      errors: [
+        {
+          messageId: 'wrongIndent',
+          data: {
+            needed: 10,
+            type: 'space',
+            characters: 'characters',
+            gotten: 0,
+          },
+        },
+      ],
+    },
+    {
+      code: `
+      <div
+        style={
+          true
+            ? {
+                color: 'red',
+              }
+            : {
+                height: 1,
+        }
+        }
+      />
+      `,
+      output: `
+      <div
+        style={
+          true
+            ? {
+                color: 'red',
+              }
+            : {
+                height: 1,
+              }
+        }
+      />
+      `,
+      errors: [
+        {
+          messageId: 'wrongIndent',
+          data: {
+            needed: 14,
+            type: 'space',
+            characters: 'characters',
+            gotten: 8,
+          },
+        },
+      ],
+    },
     skipDueToMultiErrorSorting ? [] : {
       code: `
         <div>

--- a/packages/eslint-plugin-jsx/rules/jsx-indent/jsx-indent.ts
+++ b/packages/eslint-plugin-jsx/rules/jsx-indent/jsx-indent.ts
@@ -380,6 +380,8 @@ export default createRule<MessageIds, RuleOptions>({
       const nameIndent = getNodeIndent(node.name)
       const lastToken = context.sourceCode.getLastToken(node.value)!
       const firstInLine = getFirstNodeInLine(context, lastToken)
+      if (firstInLine.loc.start.line !== lastToken.loc.start.line)
+        return
       const indent = node.name.loc.start.line === firstInLine.loc.start.line ? 0 : nameIndent
       checkNodesIndent(firstInLine as unknown as ASTNode, indent)
     }

--- a/packages/eslint-plugin-jsx/rules/jsx-indent/jsx-indent.ts
+++ b/packages/eslint-plugin-jsx/rules/jsx-indent/jsx-indent.ts
@@ -380,6 +380,7 @@ export default createRule<MessageIds, RuleOptions>({
       const nameIndent = getNodeIndent(node.name)
       const lastToken = context.sourceCode.getLastToken(node.value)!
       const firstInLine = getFirstNodeInLine(context, lastToken)
+      // leave this for `indent` rule to handle
       if (firstInLine.loc.start.line !== lastToken.loc.start.line)
         return
       const indent = node.name.loc.start.line === firstInLine.loc.start.line ? 0 : nameIndent


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Currently, there are some issues with jsx-indent, where some indentations are not checked, and there are conflicts with the indent rules. I have added some tests that cannot be passed.

### Additional context

![image](https://github.com/eslint-community/eslint-stylistic/assets/70067449/5a937a12-51b5-4ca1-a578-19028e4e3d31)
![image](https://github.com/eslint-community/eslint-stylistic/assets/70067449/f8a7ecdd-22b8-4d63-9bb5-f178f2ee2efb)
<img width="563" alt="image" src="https://github.com/eslint-community/eslint-stylistic/assets/70067449/f13b805a-3f8d-4173-bd8b-e0d9134b8873">
![image](https://github.com/eslint-community/eslint-stylistic/assets/70067449/75ed3313-bc1d-4e92-a8aa-4d2030e899b7)


<!-- e.g. is there anything you'd like reviewers to focus on? -->
