### PR TITLE
fix(quotes): quotes options execute `allowTemplateLiterals` first then `avoidEscape`

### DIFF
--- a/packages/eslint-plugin/rules/quotes/quotes._js_.test.ts
+++ b/packages/eslint-plugin/rules/quotes/quotes._js_.test.ts
@@ -21,8 +21,8 @@ run({
     { code: 'var foo = "bar";', options: ['single', { ignoreStringLiterals: true }] },
     { code: 'var foo = "\'";', options: ['single', { avoidEscape: true }] },
     { code: 'var foo = \'"\';', options: ['double', { avoidEscape: true }] },
-    { code: 'var foo = `\'`;', options: ['single', { avoidEscape: true }] },
-    { code: 'var foo = `"`;', options: ['double', { avoidEscape: true }] },
+    { code: 'var foo = `\'`;', options: ['single', { avoidEscape: true, allowTemplateLiterals: true }] },
+    { code: 'var foo = `"`;', options: ['double', { avoidEscape: true, allowTemplateLiterals: true }] },
     { code: 'var foo = <>Hello world</>;', options: ['single'], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
     { code: 'var foo = <>Hello world</>;', options: ['double'], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
     { code: 'var foo = <>Hello world</>;', options: ['double', { avoidEscape: true }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
@@ -793,6 +793,22 @@ run({
     {
       code: 'foo(() => `bar`);',
       output: 'foo(() => "bar");',
+      errors: [{
+        messageId: 'wrongQuotes',
+        data: { description: 'doublequote' },
+        type: 'TemplateLiteral',
+      }],
+    },
+    {
+      code: 'var foo = `"bar"`',
+      output: 'var foo = "\\"bar\\""',
+      options: [
+        'double',
+        {
+          avoidEscape: true,
+          allowTemplateLiterals: false,
+        },
+      ],
       errors: [{
         messageId: 'wrongQuotes',
         data: { description: 'doublequote' },

--- a/packages/eslint-plugin/rules/quotes/quotes._js_.ts
+++ b/packages/eslint-plugin/rules/quotes/quotes._js_.ts
@@ -323,7 +323,7 @@ export default createRule<RuleOptions, MessageIds>({
           return
         }
 
-        if (avoidEscape && sourceCode.getText(node).includes(settings.quote))
+        if (allowTemplateLiterals && avoidEscape && sourceCode.getText(node).includes(settings.quote))
           return
 
         context.report({

--- a/packages/eslint-plugin/rules/quotes/quotes._ts_.test.ts
+++ b/packages/eslint-plugin/rules/quotes/quotes._ts_.test.ts
@@ -92,6 +92,7 @@ run({
         'single',
         {
           avoidEscape: true,
+          allowTemplateLiterals: true,
         },
       ],
     },
@@ -101,6 +102,7 @@ run({
         'double',
         {
           avoidEscape: true,
+          allowTemplateLiterals: true,
         },
       ],
     },


### PR DESCRIPTION
### Description

only when `allowTemplateLiterals` set true, allow template literals to avoid escape sequences 

### Linked Issues

close #542 

### Additional context

