### PR TITLE
fix: move spacing rules about `as` and `satisfies` from `type-annontation-spacing` to `keyword-spacing`

### DIFF
--- a/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._js_.ts
@@ -16,7 +16,7 @@ const NEXT_TOKEN_M = /^[{*]$/u
 const TEMPLATE_OPEN_PAREN = /\$\{$/u
 const TEMPLATE_CLOSE_PAREN = /^\}/u
 const CHECK_TYPE = /^(?:JSXElement|RegularExpression|String|Template|PrivateIdentifier)$/u
-const KEYS = KEYWORDS_JS.concat(['as', 'async', 'await', 'from', 'get', 'let', 'of', 'set', 'yield']);
+const KEYS = KEYWORDS_JS.concat(['as', 'async', 'await', 'from', 'get', 'let', 'of', 'satisfies', 'set', 'yield']);
 
 // check duplications.
 (function () {

--- a/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._ts_.test.ts
@@ -106,6 +106,47 @@ run({
       options: [{ overrides: { as: {} } }],
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
+    'const foo = {} satisfies {}',
+    {
+      code: 'const foo = {}satisfies{};',
+      options: [NEITHER],
+    },
+    {
+      code: 'const foo = {} satisfies {};',
+      options: [overrides('satisfies', BOTH)],
+    },
+    {
+      code: 'const foo = {}satisfies{};',
+      options: [overrides('satisfies', NEITHER)],
+    },
+    {
+      code: 'const foo = {} satisfies {};',
+      options: [overrides('satisfies', BOTH)],
+    },
+    {
+      code: 'const a = 1 as any',
+      options: [NEITHER],
+    },
+    {
+      code: 'const a = true as any',
+      options: [NEITHER],
+    },
+    {
+      code: 'const a = b as any',
+      options: [NEITHER],
+    },
+    {
+      code: 'const a = 1 satisfies any',
+      options: [NEITHER],
+    },
+    {
+      code: 'const a = true satisfies any',
+      options: [NEITHER],
+    },
+    {
+      code: 'const a = b satisfies any',
+      options: [NEITHER],
+    },
     {
       code: 'import type { foo } from "foo";',
       options: [BOTH],
@@ -268,6 +309,34 @@ run({
       options: [{ overrides: { as: {} } }],
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: expectedAfter('as'),
+    },
+    {
+      code: 'const foo = {}satisfies {};',
+      output: 'const foo = {} satisfies {};',
+      errors: expectedBefore('satisfies'),
+    },
+    {
+      code: 'const foo = {} satisfies{};',
+      output: 'const foo = {}satisfies{};',
+      options: [NEITHER],
+      errors: unexpectedBefore('satisfies'),
+    },
+    {
+      code: 'const foo = {} satisfies{};',
+      output: 'const foo = {} satisfies {};',
+      errors: expectedAfter('satisfies'),
+    },
+    {
+      code: 'const foo = {}satisfies {};',
+      output: 'const foo = {}satisfies{};',
+      options: [NEITHER],
+      errors: unexpectedAfter('satisfies'),
+    },
+    {
+      code: 'const foo = {} satisfies{};',
+      output: 'const foo = {} satisfies {};',
+      options: [{ overrides: { satisfies: {} } }],
+      errors: expectedAfter('satisfies'),
     },
     {
       code: 'import type{ foo } from "foo";',

--- a/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._ts_.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._ts_.ts
@@ -61,11 +61,27 @@ export default createRule<RuleOptions, MessageIds>({
         // so mutating a copy would not change the underlying copy returned by that method
         asToken.type = AST_TOKEN_TYPES.Keyword
 
-        // use this selector just because it is just a call to `checkSpacingAroundFirstToken`
+        // TODO: Stage3: use this selector just because it is just a call to `checkSpacingAroundFirstToken`
         baseRules.DebuggerStatement!(asToken as never)
 
         // make sure to reset the type afterward so we don't permanently mutate the AST
         asToken.type = oldTokenType
+      },
+      // TODO: Stage3: copy from `TSAsExpression`, just call `checkSpacingAroundFirstToken` when refactor
+      TSSatisfiesExpression(node): void {
+        const satisfiesToken = nullThrows(
+          sourceCode.getTokenAfter(
+            node.expression,
+            token => token.value === 'satisfies',
+          ),
+          NullThrowsReasons.MissingToken('satisfies', node.type),
+        )
+        const oldTokenType = satisfiesToken.type
+        satisfiesToken.type = AST_TOKEN_TYPES.Keyword
+
+        baseRules.DebuggerStatement!(satisfiesToken as never)
+
+        satisfiesToken.type = oldTokenType
       },
       'ImportDeclaration[importKind=type]': function (
         node: Tree.ImportDeclaration,

--- a/packages/eslint-plugin/rules/keyword-spacing/types._js_.d.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/types._js_.d.ts
@@ -1,6 +1,6 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: tSm2ngelfv */
+/* @checksum: jkXafurrsR */
 
 export interface KeywordSpacingSchema0 {
   before?: boolean
@@ -199,6 +199,10 @@ export interface KeywordSpacingSchema0 {
       after?: boolean
     }
     return?: {
+      before?: boolean
+      after?: boolean
+    }
+    satisfies?: {
       before?: boolean
       after?: boolean
     }

--- a/packages/eslint-plugin/rules/keyword-spacing/types._ts_.d.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/types._ts_.d.ts
@@ -1,6 +1,6 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: ZDWyGI8MSG */
+/* @checksum: lhltjxE540 */
 
 export interface KeywordSpacingSchema0 {
   before?: boolean
@@ -199,6 +199,10 @@ export interface KeywordSpacingSchema0 {
       after?: boolean
     }
     return?: {
+      before?: boolean
+      after?: boolean
+    }
+    satisfies?: {
       before?: boolean
       after?: boolean
     }

--- a/packages/eslint-plugin/rules/keyword-spacing/types.d.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/types.d.ts
@@ -1,6 +1,6 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: ZDWyGI8MSG */
+/* @checksum: lhltjxE540 */
 
 export interface KeywordSpacingSchema0 {
   before?: boolean
@@ -199,6 +199,10 @@ export interface KeywordSpacingSchema0 {
       after?: boolean
     }
     return?: {
+      before?: boolean
+      after?: boolean
+    }
+    satisfies?: {
       before?: boolean
       after?: boolean
     }

--- a/packages/eslint-plugin/rules/type-annotation-spacing/type-annotation-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/type-annotation-spacing/type-annotation-spacing._ts_.test.ts
@@ -1170,74 +1170,6 @@ interface Foo {
     },
     // https://github.com/typescript-eslint/typescript-eslint/issues/1663
     'type ConstructorFn = new (...args: any[]) => any;',
-    'const a = {} as {}',
-    'const a = {} satisfies {}',
-    'const disabledRules = Object.fromEntries(pkg.rules.map(i => [i.originalId, 0] as const))',
-    {
-      code: `const a = ''as{}`,
-      options: [
-        {
-          overrides: {
-            operator: {
-              before: false,
-              after: false,
-            },
-          },
-        },
-      ],
-    },
-    {
-      code: `const a = ''as any`,
-      options: [
-        {
-          overrides: {
-            operator: {
-              before: false,
-              after: false,
-            },
-          },
-        },
-      ],
-    },
-    {
-      code: 'const a = 1 as any',
-      options: [
-        {
-          overrides: {
-            operator: {
-              before: false,
-              after: false,
-            },
-          },
-        },
-      ],
-    },
-    {
-      code: 'const a = true as any',
-      options: [
-        {
-          overrides: {
-            operator: {
-              before: false,
-              after: false,
-            },
-          },
-        },
-      ],
-    },
-    {
-      code: 'const a = b as any',
-      options: [
-        {
-          overrides: {
-            operator: {
-              before: false,
-              after: false,
-            },
-          },
-        },
-      ],
-    },
   ],
   invalid: [
     {
@@ -3850,38 +3782,6 @@ type Foo = {
           },
           line: 5,
           column: 59,
-        },
-      ],
-    },
-    {
-      code: `
-const a = {}as {}
-      `,
-      output: `
-const a = {} as {}
-      `,
-      errors: [
-        {
-          messageId: 'expectedSpaceBefore',
-          data: { type: 'as' },
-          line: 2,
-          column: 13,
-        },
-      ],
-    },
-    {
-      code: `
-const a = {}satisfies {}
-      `,
-      output: `
-const a = {} satisfies {}
-      `,
-      errors: [
-        {
-          messageId: 'expectedSpaceBefore',
-          data: { type: 'satisfies' },
-          line: 2,
-          column: 13,
         },
       ],
     },

--- a/packages/eslint-plugin/rules/type-annotation-spacing/types.d.ts
+++ b/packages/eslint-plugin/rules/type-annotation-spacing/types.d.ts
@@ -1,6 +1,6 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: HEz0tEmFXe */
+/* @checksum: xBBXh1Kir2 */
 
 export interface TypeAnnotationSpacingSchema0 {
   before?: boolean
@@ -12,7 +12,6 @@ export interface TypeAnnotationSpacingSchema0 {
     parameter?: SpacingConfig
     property?: SpacingConfig
     returnType?: SpacingConfig
-    operator?: SpacingConfig
   }
 }
 export interface SpacingConfig {

--- a/packages/eslint-plugin/rules/type-annotation-spacing/types.d.ts
+++ b/packages/eslint-plugin/rules/type-annotation-spacing/types.d.ts
@@ -1,6 +1,6 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: xBBXh1Kir2 */
+/* @checksum: LcEkMg91dp */
 
 export interface TypeAnnotationSpacingSchema0 {
   before?: boolean


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Closes #525 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
