### PR TITLE
feat: cross test `comma-spacing`

### DIFF
--- a/packages/eslint-plugin/rules/comma-spacing/comma-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/comma-spacing/comma-spacing._js_.test.ts
@@ -4,8 +4,7 @@
  */
 
 import { run } from '#test'
-// TODO: Stage 2: Test merged rule
-import rule from './comma-spacing._js_'
+import rule from '.'
 
 run({
   name: 'comma-spacing',

--- a/packages/eslint-plugin/rules/comma-spacing/comma-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/comma-spacing/comma-spacing._ts_.test.ts
@@ -411,19 +411,6 @@ run({
       ],
     },
     {
-      code: 'const arr = [1 , ];',
-      output: 'const arr = [1 ,];',
-      options: [{ before: true, after: false }],
-      errors: [
-        {
-          messageId: 'unexpected',
-          column: 16,
-          line: 1,
-          data: { loc: 'after' },
-        },
-      ],
-    },
-    {
       code: 'const arr = [1 ,2];',
       output: 'const arr = [1, 2];',
       errors: [

--- a/packages/eslint-plugin/rules/comma-spacing/comma-spacing._ts_.ts
+++ b/packages/eslint-plugin/rules/comma-spacing/comma-spacing._ts_.ts
@@ -1,4 +1,3 @@
-// TODO: Stage 2: Doesn't inherit js version
 import type { Tree } from '#types'
 
 import type { MessageIds, RuleOptions } from './types._ts_'

--- a/packages/eslint-plugin/rules/comma-spacing/comma-spacing._ts_.ts
+++ b/packages/eslint-plugin/rules/comma-spacing/comma-spacing._ts_.ts
@@ -126,23 +126,13 @@ export default createRule<RuleOptions, MessageIds>({
         })
       }
 
-      if (nextToken && isClosingParenToken(nextToken))
-        return
-
-      if (
-        spaceAfter
-        && nextToken
-        && (isClosingBraceToken(nextToken) || isClosingBracketToken(nextToken))
-      ) {
-        return
-      }
-
-      if (!spaceAfter && nextToken && nextToken.type === AST_TOKEN_TYPES.Line)
-        return
-
       if (
         nextToken
         && isTokenOnSameLine(commaToken, nextToken)
+        && !isClosingParenToken(nextToken) // controlled by space-in-parens
+        && !isClosingBracketToken(nextToken) // controlled by array-bracket-spacing
+        && !isClosingBraceToken(nextToken) // controlled by object-curly-spacing
+        && !(!spaceAfter && nextToken.type === AST_TOKEN_TYPES.Line)
         //  -- TODO - switch once our min ESLint version is 6.7.0
         && spaceAfter !== sourceCode.isSpaceBetweenTokens(commaToken, nextToken)
       ) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
I explored the rule's history and code comments to find the cause of the conflicting test cases for `comma-spacing`.

Changes:
- allow spacing between comma and closing bracket( ] )

Related links:
- https://github.com/typescript-eslint/typescript-eslint/pull/6938
- https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin/rules/comma-spacing/comma-spacing._js_.ts#L156
- https://eslint.style/rules/default/comma-spacing#rule-details

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
part of #482

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
