### PR TITLE
feat(jsx-one-expression-per-line): allow single line

### DIFF
--- a/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/README.md
+++ b/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/README.md
@@ -6,7 +6,11 @@ Note: The fixer will insert line breaks between any expression that are on the s
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```jsx
+/* eslint @stylistic/jsx-one-expression-per-line: "error" */
+
 <App><Hello /></App>
 
 <App><Hello />
@@ -49,6 +53,8 @@ Examples of **incorrect** code for this rule:
 ```
 
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```jsx
 <App>
@@ -126,4 +132,16 @@ Examples of **correct** code for this rule, when configured as `"single-child"`:
 <App>{"Hello"}</App>
 
 <App><Hello /></App>
+```
+
+Examples of **correct** code for this rule, when configured as `"single-line"`:
+
+```jsx
+<App>Hello <span>ESLint</span></App>
+
+<App>{"Hello"} {"ESLint"}</App>
+
+<App>
+  <Hello /> <ESLint />
+</App>
 ```

--- a/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.test.ts
+++ b/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.test.ts
@@ -173,6 +173,70 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       `,
       features: ['fragment', 'no-ts-old'], // TODO: FIXME: remove no-ts-old and fix
     },
+    {
+      code: '<App>{"foo"}</App>',
+      options: [{ allow: 'single-line' }],
+    },
+    {
+      code: '<App>{foo && <Bar />}</App>',
+      options: [{ allow: 'single-line' }],
+    },
+    {
+      code: '<App><Foo /></App>',
+      options: [{ allow: 'single-line' }],
+    },
+    {
+      code: `<>123<Foo/></>`,
+      options: [{ allow: 'single-line' }],
+    },
+    {
+      code: `
+        <>
+          123<Foo/><Bar/>
+        </>
+      `,
+      options: [{ allow: 'single-line' }],
+    },
+    {
+      code: `
+        <>
+          <Foo/><Bar/>{'baz'}
+        </>
+      `,
+      options: [{ allow: 'single-line' }],
+    },
+    {
+      code: `
+        <>
+          <Foo/><Bar/>baz
+        </>
+      `,
+      options: [{ allow: 'single-line' }],
+    },
+    {
+      code: `
+        <>
+          <Foo/>Bar<Baz></Baz>
+        </>
+      `,
+      options: [{ allow: 'single-line' }],
+    },
+    {
+      code: `
+        <App>
+          <Hello /> <ESLint />
+        </App>
+      `,
+      options: [{ allow: 'single-line' }],
+    },
+    {
+      code: `<App>{"Hello"} {"ESLint"}</App>`,
+      options: [{ allow: 'single-line' }],
+    },
+    {
+      code: `<App>Hello <span>ESLint</span></App>`,
+      options: [{ allow: 'single-line' }],
+    },
   ),
 
   invalid: invalids(
@@ -1557,6 +1621,29 @@ Go to page 2
         },
       ],
       parserOptions,
+    },
+    {
+      code: `
+<Layout>
+  <div style={{ maxWidth: \`300px\`, marginBottom: \`1.45rem\` }}><Image /></div>{'Bar'}
+  <Link to="/page-2/">Go to page 2</Link>
+</Layout>
+      `,
+      output: `
+<Layout>
+  <div style={{ maxWidth: \`300px\`, marginBottom: \`1.45rem\` }}><Image /></div>
+{'Bar'}
+  <Link to="/page-2/">Go to page 2</Link>
+</Layout>
+      `,
+      errors: [
+        {
+          messageId: 'moveToNewLine',
+          data: { descriptor: '{\'Bar\'}' },
+        },
+      ],
+      parserOptions,
+      options: [{ allow: 'single-line' }],
     },
   ),
 })

--- a/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.ts
+++ b/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.ts
@@ -38,7 +38,7 @@ export default createRule<MessageIds, RuleOptions>({
         properties: {
           allow: {
             type: 'string',
-            enum: ['none', 'literal', 'single-child'],
+            enum: ['none', 'literal', 'single-child', 'single-line'],
           },
         },
         default: optionDefaults,
@@ -85,9 +85,26 @@ export default createRule<MessageIds, RuleOptions>({
           if (
             options.allow === 'single-child'
             || (options.allow === 'literal' && (child.type === 'Literal' || child.type === 'JSXText'))
+            || (options.allow === 'single-line')
           )
             return
         }
+      }
+
+      if (options.allow === 'single-line') {
+        const firstChild = children[0]
+        const lastChild = children[children.length - 1]
+        let lineDifference = lastChild.loc.end.line - firstChild.loc.start.line
+        if (firstChild.type === 'Literal' || firstChild.type === 'JSXText') {
+          if (/^\s*?\n/.test(firstChild.raw))
+            lineDifference -= 1
+        }
+        if (lastChild.type === 'Literal' || lastChild.type === 'JSXText') {
+          if (/\n\s*?$/.test(lastChild.raw))
+            lineDifference -= 1
+        }
+        if (lineDifference === 0)
+          return
       }
 
       const childrenGroupedByLine: Record<number, Child[]> = {}

--- a/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/types.d.ts
+++ b/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/types.d.ts
@@ -1,7 +1,7 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
 export interface Schema0 {
-  allow?: 'none' | 'literal' | 'single-child'
+  allow?: 'none' | 'literal' | 'single-child' | 'single-line'
 }
 
 export type RuleOptions = [Schema0?]


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR introduces a new option for the jsx-one-expression-per-line rule, where setting it to `{ allow: 'single-line' }` will allow the above scenarios.

Sometimes we may wish to have multiple expressions on a single line, which can make the code more readable. For instance, in scenarios where an icon is required:

```jsx
<p>
  Go to page 2 <IconArrow />
</p>
```

All previous options would format this code as:

```jsx
<p>
  Go to page 2 
  <IconArrow />
</p>
```

The former is more readable and more intuitive.
To avoid being formatted, one can only nest it with `<>...</>`, but this is meaningless.

Similar examples:

```jsx
<div>
  This is a <strong>strong</strong> sentence.
</div>
```

```jsx
<Text style={[style.tabName, style.tabNameActive]}>
  {tab.name}
  (
  {tab?.list?.length}
  )
</Text>
```

<!-- e.g. is there anything you'd like reviewers to focus on? -->
