### PR TITLE
fix(indent): correct indentation for `PropertyDefinition` with decorators

### DIFF
--- a/packages/eslint-plugin-ts/rules/indent/indent.test.ts
+++ b/packages/eslint-plugin-ts/rules/indent/indent.test.ts
@@ -748,6 +748,23 @@ const div: JQuery<HTMLElement> = $('<div>')
     {
       code: 'const foo = function<> (): void {}',
     },
+
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/229
+    {
+      code: `
+@Bar()
+export class Foo {
+  @a
+  id: string;
+
+  @a @b()
+  age: number;
+
+  @a @b() username: string;
+}
+      `,
+      options: [2],
+    },
   ],
   invalid: [
     ...individualNodeTests.invalid!,
@@ -1733,15 +1750,31 @@ declare module "Validation" {
         },
       ],
     },
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/208
     {
-
       code: `
     @Decorator()
-class Foo {}
+class Foo {
+    @a
+        foo: any;
+
+@b @c()
+    bar: any;
+
+        @d baz: any;
+}
       `,
       output: `
 @Decorator()
-class Foo {}
+class Foo {
+    @a
+    foo: any;
+
+    @b @c()
+    bar: any;
+
+    @d baz: any;
+}
       `,
       errors: [
         {
@@ -1751,6 +1784,33 @@ class Foo {}
             actual: 4,
           },
           line: 2,
+          column: 1,
+        },
+        {
+          messageId: 'wrongIndentation',
+          data: {
+            expected: '4 spaces',
+            actual: 8,
+          },
+          line: 5,
+          column: 1,
+        },
+        {
+          messageId: 'wrongIndentation',
+          data: {
+            expected: '4 spaces',
+            actual: 0,
+          },
+          line: 7,
+          column: 1,
+        },
+        {
+          messageId: 'wrongIndentation',
+          data: {
+            expected: '4 spaces',
+            actual: 8,
+          },
+          line: 10,
           column: 1,
         },
       ],

--- a/packages/eslint-plugin-ts/rules/indent/indent.ts
+++ b/packages/eslint-plugin-ts/rules/indent/indent.ts
@@ -181,6 +181,46 @@ export default createRule<RuleOptions, MessageIds>({
           rules['*:exit'](node)
       },
 
+      'ClassBody.body > PropertyDefinition[decorators.length > 0]': function (node: Tree.PropertyDefinition) {
+        if (node.loc.start.line !== node.loc.end.line) {
+          let startDecorator = node.decorators[0]
+          let endDecorator = startDecorator
+
+          for (let i = 1; i <= node.decorators.length; i++) {
+            const decorator = node.decorators[i]
+            if (i === node.decorators.length || startDecorator.loc.start.line !== decorator.loc.start.line) {
+              rules.PropertyDefinition({
+                type: AST_NODE_TYPES.PropertyDefinition,
+                key: node.key,
+                parent: node.parent,
+                range: [startDecorator.range[0], endDecorator.range[1]],
+                loc: {
+                  start: startDecorator.loc.start,
+                  end: endDecorator.loc.end,
+                },
+              })
+              if (decorator)
+                startDecorator = endDecorator = decorator
+            }
+            else {
+              endDecorator = decorator
+            }
+          }
+
+          return rules.PropertyDefinition({
+            ...node,
+            range: [endDecorator.range[1] + 1, node.range[1]],
+            loc: {
+              start: node.key.loc.start,
+              end: node.loc.end,
+            },
+          })
+        }
+        else {
+          return rules.PropertyDefinition(node)
+        }
+      },
+
       VariableDeclaration(node: Tree.VariableDeclaration) {
         // https://github.com/typescript-eslint/typescript-eslint/issues/441
         if (node.declarations.length === 0)

--- a/packages/eslint-plugin-ts/rules/indent/indent.ts
+++ b/packages/eslint-plugin-ts/rules/indent/indent.ts
@@ -6,7 +6,6 @@
 
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import type { ASTNode, RuleFunction, Tree } from '@shared/types'
-import type { Node } from 'estree'
 import { createRule } from '../../utils'
 import { getESLintCoreRule } from '../../utils/getESLintCoreRule'
 import type { MessageIds, RuleOptions } from './types'

--- a/packages/eslint-plugin/configs/customize.ts
+++ b/packages/eslint-plugin/configs/customize.ts
@@ -142,7 +142,6 @@ export function customize(options: StylisticCustomizeOptions<boolean> = {}): Lin
         'TSTypeParameterInstantiation',
         'FunctionExpression > .params[decorators.length > 0]',
         'FunctionExpression > .params > :matches(Decorator, :not(:first-child))',
-        'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key',
       ],
       ImportDeclaration: 1,
       MemberExpression: 1,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Resolve the indentation issue for PropertyDefinition when using decorators.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
Closes #208 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
