### PR TITLE
fix(indent): handle mixed spaces and tabs

### DIFF
--- a/packages/eslint-plugin-js/rules/indent/indent.test.ts
+++ b/packages/eslint-plugin-js/rules/indent/indent.test.ts
@@ -2102,30 +2102,12 @@ run({
     {
       code: $`
         function foo() {
-          bar();
-          \tbaz();
-        \t   \t\t\t  \t\t\t  \t   \tqux();
-        }
-      `,
-      options: [2],
-    },
-    {
-      code: $`
-        function foo() {
           function bar() {
             baz();
           }
         }
       `,
       options: [2, { FunctionDeclaration: { body: 1 } }],
-    },
-    {
-      code: $`
-        function foo() {
-          bar();
-           \t\t}
-      `,
-      options: [2],
     },
     {
       code: $`
@@ -5221,15 +5203,6 @@ run({
         </foo>
       `,
       options: [4, { ignoredNodes: ['JSXOpeningElement'] }],
-    },
-    {
-      code: $`
-        {
-        \tvar x = 1,
-        \t    y = 2;
-        }
-      `,
-      options: ['tab'],
     },
     {
       code: $`
@@ -13983,6 +13956,51 @@ run({
         [7, 8, 4, 'Identifier'],
         [8, 4, 0, 'Punctuator'],
       ]),
+    },
+    {
+      code: $`
+        function foo() {
+          bar();
+          \tbaz();
+        \t   \t\t\t  \t\t\t  \t   \tqux();
+        }
+      `,
+      options: [2],
+      output: $`
+        function foo() {
+          bar();
+          baz();
+          qux();
+        }
+      `,
+    },
+    {
+      code: $`
+        function foo() {
+          bar();
+           \t\t}
+      `,
+      options: [2],
+      output: $`
+        function foo() {
+          bar();
+        }
+      `,
+    },
+    {
+      code: $`
+        {
+        \tvar x = 1,
+        \t    y = 2;
+        }
+      `,
+      options: ['tab'],
+      output: $`
+        {
+        \tvar x = 1,
+        \t\ty = 2;
+        }
+      `,
     },
   ],
 })

--- a/packages/eslint-plugin-js/rules/indent/indent.ts
+++ b/packages/eslint-plugin-js/rules/indent/indent.ts
@@ -755,8 +755,6 @@ export default createRule<MessageIds, RuleOptions>({
       const indentation = tokenInfo.getTokenIndent(token)
 
       return indentation === desiredIndent
-        // To avoid conflicts with no-mixed-spaces-and-tabs, don't report mixed spaces and tabs.
-        || indentation.includes(' ') && indentation.includes('\t')
     }
 
     /**


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

As far as I know, `no-mixed-spaces-and-tabs` does not provide auto-fix, I don't know when they would conflict. At the same time, this prevents the `indent` rule from fixing errors when tabs and spaces are mixed.

I tested it in my ESLint config, it works fine.

https://github.com/hyoban/eslint-config-hyoban/blob/5b6a5301b9c1db0f2daa8605e4c30f92b20f4abb/patches/%40stylistic__eslint-plugin-js%402.6.0-beta.0.patch

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
