### PR TITLE
feat(js): add option `ignoreStringLiterals`

### DIFF
--- a/packages/eslint-plugin-js/rules/quotes/README.md
+++ b/packages/eslint-plugin-js/rules/quotes/README.md
@@ -39,6 +39,7 @@ Object option:
 
 - `"avoidEscape": true` allows strings to use single-quotes or double-quotes so long as the string contains a quote that would have to be escaped otherwise
 - `"allowTemplateLiterals": true` allows strings to use backticks
+- `"ignoreStringLiterals": true` don’t report string literals, only template strings
 
 **Deprecated**: The object property `avoid-escape` is deprecated; please use the object property `avoidEscape` instead.
 

--- a/packages/eslint-plugin-js/rules/quotes/quotes.test.ts
+++ b/packages/eslint-plugin-js/rules/quotes/quotes.test.ts
@@ -17,6 +17,8 @@ run({
     { code: 'var foo = "bar";', options: ['double'] },
     { code: 'var foo = 1;', options: ['single'] },
     { code: 'var foo = 1;', options: ['double'] },
+    { code: 'var foo = \'bar\';', options: ['double', { ignoreStringLiterals: true }] },
+    { code: 'var foo = "bar";', options: ['single', { ignoreStringLiterals: true }] },
     { code: 'var foo = "\'";', options: ['single', { avoidEscape: true }] },
     { code: 'var foo = \'"\';', options: ['double', { avoidEscape: true }] },
     { code: 'var foo = <>Hello world</>;', options: ['single'], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
@@ -108,6 +110,19 @@ run({
       code: 'var foo = `bar`;',
       output: 'var foo = \'bar\';',
       options: ['single'],
+      parserOptions: {
+        ecmaVersion: 6,
+      },
+      errors: [{
+        messageId: 'wrongQuotes',
+        data: { description: 'singlequote' },
+        type: 'TemplateLiteral',
+      }],
+    },
+    {
+      code: 'var foo = `bar`;',
+      output: 'var foo = \'bar\';',
+      options: ['single', { ignoreStringLiterals: true }],
       parserOptions: {
         ecmaVersion: 6,
       },

--- a/packages/eslint-plugin-js/rules/quotes/quotes.ts
+++ b/packages/eslint-plugin-js/rules/quotes/quotes.ts
@@ -96,6 +96,9 @@ export default createRule<MessageIds, RuleOptions>({
               allowTemplateLiterals: {
                 type: 'boolean',
               },
+              ignoreStringLiterals: {
+                type: 'boolean',
+              },
             },
             additionalProperties: false,
           },
@@ -113,6 +116,7 @@ export default createRule<MessageIds, RuleOptions>({
     const settings = QUOTE_SETTINGS[quoteOption || 'double']
     const options = context.options[1]
     const allowTemplateLiterals = options && typeof (options) === 'object' && options.allowTemplateLiterals === true
+    const ignoreStringLiterals = options && typeof (options) === 'object' && options.ignoreStringLiterals === true
     const sourceCode = context.sourceCode
     let avoidEscape = options && typeof (options) === 'object' && options.avoidEscape === true
 
@@ -272,6 +276,9 @@ export default createRule<MessageIds, RuleOptions>({
     return {
 
       Literal(node) {
+        if (ignoreStringLiterals)
+          return
+
         const val = node.value
         const rawVal = node.raw
 

--- a/packages/eslint-plugin-js/rules/quotes/types.d.ts
+++ b/packages/eslint-plugin-js/rules/quotes/types.d.ts
@@ -7,6 +7,7 @@ export type Schema1 =
   | {
     avoidEscape?: boolean
     allowTemplateLiterals?: boolean
+    ignoreStringLiterals?: boolean
   }
 
 export type RuleOptions = [Schema0?, Schema1?]

--- a/packages/eslint-plugin-ts/rules/quotes/quotes.test.ts
+++ b/packages/eslint-plugin-ts/rules/quotes/quotes.test.ts
@@ -61,6 +61,14 @@ run({
       options: ['double'],
     },
     {
+      code: 'var foo = \'bar\';',
+      options: ['double', { ignoreStringLiterals: true }],
+    },
+    {
+      code: 'var foo = "bar";',
+      options: ['single', { ignoreStringLiterals: true }],
+    },
+    {
       code: 'var foo = "\'";',
       options: [
         'single',
@@ -532,6 +540,19 @@ run({
       output: 'var foo = \'bar\';',
       options: ['single'],
       errors: [useSingleQuote],
+    },
+    {
+      code: 'var foo = `bar`;',
+      output: 'var foo = \'bar\';',
+      options: ['single', { ignoreStringLiterals: true }],
+      parserOptions: {
+        ecmaVersion: 6,
+      },
+      errors: [{
+        messageId: 'wrongQuotes',
+        data: { description: 'singlequote' },
+        type: 'TemplateLiteral',
+      }],
     },
     {
       code: 'var foo = \'don\\\'t\';',

--- a/packages/eslint-plugin-ts/rules/quotes/quotes.ts
+++ b/packages/eslint-plugin-ts/rules/quotes/quotes.ts
@@ -26,6 +26,7 @@ export default createRule<RuleOptions, MessageIds>({
     {
       allowTemplateLiterals: false,
       avoidEscape: false,
+      ignoreStringLiterals: false,
     },
   ],
   create(context, [option]) {

--- a/packages/eslint-plugin-ts/rules/quotes/types.d.ts
+++ b/packages/eslint-plugin-ts/rules/quotes/types.d.ts
@@ -7,6 +7,7 @@ export type Schema1 =
   | {
     avoidEscape?: boolean
     allowTemplateLiterals?: boolean
+    ignoreStringLiterals?: boolean
   }
 
 export type RuleOptions = [Schema0?, Schema1?]


### PR DESCRIPTION
### Description

This adds a new option `ignoreStringLiterals` to the `quotes` rule. When `ignoreStringLiterals` is enabled, only template literals are reported, not string literals.

### Linked Issues

Closes #400

### Additional context

N/A
