### PR TITLE
fix(quotes): allow template literals to avoid escape sequences

### DIFF
--- a/packages/eslint-plugin-js/rules/quotes/README.md
+++ b/packages/eslint-plugin-js/rules/quotes/README.md
@@ -37,7 +37,7 @@ String option:
 
 Object option:
 
-- `"avoidEscape": true` allows strings to use single-quotes or double-quotes so long as the string contains a quote that would have to be escaped otherwise
+- `"avoidEscape": true` allows strings to use single-quotes, double-quotes, or template literals so long as the string contains a quote that would have to be escaped otherwise
 - `"allowTemplateLiterals": true` allows strings to use backticks
 - `"ignoreStringLiterals": true` don’t report string literals, only template strings
 

--- a/packages/eslint-plugin-js/rules/quotes/quotes.test.ts
+++ b/packages/eslint-plugin-js/rules/quotes/quotes.test.ts
@@ -21,6 +21,8 @@ run({
     { code: 'var foo = "bar";', options: ['single', { ignoreStringLiterals: true }] },
     { code: 'var foo = "\'";', options: ['single', { avoidEscape: true }] },
     { code: 'var foo = \'"\';', options: ['double', { avoidEscape: true }] },
+    { code: 'var foo = `\'`;', options: ['single', { avoidEscape: true }] },
+    { code: 'var foo = `"`;', options: ['double', { avoidEscape: true }] },
     { code: 'var foo = <>Hello world</>;', options: ['single'], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
     { code: 'var foo = <>Hello world</>;', options: ['double'], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
     { code: 'var foo = <>Hello world</>;', options: ['double', { avoidEscape: true }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
@@ -180,6 +182,32 @@ run({
       errors: [{
         messageId: 'wrongQuotes',
         data: { description: 'doublequote' },
+        type: 'TemplateLiteral',
+      }],
+    },
+    {
+      code: 'var foo = `"`;',
+      output: 'var foo = "\\\"";',
+      options: ['double'],
+      parserOptions: {
+        ecmaVersion: 6,
+      },
+      errors: [{
+        messageId: 'wrongQuotes',
+        data: { description: 'doublequote' },
+        type: 'TemplateLiteral',
+      }],
+    },
+    {
+      code: 'var foo = `\'`;',
+      output: 'var foo = \'\\\'\';',
+      options: ['single'],
+      parserOptions: {
+        ecmaVersion: 6,
+      },
+      errors: [{
+        messageId: 'wrongQuotes',
+        data: { description: 'singlequote' },
         type: 'TemplateLiteral',
       }],
     },

--- a/packages/eslint-plugin-js/rules/quotes/quotes.ts
+++ b/packages/eslint-plugin-js/rules/quotes/quotes.ts
@@ -322,6 +322,9 @@ export default createRule<MessageIds, RuleOptions>({
         )
           return
 
+        if (avoidEscape && sourceCode.getText(node).includes(settings.quote))
+          return
+
         context.report({
           node,
           messageId: 'wrongQuotes',

--- a/packages/eslint-plugin-ts/rules/quotes/quotes.test.ts
+++ b/packages/eslint-plugin-ts/rules/quotes/quotes.test.ts
@@ -87,6 +87,24 @@ run({
       ],
     },
     {
+      code: 'var foo = `\'`;',
+      options: [
+        'single',
+        {
+          avoidEscape: true,
+        },
+      ],
+    },
+    {
+      code: 'var foo = `"`;',
+      options: [
+        'double',
+        {
+          avoidEscape: true,
+        },
+      ],
+    },
+    {
       code: 'var foo = <>Hello world</>;',
       options: ['single'],
       parserOptions: {
@@ -589,6 +607,24 @@ run({
           avoidEscape: true,
         },
       ],
+      errors: [useSingleQuote],
+    },
+    {
+      code: 'var foo = `"`;',
+      output: 'var foo = "\\\"";',
+      options: ['double'],
+      parserOptions: {
+        ecmaVersion: 6,
+      },
+      errors: [useDoubleQuote],
+    },
+    {
+      code: 'var foo = `\'`;',
+      output: 'var foo = \'\\\'\';',
+      options: ['single'],
+      parserOptions: {
+        ecmaVersion: 6,
+      },
       errors: [useSingleQuote],
     },
     {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When `avoidEscape: true`, template literals are allowed if  the string contains a quote that would have to be escaped otherwise.

### Linked Issues

Fixes https://github.com/eslint-stylistic/eslint-stylistic/issues/235
