### PR TITLE
feat(jsx/jsx-closing-tag-location): add location option to customize indentation

### DIFF
--- a/packages/eslint-plugin/rules/jsx-closing-tag-location/README._jsx_.md
+++ b/packages/eslint-plugin/rules/jsx-closing-tag-location/README._jsx_.md
@@ -37,9 +37,10 @@ There is one way to configure this rule.
 
 The first form is a string shortcut corresponding to the `location` values specified below. If omitted, it defaults to `"tag-aligned"`.
 
-```js
-"@stylistic/jsx/jsx-closing-tag-location": <enabled> // -> [<enabled>, "tag-aligned"]
-"react/jsx-closing-tag-location": [<enabled>, "<location>"]
+```json
+{
+  "@stylistic/jsx/jsx-closing-tag-location": ["error", "tag-aligned"]
+}
 ```
 
 ### `location`
@@ -51,14 +52,11 @@ Enforced location for the closing tag.
 
 Defaults to `tag-aligned`.
 
-You may pass an object `{ "location": <location> }` that is equivalent to the first string shortcut form.
-
 Examples of **incorrect** code for this rule:
 
 ```jsx
 // 'jsx-closing-tag-location': 1
 // 'jsx-closing-tag-location': [1, 'tag-aligned']
-// 'jsx-closing-tag-location': [1, {"location":'tag-aligned'}]
 <Say
   firstName="John"
   lastName="Smith">
@@ -66,13 +64,11 @@ Examples of **incorrect** code for this rule:
   </Say>;
 
 // 'jsx-closing-tag-location': [1, 'tag-aligned']
-// 'jsx-closing-tag-location': [1, {"location":'tag-aligned'}]
 const App = <Bar>
   Foo
 </Bar>;
 
 // 'jsx-closing-tag-location': [1, 'line-aligned']
-// 'jsx-closing-tag-location': [1, {"location":'line-aligned'}]
 const App = <Bar>
   Foo
             </Bar>;
@@ -83,7 +79,6 @@ Examples of **correct** code for this rule:
 ```jsx
 // 'jsx-closing-tag-location': 1
 // 'jsx-closing-tag-location': [1, 'tag-aligned']
-// 'jsx-closing-tag-location': [1, {"location":'tag-aligned'}]
 <Say
   firstName="John"
   lastName="Smith">
@@ -91,13 +86,11 @@ Examples of **correct** code for this rule:
 </Say>;
 
 // 'jsx-closing-tag-location': [1, 'tag-aligned']
-// 'jsx-closing-tag-location': [1, {"location":'tag-aligned'}]
 const App = <Bar>
   Foo
             </Bar>;
 
 // 'jsx-closing-tag-location': [1, 'line-aligned']
-// 'jsx-closing-tag-location': [1, {"location":'line-aligned'}]
 const App = <Bar>
   Foo
 </Bar>;

--- a/packages/eslint-plugin/rules/jsx-closing-tag-location/README._jsx_.md
+++ b/packages/eslint-plugin/rules/jsx-closing-tag-location/README._jsx_.md
@@ -31,6 +31,78 @@ Examples of **correct** code for this rule:
 <Hello>marklar</Hello>
 ```
 
+## Rule Options
+
+There is one way to configure this rule.
+
+The first form is a string shortcut corresponding to the `location` values specified below. If omitted, it defaults to `"tag-aligned"`.
+
+```js
+"@stylistic/jsx/jsx-closing-tag-location": <enabled> // -> [<enabled>, "tag-aligned"]
+"react/jsx-closing-tag-location": [<enabled>, "<location>"]
+```
+
+### `location`
+
+Enforced location for the closing tag.
+
+- `tag-aligned`: must be aligned with the opening tag.
+- `line-aligned`: must be aligned with the line containing the opening tag.
+
+Defaults to `tag-aligned`.
+
+You may pass an object `{ "location": <location> }` that is equivalent to the first string shortcut form.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+// 'jsx-closing-tag-location': 1
+// 'jsx-closing-tag-location': [1, 'tag-aligned']
+// 'jsx-closing-tag-location': [1, {"location":'tag-aligned'}]
+<Say
+  firstName="John"
+  lastName="Smith">
+  Hello
+  </Say>;
+
+// 'jsx-closing-tag-location': [1, 'tag-aligned']
+// 'jsx-closing-tag-location': [1, {"location":'tag-aligned'}]
+const App = <Bar>
+  Foo
+</Bar>;
+
+// 'jsx-closing-tag-location': [1, 'line-aligned']
+// 'jsx-closing-tag-location': [1, {"location":'line-aligned'}]
+const App = <Bar>
+  Foo
+            </Bar>;
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+// 'jsx-closing-tag-location': 1
+// 'jsx-closing-tag-location': [1, 'tag-aligned']
+// 'jsx-closing-tag-location': [1, {"location":'tag-aligned'}]
+<Say
+  firstName="John"
+  lastName="Smith">
+  Hello
+</Say>;
+
+// 'jsx-closing-tag-location': [1, 'tag-aligned']
+// 'jsx-closing-tag-location': [1, {"location":'tag-aligned'}]
+const App = <Bar>
+  Foo
+            </Bar>;
+
+// 'jsx-closing-tag-location': [1, 'line-aligned']
+// 'jsx-closing-tag-location': [1, {"location":'line-aligned'}]
+const App = <Bar>
+  Foo
+</Bar>;
+```
+
 ## When Not To Use It
 
 If you do not care about closing tag JSX alignment then you can disable this rule.

--- a/packages/eslint-plugin/rules/jsx-closing-tag-location/jsx-closing-tag-location._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-closing-tag-location/jsx-closing-tag-location._jsx_.test.ts
@@ -51,7 +51,7 @@ run({
        bar</App>
         }
       `,
