### PR TITLE
feat(padding-line-between-statements): multiline/singleline-export

### DIFF
--- a/packages/eslint-plugin/rules/padding-line-between-statements/README._js_.md
+++ b/packages/eslint-plugin/rules/padding-line-between-statements/README._js_.md
@@ -75,11 +75,13 @@ You can supply any number of configurations. If a statement pair matches multipl
   - `"let"` is `let` variable declarations, both single-line and multiline.
   - `"multiline-block-like"` is block like statements. This is the same as `block-like` type, but only if the block is multiline.
   - `"multiline-const"` is multiline `const` variable declarations.
+  - `"multiline-export"` is multiline `export` declarations.
   - `"multiline-expression"` is expression statements. This is the same as `expression` type, but only if the statement is multiline.
   - `"multiline-let"` is multiline `let` variable declarations.
   - `"multiline-var"` is multiline `var` variable declarations.
   - `"return"` is `return` statements.
   - `"singleline-const"` is single-line `const` variable declarations.
+  - `"singleline-export"` is single-line `export` declarations.
   - `"singleline-let"` is single-line `let` variable declarations.
   - `"singleline-var"` is single-line `var` variable declarations.
   - `"switch"` is `switch` statements.

--- a/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements._js_.test.ts
+++ b/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements._js_.test.ts
@@ -2736,6 +2736,72 @@ run({
       ],
       parserOptions: { ecmaVersion: 2022 },
     },
+
+    // ----------------------------------------------------------------------
+    // multiline-export
+    // ----------------------------------------------------------------------
+
+    {
+      code: 'export const a={\nb:1,\nc:2\n}\n\nexport const d=3',
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'multiline-export', next: '*' },
+      ],
+    },
+    {
+      code: 'export const a=1\n\nexport const b={\nc:2,\nd:3\n}',
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: '*', next: 'multiline-export' },
+      ],
+    },
+    {
+      code: 'export const a=1\nexport const b=2',
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'multiline-export', next: '*' },
+      ],
+    },
+    {
+      code: 'export const a=1\nexport const b=2',
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: '*', next: 'multiline-export' },
+      ],
+    },
+
+    // ----------------------------------------------------------------------
+    // singleline-export
+    // ----------------------------------------------------------------------
+
+    {
+      code: 'export const a=1\n\nexport const b=2',
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'singleline-export', next: '*' },
+      ],
+    },
+    {
+      code: 'export const a=1\n\nexport const b=2',
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: '*', next: 'singleline-export' },
+      ],
+    },
+    {
+      code: 'export const a={\nb:1,\nc:2\n}\nexport const d={\ne:3,\nf:4\n}',
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'singleline-export', next: '*' },
+      ],
+    },
+    {
+      code: 'export const a={\nb:1,\nc:2\n}\nexport const d={\ne:3,\nf:4\n}',
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: '*', next: 'singleline-export' },
+      ],
+    },
   ],
   invalid: [
 
@@ -5207,6 +5273,64 @@ run({
         { blankLine: 'always', prev: 'expression', next: 'let' },
       ],
       parserOptions: { ecmaVersion: 2022 },
+      errors: [{ messageId: 'expectedBlankLine' }],
+    },
+
+    // ----------------------------------------------------------------------
+    // multiline-export
+    // ----------------------------------------------------------------------
+
+    {
+      code: 'export const a={\nb:1,\nc:2\n}\n\nexport const d=3',
+      output: 'export const a={\nb:1,\nc:2\n}\nexport const d=3',
+      options: [{ blankLine: 'never', prev: 'multiline-export', next: '*' }],
+      errors: [{ messageId: 'unexpectedBlankLine' }],
+    },
+    {
+      code: 'export const a={\nb:1,\nc:2\n}\nexport const d=3',
+      output: 'export const a={\nb:1,\nc:2\n}\n\nexport const d=3',
+      options: [{ blankLine: 'always', prev: 'multiline-export', next: '*' }],
+      errors: [{ messageId: 'expectedBlankLine' }],
+    },
+    {
+      code: 'export const a=1\n\nexport const b={\nc:2,\nd:3\n}',
+      output: 'export const a=1\nexport const b={\nc:2,\nd:3\n}',
+      options: [{ blankLine: 'never', prev: '*', next: 'multiline-export' }],
+      errors: [{ messageId: 'unexpectedBlankLine' }],
+    },
+    {
+      code: 'export const a=1\nexport const b={\nc:2,\nd:3\n}',
+      output: 'export const a=1\n\nexport const b={\nc:2,\nd:3\n}',
+      options: [{ blankLine: 'always', prev: '*', next: 'multiline-export' }],
+      errors: [{ messageId: 'expectedBlankLine' }],
+    },
+
+    // ----------------------------------------------------------------------
+    // singleline-export
+    // ----------------------------------------------------------------------
+
+    {
+      code: 'export const a=1\n\nexport const b=2',
+      output: 'export const a=1\nexport const b=2',
+      options: [{ blankLine: 'never', prev: 'singleline-export', next: '*' }],
+      errors: [{ messageId: 'unexpectedBlankLine' }],
+    },
+    {
+      code: 'export const a=1\nexport const b=2',
+      output: 'export const a=1\n\nexport const b=2',
+      options: [{ blankLine: 'always', prev: 'singleline-export', next: '*' }],
+      errors: [{ messageId: 'expectedBlankLine' }],
+    },
+    {
+      code: 'export const a=1\n\nexport const b=2',
+      output: 'export const a=1\nexport const b=2',
+      options: [{ blankLine: 'never', prev: '*', next: 'singleline-export' }],
+      errors: [{ messageId: 'unexpectedBlankLine' }],
+    },
+    {
+      code: 'export const a=1\nexport const b=2',
+      output: 'export const a=1\n\nexport const b=2',
+      options: [{ blankLine: 'always', prev: '*', next: 'singleline-export' }],
       errors: [{ messageId: 'expectedBlankLine' }],
     },
   ],

