### PR TITLE
feat(jsx-one-expression-per-line): allow `non-jsx` option

### DIFF
--- a/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/README.md
+++ b/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/README.md
@@ -112,7 +112,7 @@ Examples of **correct** code for this rule:
 
 ```js
 ...
-"@stylistic/jsx/jsx-one-expression-per-line": [<enabled>, { "allow": "none"|"literal"|"single-child" }]
+"@stylistic/jsx/jsx-one-expression-per-line": [<enabled>, { "allow": "none"|"literal"|"single-child"|"non-jsx" }]
 ...
 ```
 
@@ -145,5 +145,19 @@ Examples of **correct** code for this rule, when configured as `"single-line"`:
 
 <App>
   <Hello /> <ESLint />
+</App>
+```
+
+Examples of **correct** code for this rule, when configured as `"non-jsx"`:
+
+```jsx
+<App>Hello {someVariable}</App>
+
+<App>Hello {<Hello />} there!</App>
+
+<App>
+  Hello
+  <Hello />
+  there!
 </App>
 ```

--- a/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.test.ts
+++ b/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.test.ts
@@ -144,6 +144,22 @@ run({
       options: [{ allow: 'single-child' }],
     },
     {
+      code: '<App>123</App>',
+      options: [{ allow: 'non-jsx' }],
+    },
+    {
+      code: '<App>foo</App>',
+      options: [{ allow: 'non-jsx' }],
+    },
+    {
+      code: '<App>{"foo"}</App>',
+      options: [{ allow: 'non-jsx' }],
+    },
+    {
+      code: '<App>{<Bar />}</App>',
+      options: [{ allow: 'non-jsx' }],
+    },
+    {
       code: '<App>{foo && <Bar />}</App>',
       options: [{ allow: 'single-child' }],
     },
@@ -171,6 +187,56 @@ run({
         </>
       `,
       features: ['fragment', 'no-ts-old'], // TODO: FIXME: remove no-ts-old and fix
+    },
+    {
+      code: '<App>Hello {name}</App>',
+      options: [{ allow: 'non-jsx' }],
+    },
+    {
+      code: `
+        <App>
+          Hello {name} there!
+        </App>`,
+      options: [{ allow: 'non-jsx' }],
+    },
+    {
+      code: `
+        <App>
+          Hello {<Bar />} there!
+        </App>`,
+      options: [{ allow: 'non-jsx' }],
+    },
+    {
+      code: `
+        <App>
+          Hello {(<Bar />)} there!
+        </App>`,
+      options: [{ allow: 'non-jsx' }],
+    },
+    {
+      code: `
+        <App>
+          Hello {(() => <Bar />)()} there!
+        </App>`,
+      options: [{ allow: 'non-jsx' }],
+    },
+    {
+      code: `<>
+               123
+               <Foo/>
+             </>`,
+      options: [{ allow: 'non-jsx' }],
+    },
+    {
+      code: `
+        <>
+          <Foo/>
+            Bar
+            <Baz>
+          </Baz>
+        </>
+      `,
+      options: [{ allow: 'non-jsx' }],
     },
     {
       code: '<App>{"foo"}</App>',
@@ -530,6 +596,27 @@ foo
           data: { descriptor: 'Baz' },
         },
       ],
+    },
+    {
+      code: `
+        <Text style={styles.foo}>
+          <Bar /> <Baz />
+        </Text>
+      `,
+      output: `
+        <Text style={styles.foo}>
+          <Bar />${' '/* intentional trailing space */}
+{' '}
+<Baz />
+        </Text>
+      `,
+      errors: [
+        {
+          messageId: 'moveToNewLine',
+          data: { descriptor: 'Baz' },
+        },
+      ],
+      options: [{ allow: 'non-jsx' }],
     },
     {
       code: `
@@ -1247,6 +1334,23 @@ foo
     },
     {
       code: `
+        <App><Foo /></App>
+      `,
+      output: `
+        <App>
+<Foo />
+</App>
+      `,
+      options: [{ allow: 'non-jsx' }],
+      errors: [
+        {
+          messageId: 'moveToNewLine',
+          data: { descriptor: 'Foo' },
+        },
+      ],
+    },
+    {
+      code: `
         <App
           foo="1"
           bar="2"
@@ -1546,6 +1650,34 @@ Go to page 2
           data: { descriptor: 'Go to page 2' },
         },
       ],
+    },
+    {
+      code: `
+<Layout>
+  <div style={{ maxWidth: \`300px\`, marginBottom: \`1.45rem\` }}><Image /></div>{'Bar'}
+  <Link to="/page-2/">Go to page 2</Link>
+</Layout>
+      `,
+      output: `
+<Layout>
+  <div style={{ maxWidth: \`300px\`, marginBottom: \`1.45rem\` }}>
+<Image />
+</div>
+{'Bar'}
+  <Link to="/page-2/">Go to page 2</Link>
+</Layout>
+      `,
+      errors: [
+        {
+          messageId: 'moveToNewLine',
+          data: { descriptor: 'Image' },
+        },
+        {
+          messageId: 'moveToNewLine',
+          data: { descriptor: '{\'Bar\'}' },
+        },
+      ],
+      options: [{ allow: 'non-jsx' }],
     },
     {
       code: `

--- a/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.ts
+++ b/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.ts
@@ -38,7 +38,7 @@ export default createRule<MessageIds, RuleOptions>({
         properties: {
           allow: {
             type: 'string',
-            enum: ['none', 'literal', 'single-child', 'single-line'],
+            enum: ['none', 'literal', 'single-child', 'single-line', 'non-jsx'],
           },
         },
         default: optionDefaults,
@@ -64,6 +64,12 @@ export default createRule<MessageIds, RuleOptions>({
       const children = node.children as Child[]
 
       if (!children || !children.length)
+        return
+
+      if (
+        options.allow === 'non-jsx'
+        && !children.find(child => (child.type === 'JSXFragment' || child.type === 'JSXElement'))
+      )
         return
 
       const openingElement = (<Tree.JSXElement>node).openingElement || (<Tree.JSXFragment>node).openingFragment

--- a/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/types.d.ts
+++ b/packages/eslint-plugin-jsx/rules/jsx-one-expression-per-line/types.d.ts
@@ -1,7 +1,7 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
 export interface Schema0 {
-  allow?: 'none' | 'literal' | 'single-child' | 'single-line'
+  allow?: 'none' | 'literal' | 'single-child' | 'single-line' | 'non-jsx'
 }
 
 export type RuleOptions = [Schema0?]


### PR DESCRIPTION
This PR is a sync of https://github.com/jsx-eslint/eslint-plugin-react/pull/3677.