-      options: [{ location: 'line-aligned' }],
+      options: ['line-aligned'],
     },
     {
       code: `

--- a/packages/eslint-plugin/rules/jsx-closing-tag-location/jsx-closing-tag-location._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-closing-tag-location/jsx-closing-tag-location._jsx_.test.ts
@@ -44,6 +44,57 @@ run({
       `,
       features: ['fragment'],
     },
+    {
+      code: `
+        const foo = () => {
+          return <App>
+       bar</App>
+        }
+      `,
+      options: [{ location: 'line-aligned' }],
+    },
+    {
+      code: `
+        const foo = () => {
+          return <App>
+              bar</App>
+        }
+      `,
+    },
+    {
+      code: `
+        const foo = () => {
+          return <App>
+              bar
+          </App>
+        }
+      `,
+      options: ['line-aligned'],
+    },
+    {
+      code: `
+        const foo = <App>
+              bar
+        </App>
+      `,
+      options: ['line-aligned'],
+    },
+    {
+      code: `
+        const x = <App>
+              foo
+                  </App>
+      `,
+    },
+    {
+      code: `
+        const foo =
+          <App>
+              bar
+          </App>
+      `,
+      options: ['line-aligned'],
+    },
   ),
 
   invalid: invalids(
@@ -98,6 +149,37 @@ run({
         </>
       `,
       errors: [{ messageId: 'onOwnLine' }],
+    },
+    {
+      code: `
+        const x = () => {
+          return <App>
+              foo</App>
+        }
+      `,
+      output: `
+        const x = () => {
+          return <App>
+              foo
+          </App>
+        }
+      `,
+      errors: [{ messageId: 'onOwnLine' }],
+      options: ['line-aligned'],
+    },
+    {
+      code: `
+        const x = <App>
+              foo
+                  </App>
+      `,
+      output: `
+        const x = <App>
+              foo
+        </App>
+      `,
+      errors: [{ messageId: 'alignWithOpening' }],
+      options: ['line-aligned'],
     },
   ),
 })

--- a/packages/eslint-plugin/rules/jsx-closing-tag-location/jsx-closing-tag-location._jsx_.ts
+++ b/packages/eslint-plugin/rules/jsx-closing-tag-location/jsx-closing-tag-location._jsx_.ts
@@ -58,10 +58,8 @@ export default createRule<RuleOptions, MessageIds>({
     ) {
       if (option === 'line-aligned')
         return openingStartOfLine.column
-      else if (option === 'tag-aligned')
-        return opening.loc.start.column
       else
-        throw new Error(`Invalid option ${option}`)
+        return opening.loc.start.column
     }
 
     function handleClosingElement(node: Tree.JSXClosingElement | Tree.JSXClosingFragment) {

--- a/packages/eslint-plugin/rules/jsx-closing-tag-location/jsx-closing-tag-location._jsx_.ts
+++ b/packages/eslint-plugin/rules/jsx-closing-tag-location/jsx-closing-tag-location._jsx_.ts
@@ -11,6 +11,14 @@ import { createRule } from '#utils/create-rule'
 const messages = {
   onOwnLine: 'Closing tag of a multiline JSX expression must be on its own line.',
   matchIndent: 'Expected closing tag to match indentation of opening.',
+  alignWithOpening: 'Expected closing tag to be aligned with the line containing the opening tag',
+}
+
+const DEFAULT_LOCATION = 'tag-aligned'
+
+const MESSAGE_LOCATION = {
+  'tag-aligned': 'matchIndent',
+  'line-aligned': 'alignWithOpening',
 }
 
 export default createRule<RuleOptions, MessageIds>({
@@ -18,19 +26,54 @@ export default createRule<RuleOptions, MessageIds>({
   package: 'jsx',
   meta: {
     type: 'layout',
-
     docs: {
       description: 'Enforce closing tag location for multiline JSX',
     },
     fixable: 'whitespace',
     messages,
-    schema: [],
+    schema: [{
+      anyOf: [
+        {
+          enum: ['tag-aligned', 'line-aligned'],
+        },
+        {
+          type: 'object',
+          properties: {
+            location: {
+              enum: ['tag-aligned', 'line-aligned'],
+            },
+          },
+          additionalProperties: false,
+        },
+      ],
+    }],
   },
 
   create(context) {
+    const config = context.options[0]
+    let option = DEFAULT_LOCATION
+
+    if (typeof config === 'string') {
+      option = config
+    }
+    else if (typeof config === 'object') {
+      if (Object.hasOwn(config, 'location')) {
+        option = config.location
+      }
+    }
+
+    function getIndentation(openingStartOfLine, opening) {
+      if (option === 'line-aligned')
+        return openingStartOfLine.column
+      if (option === 'tag-aligned')
+        return opening.loc.start.column
+    }
+
     function handleClosingElement(node: Tree.JSXClosingElement | Tree.JSXClosingFragment) {
       if (!node.parent)
         return
+
+      const sourceCode = context.getSourceCode()
 
       let opening: ASTNode
       if ('openingFragment' in node.parent)
@@ -38,14 +81,32 @@ export default createRule<RuleOptions, MessageIds>({
       if ('openingElement' in node.parent)
         opening = node.parent.openingElement
 
+      const openingLoc = sourceCode.getFirstToken(opening).loc.start
+      const openingLine = sourceCode.lines[openingLoc.line - 1]
+      const openingStartOfLine = {
+        column: /^\s*/.exec(openingLine)?.[0].length,
+        line: openingLoc.line,
+      }
+
       if (opening!.loc.start.line === node.loc.start.line)
         return
 
-      if (opening!.loc.start.column === node.loc.start.column)
+      if (
+        opening.loc.start.column === node.loc.start.column
+        && option === 'tag-aligned'
+      ) {
         return
+      }
+
+      if (
+        openingStartOfLine.column === node.loc.start.column
+        && option === 'line-aligned'
+      ) {
+        return
+      }
 
       const messageId = isNodeFirstInLine(context, node)
-        ? 'matchIndent'
+        ? MESSAGE_LOCATION[option as keyof typeof MESSAGE_LOCATION]
         : 'onOwnLine'
 
       context.report({
@@ -53,7 +114,7 @@ export default createRule<RuleOptions, MessageIds>({
         messageId,
         loc: node.loc,
         fix(fixer) {
-          const indent = new Array(opening.loc.start.column + 1).join(' ')
+          const indent = new Array(getIndentation(openingStartOfLine, opening) + 1).join(' ')
           if (isNodeFirstInLine(context, node)) {
             return fixer.replaceTextRange(
               [node.range[0] - node.loc.start.column, node.range[0]],

--- a/packages/eslint-plugin/rules/jsx-closing-tag-location/types.d.ts
+++ b/packages/eslint-plugin/rules/jsx-closing-tag-location/types.d.ts
@@ -1,8 +1,17 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: 1yaX7NnzFz */
+/* @checksum: vc2c5tYSE2 */
 
-export type JsxClosingTagLocationRuleOptions = []
+export type JsxClosingTagLocationSchema0 =
+  | 'tag-aligned'
+  | 'line-aligned'
+
+export type JsxClosingTagLocationRuleOptions = [
+  JsxClosingTagLocationSchema0?,
+]
 
 export type RuleOptions = JsxClosingTagLocationRuleOptions
-export type MessageIds = 'onOwnLine' | 'matchIndent'
+export type MessageIds =
+  | 'onOwnLine'
+  | 'matchIndent'
+  | 'alignWithOpening'


### PR DESCRIPTION
### Description

Add location option to customize indentation in the way of jsx-closing-bracket-location

### Linked Issues

### Additional context

Reproduction of https://github.com/jsx-eslint/eslint-plugin-react/pull/3777