### PR TITLE
fix(type-generic-spacing): consider parentheses

### DIFF
--- a/packages/eslint-plugin-plus/rules/type-generic-spacing/type-generic-spacing.test.ts
+++ b/packages/eslint-plugin-plus/rules/type-generic-spacing/type-generic-spacing.test.ts
@@ -7,6 +7,8 @@ run({
   valid: [
     'type Foo<T = true> = T',
     'type Foo<T extends true = true> = T',
+    'type Foo<T = (true)> = T',
+    'type Foo<T extends (true) = (true)> = T',
     $`
       type Foo<
         T = true,
@@ -39,6 +41,8 @@ run({
   ],
   invalid: ([
     ['type Foo<T=true> = T', 'type Foo<T = true> = T'],
+    ['type Foo<T=(true)> = T', 'type Foo<T = (true)> = T'],
+    ['type Foo<T extends (true)=(true)> = T', 'type Foo<T extends (true) = (true)> = T'],
     ['type Foo<T,K> = T', 'type Foo<T, K> = T'],
     ['type Foo<T=false,K=1|2> = T', 'type Foo<T = false, K = 1|2> = T', 3],
     ['function foo <T>() {}', 'function foo<T>() {}'],

--- a/packages/eslint-plugin-plus/rules/type-generic-spacing/type-generic-spacing.ts
+++ b/packages/eslint-plugin-plus/rules/type-generic-spacing/type-generic-spacing.ts
@@ -73,10 +73,12 @@ export default createRule<RuleOptions, MessageIds>({
         const endNode = node.constraint || node.name
         const from = endNode.range[1]
         const to = node.default.range[0]
-        if (sourceCode.text.slice(from, to) !== ' = ') {
+        const textBetween = sourceCode.text.slice(from, to)
+
+        if (!/(?:^|[^ ]) = (?:$|[^ ])/.test(textBetween)) {
           context.report({
             *fix(fixer) {
-              yield fixer.replaceTextRange([from, to], ' = ')
+              yield fixer.replaceTextRange([from, to], textBetween.replace(/\s*=\s*/, ' = '))
             },
             loc: {
               start: endNode.loc.end,

--- a/packages/eslint-plugin-plus/rules/type-generic-spacing/type-generic-spacing.ts
+++ b/packages/eslint-plugin-plus/rules/type-generic-spacing/type-generic-spacing.ts
@@ -73,12 +73,12 @@ export default createRule<RuleOptions, MessageIds>({
         const endNode = node.constraint || node.name
         const from = endNode.range[1]
         const to = node.default.range[0]
-        const textBetween = sourceCode.text.slice(from, to)
+        const span = sourceCode.text.slice(from, to)
 
-        if (!/(?:^|[^ ]) = (?:$|[^ ])/.test(textBetween)) {
+        if (!span.match(/(?:^|[^ ]) = (?:$|[^ ])/)) {
           context.report({
             *fix(fixer) {
-              yield fixer.replaceTextRange([from, to], textBetween.replace(/\s*=\s*/, ' = '))
+              yield fixer.replaceTextRange([from, to], span.replace(/\s*=\s*/, ' = '))
             },
             loc: {
               start: endNode.loc.end,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

fixes #438 

Consider parentheses between `node.constraint/name` and `node.default`, e.g. `type Foo<T = (string | number)> = T`

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

#438 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
