### PR TITLE
fix(indent): handle undefined `node.decorators` when tsParser is not configured

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,5 +27,6 @@
     "json",
     "jsonc",
     "yaml"
-  ]
+  ],
+  "vitest.rootConfig": "vitest.config.unit.ts"
 }

--- a/packages/eslint-plugin-ts/rules/indent/indent.ts
+++ b/packages/eslint-plugin-ts/rules/indent/indent.ts
@@ -186,46 +186,43 @@ export default createRule<RuleOptions, MessageIds>({
       PropertyDefinition(node) {
         if (node.parent.type !== AST_NODE_TYPES.ClassBody)
           return
-        if (!node.decorators.length)
+        if (!node.decorators?.length)
+          return
+        if (node.loc.start.line === node.loc.end.line)
           return
 
-        if (node.loc.start.line !== node.loc.end.line) {
-          let startDecorator = node.decorators[0]
-          let endDecorator = startDecorator
+        let startDecorator = node.decorators[0]
+        let endDecorator = startDecorator
 
-          for (let i = 1; i <= node.decorators.length; i++) {
-            const decorator = node.decorators[i]
-            if (i === node.decorators.length || startDecorator.loc.start.line !== decorator.loc.start.line) {
-              rules.PropertyDefinition({
-                type: AST_NODE_TYPES.PropertyDefinition,
-                key: node.key,
-                parent: node.parent,
-                range: [startDecorator.range[0], endDecorator.range[1]],
-                loc: {
-                  start: startDecorator.loc.start,
-                  end: endDecorator.loc.end,
-                },
-              })
-              if (decorator)
-                startDecorator = endDecorator = decorator
-            }
-            else {
-              endDecorator = decorator
-            }
+        for (let i = 1; i <= node.decorators.length; i++) {
+          const decorator = node.decorators[i]
+          if (i === node.decorators.length || startDecorator.loc.start.line !== decorator.loc.start.line) {
+            rules.PropertyDefinition({
+              type: AST_NODE_TYPES.PropertyDefinition,
+              key: node.key,
+              parent: node.parent,
+              range: [startDecorator.range[0], endDecorator.range[1]],
+              loc: {
+                start: startDecorator.loc.start,
+                end: endDecorator.loc.end,
+              },
+            })
+            if (decorator)
+              startDecorator = endDecorator = decorator
           }
+          else {
+            endDecorator = decorator
+          }
+        }
 
-          return rules.PropertyDefinition({
-            ...node,
-            range: [endDecorator.range[1] + 1, node.range[1]],
-            loc: {
-              start: node.key.loc.start,
-              end: node.loc.end,
-            },
-          })
-        }
-        else {
-          return rules.PropertyDefinition(node)
-        }
+        return rules.PropertyDefinition({
+          ...node,
+          range: [endDecorator.range[1] + 1, node.range[1]],
+          loc: {
+            start: node.key.loc.start,
+            end: node.loc.end,
+          },
+        })
       },
 
       VariableDeclaration(node) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Prevent errors caused by accessing `node.decorators` when it is `undefined` by using optional chaining. This ensures that the code does not break without `ts-parser`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Closes #421 

### Additional context

Should we decide whether to add ts rules in `@stylistic/eslint-plugin` to determine whether `ts-parser` is used?

<!-- e.g. is there anything you'd like reviewers to focus on? -->
