### PR TITLE
feat(no-multi-spaces): add `ImportAttribute` node type to default `exceptions` option

### DIFF
--- a/packages/eslint-plugin/rules/no-multi-spaces/README._js_.md
+++ b/packages/eslint-plugin/rules/no-multi-spaces/README._js_.md
@@ -78,7 +78,7 @@ a ? b: c
 This rule's configuration consists of an object with the following properties:
 
 - `"ignoreEOLComments": true` (defaults to `false`) ignores multiple spaces before comments that occur at the end of lines
-- `"exceptions": { "Property": true }` (`"Property"` is the only node specified by default) specifies nodes to ignore
+- `"exceptions": { "Property": true, "ImportAttribute": true }` (`"Property"` and `"ImportAttribute"` are the nodes specified by default) specifies nodes to ignore
 - `"includeTabs": false` (defaults to `true`) consider multiple tabs or spaces mixed with tabs as multiple spaces
 
 ### ignoreEOLComments
@@ -138,9 +138,9 @@ To avoid contradictions with other rules that require multiple spaces, this rule
 
 This option is an object that expects property names to be AST node types as defined by [ESTree](https://github.com/estree/estree). The easiest way to determine the node types for `exceptions` is to use [AST Explorer](https://astexplorer.net/) with the espree parser.
 
-Only the `Property` node type is ignored by default, because for the [key-spacing](key-spacing) rule some alignment options require multiple spaces in properties of object literals.
+The `Property` and `ImportAttribute` node types are ignored by default, because for the [key-spacing](key-spacing) rule some alignment options require multiple spaces in properties of object literals and import attributes.
 
-Examples of **correct** code for the default `"exceptions": { "Property": true }` option:
+Examples of **correct** code for the default `"exceptions": { "Property": true, "ImportAttribute": true }` option:
 
 ::: correct
 

--- a/packages/eslint-plugin/rules/no-multi-spaces/no-multi-spaces._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-multi-spaces/no-multi-spaces._js_.test.ts
@@ -688,5 +688,28 @@ run({
         type: 'Identifier',
       }],
     },
+    {
+      code: 'import foo from "./foo" with  { type:  "json" }',
+      output: 'import foo from "./foo" with { type:  "json" }',
+      errors: [{
+        messageId: 'multipleSpaces',
+        data: { displayValue: '{' },
+      }],
+    },
+    {
+      code: 'import foo from "./foo" with  { type:  "json" }',
+      output: 'import foo from "./foo" with { type: "json" }',
+      options: [{ exceptions: { ImportAttribute: false } }],
+      errors: [
+        {
+          messageId: 'multipleSpaces',
+          data: { displayValue: '{' },
+        },
+        {
+          messageId: 'multipleSpaces',
+          data: { displayValue: '"json"' },
+        },
+      ],
+    },
   ],
 })

--- a/packages/eslint-plugin/rules/no-multi-spaces/no-multi-spaces._js_.ts
+++ b/packages/eslint-plugin/rules/no-multi-spaces/no-multi-spaces._js_.ts
@@ -55,7 +55,7 @@ export default createRule<RuleOptions, MessageIds>({
     const sourceCode = context.sourceCode
     const options = context.options[0] || {}
     const ignoreEOLComments = options.ignoreEOLComments
-    const exceptions = Object.assign({ Property: true }, options.exceptions)
+    const exceptions = Object.assign({ Property: true, ImportAttribute: true }, options.exceptions)
     const hasExceptions = Object.keys(exceptions).some(key => exceptions[key])
 
     const spacesRe = options.includeTabs === false ? / {2}/ : /[ \t]{2}/


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR modifies the `no-multi-spaces` rule to add support for import attributes.
Adds the `ImportAttribute` node type to the default `exceptions` option.
The reason for adding it is to avoid conflicts with the `key-spacing` rule, just like with `Property`.

### Linked Issues

#578

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