--- a/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements._js_.ts
+++ b/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements._js_.ts
@@ -327,9 +327,11 @@ const StatementTypes = {
   },
 
   'multiline-const': newMultilineKeywordTester('const'),
+  'multiline-export': newMultilineKeywordTester('export'),
   'multiline-let': newMultilineKeywordTester('let'),
   'multiline-var': newMultilineKeywordTester('var'),
   'singleline-const': newSinglelineKeywordTester('const'),
+  'singleline-export': newSinglelineKeywordTester('export'),
   'singleline-let': newSinglelineKeywordTester('let'),
   'singleline-var': newSinglelineKeywordTester('var'),
 

--- a/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements._ts_.test.ts
+++ b/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements._ts_.test.ts
@@ -2853,6 +2853,72 @@ run({
         },
       ],
     },
+
+    // ----------------------------------------------------------------------
+    // multiline-export
+    // ----------------------------------------------------------------------
+
+    {
+      code: 'export const a={\nb:1,\nc:2\n}\n\nexport const d=3',
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'multiline-export', next: '*' },
+      ],
+    },
+    {
+      code: 'export const a=1\n\nexport const b={\nc:2,\nd:3\n}',
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: '*', next: 'multiline-export' },
+      ],
+    },
+    {
+      code: 'export const a=1\nexport const b=2',
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'multiline-export', next: '*' },
+      ],
+    },
+    {
+      code: 'export const a=1\nexport const b=2',
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: '*', next: 'multiline-export' },
+      ],
+    },
+
+    // ----------------------------------------------------------------------
+    // singleline-export
+    // ----------------------------------------------------------------------
+
+    {
+      code: 'export const a=1\n\nexport const b=2',
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'singleline-export', next: '*' },
+      ],
+    },
+    {
+      code: 'export const a=1\n\nexport const b=2',
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: '*', next: 'singleline-export' },
+      ],
+    },
+    {
+      code: 'export const a={\nb:1,\nc:2\n}\nexport const d={\ne:3,\nf:4\n}',
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'singleline-export', next: '*' },
+      ],
+    },
+    {
+      code: 'export const a={\nb:1,\nc:2\n}\nexport const d={\ne:3,\nf:4\n}',
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: '*', next: 'singleline-export' },
+      ],
+    },
   ],
   invalid: [
     // ----------------------------------------------------------------------
@@ -5221,6 +5287,64 @@ run({
         type Foo = {\na(): string;\n\nb(): number;\n\nc(): boolean;\n\nd(): string;\n}
       `,
       options: [{ blankLine: 'always', prev: 'ts-method', next: '*' }],
+      errors: [{ messageId: 'expectedBlankLine' }],
+    },
+
+    // ----------------------------------------------------------------------
+    // multiline-export
+    // ----------------------------------------------------------------------
+
+    {
+      code: 'export const a={\nb:1,\nc:2\n}\n\nexport const d=3',
+      output: 'export const a={\nb:1,\nc:2\n}\nexport const d=3',
+      options: [{ blankLine: 'never', prev: 'multiline-export', next: '*' }],
+      errors: [{ messageId: 'unexpectedBlankLine' }],
+    },
+    {
+      code: 'export const a={\nb:1,\nc:2\n}\nexport const d=3',
+      output: 'export const a={\nb:1,\nc:2\n}\n\nexport const d=3',
+      options: [{ blankLine: 'always', prev: 'multiline-export', next: '*' }],
+      errors: [{ messageId: 'expectedBlankLine' }],
+    },
+    {
+      code: 'export const a=1\n\nexport const b={\nc:2,\nd:3\n}',
+      output: 'export const a=1\nexport const b={\nc:2,\nd:3\n}',
+      options: [{ blankLine: 'never', prev: '*', next: 'multiline-export' }],
+      errors: [{ messageId: 'unexpectedBlankLine' }],
+    },
+    {
+      code: 'export const a=1\nexport const b={\nc:2,\nd:3\n}',
+      output: 'export const a=1\n\nexport const b={\nc:2,\nd:3\n}',
+      options: [{ blankLine: 'always', prev: '*', next: 'multiline-export' }],
+      errors: [{ messageId: 'expectedBlankLine' }],
+    },
+
+    // ----------------------------------------------------------------------
+    // singleline-export
+    // ----------------------------------------------------------------------
+
+    {
+      code: 'export const a=1\n\nexport const b=2',
+      output: 'export const a=1\nexport const b=2',
+      options: [{ blankLine: 'never', prev: 'singleline-export', next: '*' }],
+      errors: [{ messageId: 'unexpectedBlankLine' }],
+    },
+    {
+      code: 'export const a=1\nexport const b=2',
+      output: 'export const a=1\n\nexport const b=2',
+      options: [{ blankLine: 'always', prev: 'singleline-export', next: '*' }],
+      errors: [{ messageId: 'expectedBlankLine' }],
+    },
+    {
+      code: 'export const a=1\n\nexport const b=2',
+      output: 'export const a=1\nexport const b=2',
+      options: [{ blankLine: 'never', prev: '*', next: 'singleline-export' }],
+      errors: [{ messageId: 'unexpectedBlankLine' }],
+    },
+    {
+      code: 'export const a=1\nexport const b=2',
+      output: 'export const a=1\n\nexport const b=2',
+      options: [{ blankLine: 'always', prev: '*', next: 'singleline-export' }],
       errors: [{ messageId: 'expectedBlankLine' }],
     },
   ],

--- a/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements._ts_.ts
+++ b/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements._ts_.ts
@@ -525,9 +525,11 @@ const StatementTypes: Record<string, NodeTestObject> = {
   },
 
   'multiline-const': newMultilineKeywordTester('const'),
+  'multiline-export': newMultilineKeywordTester('export'),
   'multiline-let': newMultilineKeywordTester('let'),
   'multiline-var': newMultilineKeywordTester('var'),
   'singleline-const': newSinglelineKeywordTester('const'),
+  'singleline-export': newSinglelineKeywordTester('export'),
   'singleline-let': newSinglelineKeywordTester('let'),
   'singleline-var': newSinglelineKeywordTester('var'),
 

--- a/packages/eslint-plugin/rules/padding-line-between-statements/types._js_.d.ts
+++ b/packages/eslint-plugin/rules/padding-line-between-statements/types._js_.d.ts
@@ -1,6 +1,6 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: q3zlDRuHLM */
+/* @checksum: vGPSwm65IQ */
 
 export type PaddingType = 'any' | 'never' | 'always'
 export type StatementType =
@@ -15,9 +15,11 @@ export type StatementType =
     | 'multiline-block-like'
     | 'multiline-expression'
     | 'multiline-const'
+    | 'multiline-export'
     | 'multiline-let'
     | 'multiline-var'
     | 'singleline-const'
+    | 'singleline-export'
     | 'singleline-let'
     | 'singleline-var'
     | 'block'
@@ -56,9 +58,11 @@ export type StatementType =
         | 'multiline-block-like'
         | 'multiline-expression'
         | 'multiline-const'
+        | 'multiline-export'
         | 'multiline-let'
         | 'multiline-var'
         | 'singleline-const'
+        | 'singleline-export'
         | 'singleline-let'
         | 'singleline-var'
         | 'block'
@@ -96,9 +100,11 @@ export type StatementType =
         | 'multiline-block-like'
         | 'multiline-expression'
         | 'multiline-const'
+        | 'multiline-export'
         | 'multiline-let'
         | 'multiline-var'
         | 'singleline-const'
+        | 'singleline-export'
         | 'singleline-let'
         | 'singleline-var'
         | 'block'

--- a/packages/eslint-plugin/rules/padding-line-between-statements/types._ts_.d.ts
+++ b/packages/eslint-plugin/rules/padding-line-between-statements/types._ts_.d.ts
@@ -1,6 +1,6 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: 6uKu5Yp4W2 */
+/* @checksum: dpKjh9VDsc */
 
 export type PaddingType = 'any' | 'never' | 'always'
 export type StatementType =
@@ -15,9 +15,11 @@ export type StatementType =
     | 'multiline-block-like'
     | 'multiline-expression'
     | 'multiline-const'
+    | 'multiline-export'
     | 'multiline-let'
     | 'multiline-var'
     | 'singleline-const'
+    | 'singleline-export'
     | 'singleline-let'
     | 'singleline-var'
     | 'block'
@@ -63,9 +65,11 @@ export type StatementType =
         | 'multiline-block-like'
         | 'multiline-expression'
         | 'multiline-const'
+        | 'multiline-export'
         | 'multiline-let'
         | 'multiline-var'
         | 'singleline-const'
+        | 'singleline-export'
         | 'singleline-let'
         | 'singleline-var'
         | 'block'
@@ -110,9 +114,11 @@ export type StatementType =
         | 'multiline-block-like'
         | 'multiline-expression'
         | 'multiline-const'
+        | 'multiline-export'
         | 'multiline-let'
         | 'multiline-var'
         | 'singleline-const'
+        | 'singleline-export'
         | 'singleline-let'
         | 'singleline-var'
         | 'block'

--- a/packages/eslint-plugin/rules/padding-line-between-statements/types.d.ts
+++ b/packages/eslint-plugin/rules/padding-line-between-statements/types.d.ts
@@ -1,6 +1,6 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: 6uKu5Yp4W2 */
+/* @checksum: dpKjh9VDsc */
 
 export type PaddingType = 'any' | 'never' | 'always'
 export type StatementType =
@@ -15,9 +15,11 @@ export type StatementType =
     | 'multiline-block-like'
     | 'multiline-expression'
     | 'multiline-const'
+    | 'multiline-export'
     | 'multiline-let'
     | 'multiline-var'
     | 'singleline-const'
+    | 'singleline-export'
     | 'singleline-let'
     | 'singleline-var'
     | 'block'
@@ -63,9 +65,11 @@ export type StatementType =
         | 'multiline-block-like'
         | 'multiline-expression'
         | 'multiline-const'
+        | 'multiline-export'
         | 'multiline-let'
         | 'multiline-var'
         | 'singleline-const'
+        | 'singleline-export'
         | 'singleline-let'
         | 'singleline-var'
         | 'block'
@@ -110,9 +114,11 @@ export type StatementType =
         | 'multiline-block-like'
         | 'multiline-expression'
         | 'multiline-const'
+        | 'multiline-export'
         | 'multiline-let'
         | 'multiline-var'
         | 'singleline-const'
+        | 'singleline-export'
         | 'singleline-let'
         | 'singleline-var'
         | 'block'


### PR DESCRIPTION
### Description

Add support for  `multiline-export` and `singleline-export` to help force newlines just between exported interfaces or types like the example below.

```
export { getCategoryId } from './getCategoryId';
export { getVideoId } from './getVideoId';
export { logDeepLinkLaunchWithCommand } from './logger';

export interface Foo {
    foo: number;
}

export interface Bar {
    bar: number;
}

export const CLIENT = 'client';
export const STARTUP = 'startup';
export const FOO = 'foo';
export const HELLO = 'hello';
```

### Additional context

See discussion started in https://github.com/eslint-stylistic/eslint-stylistic/discussions/580 
