### PR TITLE
fix(arrow-parens): wrong parens removal with optional parameter

### DIFF
--- a/packages/eslint-plugin-js/rules/arrow-parens/arrow-parens.test.ts
+++ b/packages/eslint-plugin-js/rules/arrow-parens/arrow-parens.test.ts
@@ -53,6 +53,7 @@ const valid: ValidTestCase[] = [
   { code: 'async ([a, b]) => {}', options: ['as-needed'], parserOptions: { ecmaVersion: 8 } },
   { code: 'async (a, b) => {}', options: ['as-needed'], parserOptions: { ecmaVersion: 8 } },
   { code: '(a: T) => a', options: ['as-needed'], parser: parser('identifier-type') },
+  { code: '(a?) => a', options: ['as-needed'], parser: parser('optional-parameter') },
   { code: '(a): T => a', options: ['as-needed'], parser: parser('return-type') },
 
   // "as-needed", { "requireForBlockBody": true }

--- a/packages/eslint-plugin-js/rules/arrow-parens/arrow-parens.ts
+++ b/packages/eslint-plugin-js/rules/arrow-parens/arrow-parens.ts
@@ -139,6 +139,7 @@ export default createRule<RuleOptions, MessageIds>({
           !shouldHaveParens
           && hasParens
           && param.type === 'Identifier'
+          && !param.optional
           && !param.typeAnnotation
           && !node.returnType
           && !hasCommentsInParensOfParams(node, openingParen)

--- a/packages/eslint-plugin-js/test-utils/parsers/arrow-parens/optional-parameter.js
+++ b/packages/eslint-plugin-js/test-utils/parsers/arrow-parens/optional-parameter.js
@@ -1,0 +1,216 @@
+'use strict'
+
+// @typescript-eslint/parser@8.0.1
+// (a?) => a
+
+exports.parse = () => ({
+  type: 'Program',
+  body: [
+    {
+      type: 'ExpressionStatement',
+      expression: {
+        type: 'ArrowFunctionExpression',
+        generator: false,
+        id: null,
+        params: [
+          {
+            type: 'Identifier',
+            decorators: [],
+            name: 'a',
+            optional: true,
+            range: [
+              1,
+              3,
+            ],
+            loc: {
+              start: {
+                line: 1,
+                column: 1,
+              },
+              end: {
+                line: 1,
+                column: 3,
+              },
+            },
+          },
+        ],
+        body: {
+          type: 'Identifier',
+          decorators: [],
+          name: 'a',
+          optional: false,
+          range: [
+            8,
+            9,
+          ],
+          loc: {
+            start: {
+              line: 1,
+              column: 8,
+            },
+            end: {
+              line: 1,
+              column: 9,
+            },
+          },
+        },
+        async: false,
+        expression: true,
+        range: [
+          0,
+          9,
+        ],
+        loc: {
+          start: {
+            line: 1,
+            column: 0,
+          },
+          end: {
+            line: 1,
+            column: 9,
+          },
+        },
+      },
+      range: [
+        0,
+        9,
+      ],
+      loc: {
+        start: {
+          line: 1,
+          column: 0,
+        },
+        end: {
+          line: 1,
+          column: 9,
+        },
+      },
+    },
+  ],
+  comments: [],
+  range: [
+    0,
+    9,
+  ],
+  sourceType: 'module',
+  tokens: [
+    {
+      type: 'Punctuator',
+      value: '(',
+      range: [
+        0,
+        1,
+      ],
+      loc: {
+        start: {
+          line: 1,
+          column: 0,
+        },
+        end: {
+          line: 1,
+          column: 1,
+        },
+      },
+    },
+    {
+      type: 'Identifier',
+      value: 'a',
+      range: [
+        1,
+        2,
+      ],
+      loc: {
+        start: {
+          line: 1,
+          column: 1,
+        },
+        end: {
+          line: 1,
+          column: 2,
+        },
+      },
+    },
+    {
+      type: 'Punctuator',
+      value: '?',
+      range: [
+        2,
+        3,
+      ],
+      loc: {
+        start: {
+          line: 1,
+          column: 2,
+        },
+        end: {
+          line: 1,
+          column: 3,
+        },
+      },
+    },
+    {
+      type: 'Punctuator',
+      value: ')',
+      range: [
+        3,
+        4,
+      ],
+      loc: {
+        start: {
+          line: 1,
+          column: 3,
+        },
+        end: {
+          line: 1,
+          column: 4,
+        },
+      },
+    },
+    {
+      type: 'Punctuator',
+      value: '=>',
+      range: [
+        5,
+        7,
+      ],
+      loc: {
+        start: {
+          line: 1,
+          column: 5,
+        },
+        end: {
+          line: 1,
+          column: 7,
+        },
+      },
+    },
+    {
+      type: 'Identifier',
+      value: 'a',
+      range: [
+        8,
+        9,
+      ],
+      loc: {
+        start: {
+          line: 1,
+          column: 8,
+        },
+        end: {
+          line: 1,
+          column: 9,
+        },
+      },
+    },
+  ],
+  loc: {
+    start: {
+      line: 1,
+      column: 0,
+    },
+    end: {
+      line: 1,
+      column: 9,
+    },
+  },
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Closes #498 

### Additional context

Should we continue to test this way?
It uses some immutable files as parsing results, which cannot be verified with the latest version of parser.
At the same time, this requires us to keep these files in the repo. I think this is unnecessary.

<!-- e.g. is there anything you'd like reviewers to focus on? -->
