### PR TITLE
feat(js/array-element-newline): options multiline and consistent combination

### DIFF
--- a/packages/eslint-plugin-js/rules/array-element-newline/README.md
+++ b/packages/eslint-plugin-js/rules/array-element-newline/README.md
@@ -30,6 +30,7 @@ This rule has either a string option:
 
 Or an object option (Requires line breaks if any of properties is satisfied. Otherwise, disallows line breaks):
 
+- `"consistent": <boolean>` requires consistent usage of line breaks between array elements. If this is false, this condition is disabled.
 - `"multiline": <boolean>` requires line breaks if there are line breaks inside elements. If this is false, this condition is disabled.
 - `"minItems": <number>` requires line breaks if the number of elements is at least the given integer. If this is 0, this condition will act the same as the option `"always"`. If this is `null` (the default), this condition is disabled.
 
@@ -242,6 +243,11 @@ Examples of **incorrect** code for this rule with the `{ "multiline": true }` op
 ```js
 /*eslint array-element-newline: ["error", { "multiline": true }]*/
 
+var c = [
+    1,
+    2,
+    3
+];
 var d = [1,
     2, 3];
 var e = [
@@ -267,6 +273,56 @@ var b = [1];
 var c = [1, 2];
 var d = [1, 2, 3];
 var e = [
+    function foo() {
+        dosomething();
+    },
+    function bar() {
+        dosomething();
+    }
+];
+```
+
+:::
+
+### consistent and multiline
+
+Examples of **incorrect** code for this rule with the `{ "consistent": true, "multiline": true }` option:
+
+:::incorrect
+
+```js
+/*eslint array-element-newline: ["error", { "consistent": true, "multiline": true }]*/
+
+var d = [1,
+    2, 3];
+var e = [
+    function foo() {
+        dosomething();
+    }, function bar() {
+        dosomething();
+    }
+];
+```
+
+:::
+
+Examples of **correct** code for this rule with the `{ "consistent": true, "multiline": true }` option:
+
+:::correct
+
+```js
+/*eslint array-element-newline: ["error", { "consistent": true, "multiline": true }]*/
+
+var a = [];
+var b = [1];
+var c = [1, 2];
+var d = [1, 2, 3];
+var e = [
+    1,
+    2,
+    3
+];
+var f = [
     function foo() {
         dosomething();
     },

--- a/packages/eslint-plugin-js/rules/array-element-newline/array-element-newline.test.ts
+++ b/packages/eslint-plugin-js/rules/array-element-newline/array-element-newline.test.ts
@@ -88,6 +88,15 @@ run({
     { code: 'var f = [\nfunction foo() {\ndosomething();\n},\nfunction bar() {\ndosomething();\n}\n];', options: [{ multiline: true }] },
     { code: 'var foo = [\n1,\n2,\n3,\n[\n]\n];', options: [{ multiline: true }] },
 
+    // { consistent: true, multiline: true }
+    { code: 'var foo = [];', options: [{ consistent: true, multiline: true }] },
+    { code: 'var foo = [1];', options: [{ consistent: true, multiline: true }] },
+    { code: 'var foo = [1, 2];', options: [{ consistent: true, multiline: true }] },
+    { code: 'var foo = [1, 2, 3];', options: [{ consistent: true, multiline: true }] },
+    { code: 'var foo = [1,\n2,\n3];', options: [{ consistent: true, multiline: true }] },
+    { code: 'var f = [\nfunction foo() {\ndosomething();\n},\nfunction bar() {\ndosomething();\n}\n];', options: [{ consistent: true, multiline: true }] },
+    { code: 'var foo = [\n1,\n2,\n3,\n[\n]\n];', options: [{ consistent: true, multiline: true }] },
+
     // { minItems: null }
     { code: 'var foo = [];', options: [{ minItems: null }] },
     { code: 'var foo = [1];', options: [{ minItems: null }] },
@@ -616,6 +625,23 @@ run({
 
     // { multiline: true }
     {
+      code: 'var foo = [1,\n2,\n3];',
+      output: 'var foo = [1, 2, 3];',
+      options: [{ multiline: true }],
+      errors: [
+        {
+          messageId: 'unexpectedLineBreak',
+          line: 1,
+          column: 14,
+        },
+        {
+          messageId: 'unexpectedLineBreak',
+          line: 2,
+          column: 3,
+        },
+      ],
+    },
+    {
       code: 'var foo = [1,\n2, 3];',
       output: 'var foo = [1, 2, 3];',
       options: [{ multiline: true }],
@@ -655,6 +681,61 @@ run({
       code: 'var foo = [\n1,2,3,\n[\n]\n];',
       output: 'var foo = [\n1,\n2,\n3,\n[\n]\n];',
       options: [{ multiline: true }],
+      errors: [
+        {
+          line: 2,
+          column: 3,
+          messageId: 'missingLineBreak',
+        },
+        {
+          line: 2,
+          column: 5,
+          messageId: 'missingLineBreak',
+        },
+      ],
+    },
+
+    // { consistent: true, multiline: true }
+    {
+      code: 'var foo = [1,\n2, 3];',
+      output: 'var foo = [1,\n2,\n3];',
+      options: [{ consistent: true, multiline: true }],
+      errors: [
+        {
+          messageId: 'missingLineBreak',
+          line: 2,
+          column: 3,
+        },
+      ],
+    },
+    {
+      code: 'var foo = [\nfunction foo() {\ndosomething();\n}, function bar() {\ndosomething();\n}\n];',
+      output: 'var foo = [\nfunction foo() {\ndosomething();\n},\nfunction bar() {\ndosomething();\n}\n];',
+      options: [{ consistent: true, multiline: true }],
+      errors: [
+        {
+          messageId: 'missingLineBreak',
+          line: 4,
+          column: 3,
+        },
+      ],
+    },
+    {
+      code: 'var foo = [\nfunction foo() {\ndosomething();\n}, /* any comment */ function bar() {\ndosomething();\n}\n];',
+      output: 'var foo = [\nfunction foo() {\ndosomething();\n}, /* any comment */\nfunction bar() {\ndosomething();\n}\n];',
+      options: [{ consistent: true, multiline: true }],
+      errors: [
+        {
+          messageId: 'missingLineBreak',
+          line: 4,
+          column: 21,
+        },
+      ],
+    },
+    {
+      code: 'var foo = [\n1,2,3,\n[\n]\n];',
+      output: 'var foo = [\n1,\n2,\n3,\n[\n]\n];',
+      options: [{ consistent: true, multiline: true }],
       errors: [
         {
           line: 2,

--- a/packages/eslint-plugin-js/rules/array-element-newline/array-element-newline.ts
+++ b/packages/eslint-plugin-js/rules/array-element-newline/array-element-newline.ts
@@ -30,6 +30,9 @@ export default createRule<MessageIds, RuleOptions>({
             {
               type: 'object',
               properties: {
+                consistent: {
+                  type: 'boolean',
+                },
                 multiline: {
                   type: 'boolean',
                 },
@@ -100,6 +103,7 @@ export default createRule<MessageIds, RuleOptions>({
         minItems = Number.POSITIVE_INFINITY
       }
       else {
+        consistent = Boolean(option.consistent)
         multiline = Boolean(option.multiline)
         minItems = option.minItems || Number.POSITIVE_INFINITY
       }

--- a/packages/eslint-plugin-js/rules/array-element-newline/types.d.ts
+++ b/packages/eslint-plugin-js/rules/array-element-newline/types.d.ts
@@ -12,6 +12,7 @@ export type Schema0 =
 export type BasicConfig =
   | ('always' | 'never' | 'consistent')
   | {
+    consistent?: boolean
     multiline?: boolean
     minItems?: number | null
   }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

The rule array-element-newline doesn't allow combining the `"consistent"` and `{ "multiline": true }` options.

The `{ "multiline": true }` is excellent for readability.

But with singleline values, it entirely forbid having newlines between elements.
Yet it's also quite helpful for readability with long values or some nested arrays.

With `{ "multiline": true }`, this is invalid.
```js
const urls = [
    "https://www.example.com/path/to/something",
    "https://www.example.com/path/to/something/else",
    "https://www.example.com/path/to/an/other/thing",
];

const matrix = [
    [0, 1, 2],
    [3, 4, 5],
    [6, 7, 8],
];
```

### Linked Issues

None here, but I opened this very issue on the eslint github back in 2020 before the split occured.
At the time, stylistic rules were frozen.
https://github.com/eslint/eslint/issues/13818

### Additional context

This change was made to be entirely backward compatible for ease.
It was just a matter of adding the possibility to put a boolean property named "consistent" to the option object.

`{ "consistent": true, "multiline": true }` has the meaning "if there is a multiline element, then the rule is `"always"` else the rule is `"consistent"`".