### PR TITLE
test(indent): add tests

### DIFF
--- a/packages/eslint-plugin-js/rules/indent/indent.test.ts
+++ b/packages/eslint-plugin-js/rules/indent/indent.test.ts
@@ -13074,6 +13074,27 @@ run({
       ]),
     },
 
+    {
+      code: $`
+        class C {
+        foo =
+        "bar";
+        }
+      `,
+      output: $`
+        class C {
+            foo =
+                "bar";
+        }
+      `,
+      options: [4],
+      parserOptions: { ecmaVersion: 2022 },
+      errors: expectedErrors([
+        [2, 4, 0, 'Identifier'],
+        [3, 8, 0, 'String'],
+      ]),
+    },
+
     // https://github.com/eslint/eslint/issues/15930
     {
       code: $`

--- a/packages/eslint-plugin-ts/rules/indent/indent.test.ts
+++ b/packages/eslint-plugin-ts/rules/indent/indent.test.ts
@@ -1830,5 +1830,30 @@ class Foo {
         },
       ],
     },
+    {
+      code: `
+class Foo {
+    bar =
+"baz";
+}
+      `,
+      output: `
+class Foo {
+    bar =
+        "baz";
+}
+      `,
+      errors: [
+        {
+          messageId: 'wrongIndentation',
+          data: {
+            expected: '8 spaces',
+            actual: 0,
+          },
+          line: 4,
+          column: 1,
+        },
+      ],
+    },
   ],
 })


### PR DESCRIPTION
Class property initialization in next line has broken expected indentation.

Breaking change: #416.
Issue: #429.

### Description

This is a failing test to demonstrate broken indentation for property initializer.

### Linked Issues
