### PR TITLE
fix(jsx-closing-bracket-location): should not remove comment in jsx

### DIFF
--- a/packages/eslint-plugin/rules/jsx-closing-bracket-location/jsx-closing-bracket-location._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-closing-bracket-location/jsx-closing-bracket-location._jsx_.test.ts
@@ -35,6 +35,18 @@ run({
     },
     {
       code: `
+        <App
+          // comment
+        />
+      `,
+    },
+    {
+      code: `
+        <App /** comment */ />
+      `,
+    },
+    {
+      code: `
         <App foo />
       `,
     },
@@ -42,6 +54,14 @@ run({
       code: `
         <App
           foo
+        />
+      `,
+    },
+    {
+      code: `
+        <App
+          foo
+          // comment
         />
       `,
     },

--- a/packages/eslint-plugin/rules/jsx-closing-bracket-location/jsx-closing-bracket-location._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-closing-bracket-location/jsx-closing-bracket-location._jsx_.test.ts
@@ -1905,5 +1905,181 @@ run({
         },
       ],
     },
+    {
+      code: `
+        <input
+          // comment
+          type="text"
+          // comment
+          />
+      `,
+      output: `
+        <input
+          // comment
+          type="text"
+          // comment
+        />
+      `,
+      options: [{ location: 'tag-aligned' }],
+      errors: [
+        {
+          messageId: 'bracketLocation',
+          data: {
+            location: MESSAGE_TAG_ALIGNED,
+            details: details(9, false),
+          },
+          line: 6,
+          column: 11,
+        },
+      ],
+    },
+    {
+      code: `
+        <input
+          // comment
+          type="text"
+          /**
+           * 
+           * comment
+           * 
+           */
+          />
+      `,
+      output: `
+        <input
+          // comment
+          type="text"
+          /**
+           * 
+           * comment
+           * 
+           */
+        />
+      `,
+      options: [{ location: 'tag-aligned' }],
+      errors: [
+        {
+          messageId: 'bracketLocation',
+          data: {
+            location: MESSAGE_TAG_ALIGNED,
+            details: details(9, false),
+          },
+          line: 10,
+          column: 11,
+        },
+      ],
+    },
+    {
+      code: `
+        <input
+          // comment
+          type="text"
+
+        />
+      `,
+      output: `
+        <input
+          // comment
+          type="text"/>
+      `,
+      options: [{ location: 'after-props' }],
+      errors: [
+        {
+          messageId: 'bracketLocation',
+          data: {
+            location: MESSAGE_AFTER_PROPS,
+            details: '',
+          },
+          line: 6,
+          column: 9,
+        },
+      ],
+    },
+    {
+      code: `
+        <input
+          // comment
+          type="text"
+          // comment
+          />
+      `,
+      output: `
+        <input
+          // comment
+          type="text"
+          // comment
+        />
+      `,
+      options: [{ location: 'after-props' }],
+      errors: [
+        {
+          messageId: 'bracketLocation',
+          data: {
+            location: MESSAGE_LINE_ALIGNED,
+            details: details(9, false),
+          },
+          line: 6,
+          column: 11,
+        },
+      ],
+    },
+    {
+      code: `
+        <input
+          // comment
+          // comment
+          />
+      `,
+      output: `
+        <input
+          // comment
+          // comment
+        />
+      `,
+      options: [{ location: 'after-props' }],
+      errors: [
+        {
+          messageId: 'bracketLocation',
+          data: {
+            location: MESSAGE_LINE_ALIGNED,
+            details: details(9, false),
+          },
+          line: 5,
+          column: 11,
+        },
+      ],
+    },
+    {
+      code: `
+\t\t\t\t<a
+\t\t\t\t\thref="javascript:;"
+\t\t\t\t\t// comment
+\t\t\t\t\t// comment
+\t\t\t\t\t>
+\t\t\t\t\ttext
+\t\t\t\t</a>
+      `,
+      output: `
+\t\t\t\t<a
+\t\t\t\t\thref="javascript:;"
+\t\t\t\t\t// comment
+\t\t\t\t\t// comment
+\t\t\t\t>
+\t\t\t\t\ttext
+\t\t\t\t</a>
+      `,
+      options: [{ location: 'after-props' }],
+      errors: [
+        {
+          messageId: 'bracketLocation',
+          data: {
+            location: MESSAGE_LINE_ALIGNED,
+            details: details(5, false),
+          },
+          line: 6,
+          column: 6,
+        },
+      ],
+    },
   ),
 })

--- a/packages/eslint-plugin/rules/jsx-closing-bracket-location/jsx-closing-bracket-location._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-closing-bracket-location/jsx-closing-bracket-location._jsx_.test.ts
@@ -67,6 +67,21 @@ run({
     },
     {
       code: `
+        <App
+          {...foo}
+        />
+      `,
+    },
+    {
+      code: `
+        <App
+          {...foo}
+          // comment
+        />
+      `,
+    },
+    {
+      code: `
         <App foo />
       `,
       options: [{ location: 'after-props' }],


### PR DESCRIPTION
### Description

because attribute comments are different from jsx comments.  so when the last attribute line is a comment and closing tag should with last attribute at same line, expected location will change to 'line-aligned'

```jsx
// incorrect 'jsx-closing-bracket-location': [1, 'after-props']
  <input
    // comment
    type="text"
    // comment
    />
```

```jsx
// correct 'jsx-closing-bracket-location': [1, 'after-props']
  <input
    // comment
    type="text"
    // comment
  />
```

### Linked Issues

close #559 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
