### PR TITLE
docs: fix "Contributing" link

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -48,7 +48,7 @@ const PACKAGES: DefaultTheme.NavItemWithLink[] = [
 const VERSIONS: DefaultTheme.NavItemWithLink[] = [
   { text: `v${version} (current)`, link: '/' },
   { text: `Release Notes`, link: 'https://github.com/eslint-stylistic/eslint-stylistic/releases' },
-  { text: `Contributing`, link: 'https://github.com/eslint-stylistic/eslint-stylistic/blob/main/CONTRIBUTING.md' },
+  { text: `Contributing`, link: '/contribute/guide' },
 ]
 
 const packageNames: Record<string, string> = {


### PR DESCRIPTION
### Description

Hi 🙌,

Not real Bug, more UX issue:
In the Documentation, navigate to Header v1.8.0 > click on Contributing > Github Contributing page > return to docs 🥲.

I believe it's unnecessary to direct users to the "Github Contribution page" with this instruction:
"Please refer to https://eslint.style/contribute/guide for more information."

This may negatively impact the user experience.

Thanks 😄,

### Linked Issues
#382 

### Additional context

before update:
<img width="269" alt="Capture d’écran 2024-05-06 à 00 33 18" src="https://github.com/eslint-stylistic/eslint-stylistic/assets/76450798/2aa6a80c-1757-4b21-bf2b-0448fc468f39">

after update:
<img width="237" alt="Capture d’écran 2024-05-06 à 00 44 19" src="https://github.com/eslint-stylistic/eslint-stylistic/assets/76450798/b5d6058e-2cca-4d43-8e3a-5757f5ee5caf">

