### PR TITLE
docs: fix note block display

### DIFF
--- a/packages/eslint-plugin-ts/rules/member-delimiter-style/README.md
+++ b/packages/eslint-plugin-ts/rules/member-delimiter-style/README.md
@@ -60,11 +60,7 @@ Accepts three values (or two for `singleline`):
 - `semi` - each member should be delimited with a semicolon (`;`).
 - `none` - each member should be delimited with nothing.
 
-::: note
-
-`none` is not an option for `singleline` because having no delimiter between members on a single line is a syntax error in TS.
-
-:::
+Note: `none` is not an option for `singleline` because having no delimiter between members on a single line is a syntax error in TS.
 
 ### `requireLast`
 

--- a/packages/eslint-plugin-ts/rules/member-delimiter-style/README.md
+++ b/packages/eslint-plugin-ts/rules/member-delimiter-style/README.md
@@ -60,7 +60,11 @@ Accepts three values (or two for `singleline`):
 - `semi` - each member should be delimited with a semicolon (`;`).
 - `none` - each member should be delimited with nothing.
 
-Note: `none` is not an option for `singleline` because having no delimiter between members on a single line is a syntax error in TS.
+:::tip Note
+
+`none` is not an option for `singleline` because having no delimiter between members on a single line is a syntax error in TS.
+
+:::
 
 ### `requireLast`
 


### PR DESCRIPTION
fixes #404

### Description

Removed weird non-working formatting for a side-note

### Linked Issues

#404 