### PR TITLE
Fix link of the curly rule

### DIFF
--- a/packages/eslint-plugin-js/rules/nonblock-statement-body-position/README.md
+++ b/packages/eslint-plugin-js/rules/nonblock-statement-body-position/README.md
@@ -32,7 +32,7 @@ if (foo) bar();
 
 This rule aims to enforce a consistent location for single-line statements.
 
-Note that this rule does not enforce the usage of single-line statements in general. If you would like to disallow single-line statements, use the [`curly`](curly) rule instead.
+Note that this rule does not enforce the usage of single-line statements in general. If you would like to disallow single-line statements, use the [`curly`](https://eslint.org/docs/latest/rules/curly) rule instead.
 
 ### Options
 


### PR DESCRIPTION


### Description

The documentation of the `nonblock-statement-body-position` rule is pointing to the `curly` rule that has been moved to the main eslint rule so the link became invalid. This PR updates the link to point to the eslint doc instead. 
