### PR TITLE
fix(indent): correct indentation in chained methods calls with generics

### DIFF
--- a/packages/eslint-plugin-js/rules/indent/indent.ts
+++ b/packages/eslint-plugin-js/rules/indent/indent.ts
@@ -935,7 +935,7 @@ export default createRule<MessageIds, RuleOptions>({
 
       const offsetAfterToken = node.callee.type === 'TaggedTemplateExpression'
         ? sourceCode.getFirstToken(node.callee.quasi)!
-        : openingParen
+        : node.typeArguments ?? openingParen
       const offsetToken = sourceCode.getTokenBefore(offsetAfterToken)!
 
       offsets.setDesiredOffset(openingParen, offsetToken, 0)

--- a/packages/eslint-plugin-ts/rules/indent/indent.test.ts
+++ b/packages/eslint-plugin-ts/rules/indent/indent.test.ts
@@ -12,6 +12,7 @@ function nonTsTestCase(example: TemplateStringsArray): string {
   return ['// Non-TS Test Case', example].join('\n')
 }
 
+// #region individualNodeTests
 const individualNodeTests = [
   {
     node: AST_NODE_TYPES.ClassDeclaration,
@@ -642,6 +643,7 @@ type Foo = string | {
   },
   { valid: [], invalid: [] },
 )
+// #endregion
 
 run({
   name: 'indent',
@@ -762,6 +764,19 @@ export class Foo {
 
   @a @b() username: string;
 }
+      `,
+      options: [2],
+    },
+
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/270
+    {
+      code: `
+const map2 = Object.keys(map)
+  .filter((key) => true)
+  .reduce<Record<string, string>>((result, key) => {
+    result[key] = map[key];
+    return result;
+  }, {});
       `,
       options: [2],
     },


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Closes #270 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
