### PR TITLE
fix: make plugin assignable to ESLint.Plugin (again)

### DIFF
--- a/packages/eslint-plugin/configs/index.ts
+++ b/packages/eslint-plugin/configs/index.ts
@@ -1,4 +1,4 @@
-import type { Linter } from 'eslint'
+import type { ESLint, Linter } from 'eslint'
 import { createAllConfigs } from '../../shared/configs-all'
 import plugin from '../src/plugin'
 import disableLegacy from './disable-legacy'
@@ -8,7 +8,7 @@ export type * from './customize'
 
 const recommendedExtends = /* #__PURE__ */ customize({ flat: false })
 
-export const configs = {
+const _configs = {
   /**
    * Disable all legacy rules from `eslint`, `@typescript-eslint` and `eslint-plugin-react`
    *
@@ -43,3 +43,10 @@ export const configs = {
    */
   'recommended-legacy': recommendedExtends,
 }
+
+// Defining the config as an extension of ESLint's configs type is necessary
+// to assert that they are compatible, despite including a function ('customize').
+//
+// When we do that, we have to export the config this way to preserve the typing
+// for config names as well.
+export const configs = _configs as ESLint.Plugin['configs'] & typeof _configs

--- a/packages/eslint-plugin/dts/index.ts
+++ b/packages/eslint-plugin/dts/index.ts
@@ -1,4 +1,4 @@
-import type { ESLint, Rule } from 'eslint'
+import type { Rule } from 'eslint'
 import type { configs } from '../configs'
 import type { UnprefixedRuleOptions } from './rule-options'
 
@@ -11,7 +11,7 @@ export type Rules = {
 
 declare const plugin: {
   rules: Rules
-  configs: ESLint.Plugin['configs'] & typeof configs
+  configs: typeof configs
 }
 
 export default plugin


### PR DESCRIPTION
### Linked Issues

- #398 

- #418 (previous PR that failed to solve the issue)

<br/>

### Long description

<br/>

Here's the issue: the types for ESLint mandate that plugin configs must be a `Record<string, ConfigData | Linter.FlatConfig | Linter.FlatConfig[]>`. This means that all members must be config objects.

However, the `stylistic` plugin tries to include a function in the configs - the `customize()` method. By doing so, giving the plugin to ESLint makes TypeScript explode.

<br/>
<br/>

The easiest solution? Just remove `customize()` from the configs object and include it as a separate export of the package. This would make the `stylistic` plugin normal and perfectly fit the types.

However, this would be a breaking change and require a major version bump to 3.0.0. And it would be undoing the original intent of the project maintainers. So I tried to find a less disruptive solution.

<br/>
<br/>

Previously, in #418, I tried to define the plugin's configs object as being an extension of `ESLint.Plugin['configs']`.

```ts
declare const plugin: {
  ...,
  configs: ESLint.Plugin['configs'] & typeof configs
}
```

Turns out, TypeScript is smarter than that and sees right through our little trick. It uses the `configs` object type still.

<br/>
<br/>

It appears the only way to solve the issue is to define the configs object **itself** as an extension of `ESLint.Plugin['configs']`. It's possible by just doing this:

```ts
export const configs = {
   ...,
} as ESLint.Plugin['configs']
```

But this causes a new problem: it generifies the type for the object, so TypeScript can no longer provide suggestions for indexing the config object. In an IDE, the user can no longer see what the names of the available configs are.

<br/>
<br/>

So I tried to find a solution that defined the configs object as being an extension of `ESLint.Plugin['configs']` plus its own specific type.

Turns out, the only way to do that was to define a private `_configs` object, then export it as a new `configs` object with `ESLint.Plugin['configs']` and `typeof _configs`.

```ts
const _configs = {
   ...,
}
export const configs = _configs as ESLint.Plugin['configs'] & typeof _configs
```

In the auto-generated dts file, this changes the `configs` object type:

```diff
- declare const configs: {
+ declare const configs: Record<string, ESLint.ConfigData | Linter.FlatConfig | Linter.FlatConfig[]> & {
   ...
}
```

Finally! Exactly what we've been looking for!

And this time, I copied the generated dts file into my personal project's `node_modules/@stylistic/eslint-plugin/dist` folder to verify that it **actually** solves the problem.

Now, is this elegant? No, it's a little messy. But I couldn't find a better way that
- made the plugin compatible with ESLint's plugin type
- didn't remove the `customize()` function from the configs object
- preserved the explicit type of the configs object with all config names

<br/>
<br/>

Hopefully writing out my thought process helps make this weird change make more sense. Please let me know if you have any suggestions.

---

Closes #398 (again)