### PR TITLE
fix(jsx-one-expression-per-line): `single-line` only one line break has not been processed

### DIFF
--- a/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.test.ts
+++ b/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.test.ts
@@ -1645,5 +1645,23 @@ Go to page 2
       parserOptions,
       options: [{ allow: 'single-line' }],
     },
+    {
+      code: `
+<div><span>foo</span>
+</div>
+      `,
+      output: `
+<div>
+<span>foo</span>
+</div>
+      `,
+      options: [{ allow: 'single-line' }],
+      errors: [
+        {
+          messageId: 'moveToNewLine',
+          data: { descriptor: 'span' },
+        },
+      ],
+    },
   ),
 })

--- a/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.ts
+++ b/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.ts
@@ -94,16 +94,17 @@ export default createRule<MessageIds, RuleOptions>({
       if (options.allow === 'single-line') {
         const firstChild = children[0]
         const lastChild = children[children.length - 1]
-        let lineDifference = lastChild.loc.end.line - firstChild.loc.start.line
+        const lineDifference = lastChild.loc.end.line - firstChild.loc.start.line
+        let lineBreaks = 0
         if (firstChild.type === 'Literal' || firstChild.type === 'JSXText') {
           if (/^\s*?\n/.test(firstChild.raw))
-            lineDifference -= 1
+            lineBreaks += 1
         }
         if (lastChild.type === 'Literal' || lastChild.type === 'JSXText') {
           if (/\n\s*?$/.test(lastChild.raw))
-            lineDifference -= 1
+            lineBreaks += 1
         }
-        if (lineDifference === 0)
+        if (lineDifference === 0 && lineBreaks === 0 || lineDifference === 2 && lineBreaks === 2)
           return
       }
 


### PR DESCRIPTION
‌‌‌‌### Description

`single-line` is currently not being handled correctly:
```jsx
<div><span>foo</span>
</div>
```

It should be formatted as:
```jsx
<div>
  <span>foo</span>
</div>
```

This PR adds this test case and fixes the issue.