### PR TITLE
feat(comma-dangle): add support for Import Attributes

### DIFF
--- a/packages/eslint-plugin/rules/comma-dangle/README._js_.md
+++ b/packages/eslint-plugin/rules/comma-dangle/README._js_.md
@@ -53,7 +53,9 @@ This rule has a string option or an object option:
         "objects": "never",
         "imports": "never",
         "exports": "never",
-        "functions": "never"
+        "functions": "never",
+        "importAttributes": "never",
+        "dynamicImports": "never"
     }]
 }
 ```
@@ -73,6 +75,9 @@ The default for each option is `"never"` unless otherwise specified.
 - `exports` is for export declarations of ES Modules. (e.g. `export {a,};`)
 - `functions` is for function declarations and function calls. (e.g. `(function(a,){ })(b,);`)
   - `functions` should only be enabled when linting ECMAScript 2017 or higher.
+- `importAttributes` is for import attributes. (e.g. `import foo from "foo" with { type: "json", };`)
+- `dynamicImports` is for dynamic import calls. (e.g. `import(a,);`)
+  - `dynamicImports` should only be enabled when linting ECMAScript 2025 or higher.
 
 ### never
 

--- a/packages/eslint-plugin/rules/comma-dangle/comma-dangle._js_.test.ts
+++ b/packages/eslint-plugin/rules/comma-dangle/comma-dangle._js_.test.ts
@@ -504,6 +504,245 @@ run({
 
     // https://github.com/eslint-stylistic/eslint-stylistic/issues/158
     { code: 'a => 42;', options: ['always'], parserOptions: { ecmaVersion: 'latest' } },
+
+    // dynamic import
+    {
+      code: 'import(source)',
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import(source, )',
+      options: ['always'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import(source, options, )',
+      options: ['always'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import(source)',
+      options: ['always'],
+      parserOptions: { ecmaVersion: 15 },
+    },
+    {
+      code: 'import(source,)',
+      options: ['always'],
+      parserOptions: { ecmaVersion: 16 },
+    },
+    {
+      code: 'import(source)',
+      options: ['never'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import(source, options)',
+      options: ['never'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import(source)',
+      options: ['always-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import(source, options)',
+      options: ['always-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: $`
+        import(
+          source,
+        )
+      `,
+      options: ['always-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: $`
+        import(
+          source,
+          options,
+        )
+      `,
+      options: ['always-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import(source)',
+      options: ['only-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import(source, options)',
+      options: ['only-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: $`
+        import(
+          source,
+        )
+      `,
+      options: ['only-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: $`
+        import(
+          source
+        )
+      `,
+      options: ['only-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: $`
+        import(
+          source,
+          options,
+        )
+      `,
+      options: ['only-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: $`
+        import(
+          source,
+          options
+        )
+      `,
+      options: ['only-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import(source)',
+      options: { functions: 'always' },
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import(source,)',
+      options: { functions: 'never', dynamicImports: 'always' },
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+
+    // import attributes
+    {
+      code: 'import foo from "foo" with {type: "json"}',
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import foo from "foo" with {type: "json",}',
+      options: ['always'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import foo from "foo" with {type: "json"}',
+      options: ['never'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import foo from "foo" with {type: "json"}',
+      options: ['always-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: $`
+        import foo from "foo" with {
+          type: "json",
+        }
+      `,
+      options: ['always-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import foo from "foo" with {type: "json"}',
+      options: ['only-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import foo from "foo" with {type: "json",}',
+      options: { functions: 'never', importAttributes: 'always' },
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export {foo} from "foo" with {type: "json"}',
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export {foo,} from "foo" with {type: "json",}',
+      options: ['always'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export {foo} from "foo" with {type: "json"}',
+      options: ['never'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export {foo} from "foo" with {type: "json"}',
+      options: ['always-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: $`
+        export {foo} from "foo" with {
+          type: "json",
+        }
+      `,
+      options: ['always-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export {foo} from "foo" with {type: "json"}',
+      options: ['only-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export {foo} from "foo" with {type: "json",}',
+      options: { functions: 'never', importAttributes: 'always' },
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export * from "foo" with {type: "json"}',
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export * from "foo" with {type: "json",}',
+      options: ['always'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export * from "foo" with {type: "json"}',
+      options: ['never'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export * from "foo" with {type: "json"}',
+      options: ['always-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: $`
+        export * from "foo" with {
+          type: "json",
+        }
+      `,
+      options: ['always-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export * from "foo" with {type: "json"}',
+      options: ['only-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export * from "foo" with {type: "json",}',
+      options: { functions: 'never', importAttributes: 'always' },
+      parserOptions: { ecmaVersion: 'latest' },
+    },
   ],
   invalid: [
     {
@@ -1849,6 +2088,246 @@ run({
       `,
       options: [{ imports: 'never' }],
       errors: 2,
+    },
+
+    // dynamic import
+    {
+      code: 'import(source,)',
+      output: 'import(source)',
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import(source)',
+      output: 'import(source,)',
+      options: ['always'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import(source, options)',
+      output: 'import(source, options,)',
+      options: ['always'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import(source,)',
+      output: 'import(source)',
+      options: ['never'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import(source, options,)',
+      output: 'import(source, options)',
+      options: ['never'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import(source,)',
+      output: 'import(source)',
+      options: ['always-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import(source, options,)',
+      output: 'import(source, options)',
+      options: ['always-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: $`
+        import(
+          source
+        )
+      `,
+      output: $`
+        import(
+          source,
+        )
+      `,
+      options: ['always-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: $`
+        import(
+          source,
+          options
+        )
+      `,
+      output: $`
+        import(
+          source,
+          options,
+        )
+      `,
+      options: ['always-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import(source,)',
+      output: 'import(source)',
+      options: ['only-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import(source, options,)',
+      output: 'import(source, options)',
+      options: ['only-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import(source)',
+      output: 'import(source,)',
+      options: { functions: 'never', dynamicImports: 'always' },
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+
+    // import attributes
+    {
+      code: 'import foo from "foo" with {type: "json",}',
+      output: 'import foo from "foo" with {type: "json"}',
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import foo from "foo" with {type: "json"}',
+      output: 'import foo from "foo" with {type: "json",}',
+      options: ['always'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import foo from "foo" with {type: "json",}',
+      output: 'import foo from "foo" with {type: "json"}',
+      options: ['never'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import foo from "foo" with {type: "json",}',
+      output: 'import foo from "foo" with {type: "json"}',
+      options: ['always-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: $`
+        import foo from "foo" with {
+          type: "json"
+        }
+      `,
+      output: $`
+        import foo from "foo" with {
+          type: "json",
+        }
+      `,
+      options: ['always-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import foo from "foo" with {type: "json",}',
+      output: 'import foo from "foo" with {type: "json"}',
+      options: ['only-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'import foo from "foo" with {type: "json"}',
+      output: 'import foo from "foo" with {type: "json",}',
+      options: { functions: 'never', importAttributes: 'always' },
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export {foo} from "foo" with {type: "json",}',
+      output: 'export {foo} from "foo" with {type: "json"}',
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export {foo} from "foo" with {type: "json"}',
+      output: 'export {foo,} from "foo" with {type: "json",}',
+      options: ['always'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export {foo} from "foo" with {type: "json",}',
+      output: 'export {foo} from "foo" with {type: "json"}',
+      options: ['never'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export {foo} from "foo" with {type: "json",}',
+      output: 'export {foo} from "foo" with {type: "json"}',
+      options: ['always-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: $`
+        export {foo} from "foo" with {
+          type: "json"
+        }
+      `,
+      output: $`
+        export {foo} from "foo" with {
+          type: "json",
+        }
+      `,
+      options: ['always-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export {foo} from "foo" with {type: "json",}',
+      output: 'export {foo} from "foo" with {type: "json"}',
+      options: ['only-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export {foo} from "foo" with {type: "json"}',
+      output: 'export {foo} from "foo" with {type: "json",}',
+      options: { functions: 'never', importAttributes: 'always' },
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export * from "foo" with {type: "json",}',
+      output: 'export * from "foo" with {type: "json"}',
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export * from "foo" with {type: "json"}',
+      output: 'export * from "foo" with {type: "json",}',
+      options: ['always'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export * from "foo" with {type: "json",}',
+      output: 'export * from "foo" with {type: "json"}',
+      options: ['never'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export * from "foo" with {type: "json",}',
+      output: 'export * from "foo" with {type: "json"}',
+      options: ['always-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: $`
+        export * from "foo" with {
+          type: "json"
+        }
+      `,
+      output: $`
+        export * from "foo" with {
+          type: "json",
+        }
+      `,
+      options: ['always-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export * from "foo" with {type: "json",}',
+      output: 'export * from "foo" with {type: "json"}',
+      options: ['only-multiline'],
+      parserOptions: { ecmaVersion: 'latest' },
+    },
+    {
+      code: 'export * from "foo" with {type: "json"}',
+      output: 'export * from "foo" with {type: "json",}',
+      options: { functions: 'never', importAttributes: 'always' },
+      parserOptions: { ecmaVersion: 'latest' },
     },
   ],
 })

--- a/packages/eslint-plugin/rules/comma-dangle/comma-dangle._ts_.ts
+++ b/packages/eslint-plugin/rules/comma-dangle/comma-dangle._ts_.ts
@@ -71,6 +71,8 @@ export default createRule<RuleOptions, MessageIds>({
                 imports: { $ref: '#/$defs/valueWithIgnore' },
                 exports: { $ref: '#/$defs/valueWithIgnore' },
                 functions: { $ref: '#/$defs/valueWithIgnore' },
+                importAttributes: { $ref: '#/$defs/valueWithIgnore' },
+                dynamicImports: { $ref: '#/$defs/valueWithIgnore' },
                 enums: { $ref: '#/$defs/valueWithIgnore' },
                 generics: { $ref: '#/$defs/valueWithIgnore' },
                 tuples: { $ref: '#/$defs/valueWithIgnore' },

--- a/packages/eslint-plugin/rules/comma-dangle/types._js_.d.ts
+++ b/packages/eslint-plugin/rules/comma-dangle/types._js_.d.ts
@@ -1,6 +1,6 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: e0uyhpKPCy */
+/* @checksum: p0irYE8sXQ */
 
 export type CommaDangleSchema0 =
   | []
@@ -12,6 +12,8 @@ export type CommaDangleSchema0 =
       imports?: ValueWithIgnore
       exports?: ValueWithIgnore
       functions?: ValueWithIgnore
+      importAttributes?: ValueWithIgnore
+      dynamicImports?: ValueWithIgnore
     },
   ]
 export type Value =

--- a/packages/eslint-plugin/rules/comma-dangle/types._ts_.d.ts
+++ b/packages/eslint-plugin/rules/comma-dangle/types._ts_.d.ts
@@ -1,6 +1,6 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: 8G2lkeIQnJ */
+/* @checksum: 52pw4JcDlk */
 
 export type CommaDangleSchema0 =
   | []
@@ -12,6 +12,8 @@ export type CommaDangleSchema0 =
       imports?: ValueWithIgnore
       exports?: ValueWithIgnore
       functions?: ValueWithIgnore
+      importAttributes?: ValueWithIgnore
+      dynamicImports?: ValueWithIgnore
       enums?: ValueWithIgnore
       generics?: ValueWithIgnore
       tuples?: ValueWithIgnore

--- a/packages/eslint-plugin/rules/comma-dangle/types.d.ts
+++ b/packages/eslint-plugin/rules/comma-dangle/types.d.ts
@@ -1,6 +1,6 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: 8G2lkeIQnJ */
+/* @checksum: 52pw4JcDlk */
 
 export type CommaDangleSchema0 =
   | []
@@ -12,6 +12,8 @@ export type CommaDangleSchema0 =
       imports?: ValueWithIgnore
       exports?: ValueWithIgnore
       functions?: ValueWithIgnore
+      importAttributes?: ValueWithIgnore
+      dynamicImports?: ValueWithIgnore
       enums?: ValueWithIgnore
       generics?: ValueWithIgnore
       tuples?: ValueWithIgnore

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ catalogs:
       specifier: ^7.5.8
       version: 7.5.8
     '@typescript-eslint/parser':
-      specifier: ^8.12.2
-      version: 8.12.2
+      specifier: ^8.13.0
+      version: 8.13.0
     '@unocss/reset':
       specifier: ^0.63.6
       version: 0.63.6
@@ -215,7 +215,7 @@ catalogs:
       version: 1.4.2
 
 overrides:
-  '@typescript-eslint/utils': ^8.12.2
+  '@typescript-eslint/utils': ^8.13.0
   rollup: ^4.24.3
   twoslash-eslint: ^0.2.12
   unbuild: ^2.0.0
@@ -230,7 +230,7 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: 'catalog:'
-        version: 3.8.0(@typescript-eslint/utils@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(@vue/compiler-sfc@3.5.12)(eslint-plugin-format@0.1.2(eslint@9.13.0(jiti@2.3.3)))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)(vitest@2.1.4)
+        version: 3.8.0(@typescript-eslint/utils@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(@vue/compiler-sfc@3.5.12)(eslint-plugin-format@0.1.2(eslint@9.13.0(jiti@2.3.3)))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)(vitest@2.1.4)
       '@antfu/eslint-define-config':
         specifier: 'catalog:'
         version: 1.23.0-2
@@ -317,10 +317,10 @@ importers:
         version: 7.5.8
       '@typescript-eslint/parser':
         specifier: 'catalog:'
-        version: 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+        version: 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
       '@typescript-eslint/utils':
-        specifier: ^8.12.2
-        version: 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+        specifier: ^8.13.0
+        version: 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 2.1.4(vitest@2.1.4)
@@ -488,8 +488,8 @@ importers:
   packages/eslint-plugin:
     dependencies:
       '@typescript-eslint/utils':
-        specifier: ^8.12.2
-        version: 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+        specifier: ^8.13.0
+        version: 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
       eslint:
         specifier: '>=8.40.0'
         version: 9.13.0(jiti@2.3.3)
@@ -542,8 +542,8 @@ importers:
         specifier: workspace:*
         version: link:../metadata
       '@typescript-eslint/utils':
-        specifier: ^8.12.2
-        version: 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+        specifier: ^8.13.0
+        version: 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
 
   packages/eslint-plugin-plus:
     dependencies:
@@ -554,8 +554,8 @@ importers:
   packages/eslint-plugin-ts:
     dependencies:
       '@typescript-eslint/utils':
-        specifier: ^8.12.2
-        version: 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+        specifier: ^8.13.0
+        version: 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
       eslint:
         specifier: '>=8.40.0'
         version: 9.13.0(jiti@2.3.3)
@@ -1718,8 +1718,8 @@ packages:
   '@types/web-bluetooth@0.0.20':
     resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==}
 
-  '@typescript-eslint/eslint-plugin@8.11.0':
-    resolution: {integrity: sha512-KhGn2LjW1PJT2A/GfDpiyOfS4a8xHQv2myUagTM5+zsormOmBlYsnQ6pobJ8XxJmh6hnHwa2Mbe3fPrDJoDhbA==}
+  '@typescript-eslint/eslint-plugin@8.13.0':
+    resolution: {integrity: sha512-nQtBLiZYMUPkclSeC3id+x4uVd1SGtHuElTxL++SfP47jR0zfkZBJHc+gL4qPsgTuypz0k8Y2GheaDYn6Gy3rg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
@@ -1729,8 +1729,8 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/parser@8.12.2':
-    resolution: {integrity: sha512-MrvlXNfGPLH3Z+r7Tk+Z5moZAc0dzdVjTgUgwsdGweH7lydysQsnSww3nAmsq8blFuRD5VRlAr9YdEFw3e6PBw==}
+  '@typescript-eslint/parser@8.13.0':
+    resolution: {integrity: sha512-w0xp+xGg8u/nONcGw1UXAr6cjCPU1w0XVyBs6Zqaj5eLmxkKQAByTdV/uGgNN5tVvN/kKpoQlP2cL7R+ajZZIQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -1739,16 +1739,12 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/scope-manager@8.11.0':
-    resolution: {integrity: sha512-Uholz7tWhXmA4r6epo+vaeV7yjdKy5QFCERMjs1kMVsLRKIrSdM6o21W2He9ftp5PP6aWOVpD5zvrvuHZC0bMQ==}
+  '@typescript-eslint/scope-manager@8.13.0':
+    resolution: {integrity: sha512-XsGWww0odcUT0gJoBZ1DeulY1+jkaHUciUq4jKNv4cpInbvvrtDoyBH9rE/n2V29wQJPk8iCH1wipra9BhmiMA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/scope-manager@8.12.2':
-    resolution: {integrity: sha512-gPLpLtrj9aMHOvxJkSbDBmbRuYdtiEbnvO25bCMza3DhMjTQw0u7Y1M+YR5JPbMsXXnSPuCf5hfq0nEkQDL/JQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/type-utils@8.11.0':
-    resolution: {integrity: sha512-ItiMfJS6pQU0NIKAaybBKkuVzo6IdnAhPFZA/2Mba/uBjuPQPet/8+zh5GtLHwmuFRShZx+8lhIs7/QeDHflOg==}
+  '@typescript-eslint/type-utils@8.13.0':
+    resolution: {integrity: sha512-Rqnn6xXTR316fP4D2pohZenJnp+NwQ1mo7/JM+J1LWZENSLkJI8ID8QNtlvFeb0HnFSK94D6q0cnMX6SbE5/vA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '*'
@@ -1756,16 +1752,12 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/types@8.11.0':
-    resolution: {integrity: sha512-tn6sNMHf6EBAYMvmPUaKaVeYvhUsrE6x+bXQTxjQRp360h1giATU0WvgeEys1spbvb5R+VpNOZ+XJmjD8wOUHw==}
+  '@typescript-eslint/types@8.13.0':
+    resolution: {integrity: sha512-4cyFErJetFLckcThRUFdReWJjVsPCqyBlJTi6IDEpc1GWCIIZRFxVppjWLIMcQhNGhdWJJRYFHpHoDWvMlDzng==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.12.2':
-    resolution: {integrity: sha512-VwDwMF1SZ7wPBUZwmMdnDJ6sIFk4K4s+ALKLP6aIQsISkPv8jhiw65sAK6SuWODN/ix+m+HgbYDkH+zLjrzvOA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.11.0':
-    resolution: {integrity: sha512-yHC3s1z1RCHoCz5t06gf7jH24rr3vns08XXhfEqzYpd6Hll3z/3g23JRi0jM8A47UFKNc3u/y5KIMx8Ynbjohg==}
+  '@typescript-eslint/typescript-estree@8.13.0':
+    resolution: {integrity: sha512-v7SCIGmVsRK2Cy/LTLGN22uea6SaUIlpBcO/gnMGT/7zPtxp90bphcGf4fyrCQl3ZtiBKqVTG32hb668oIYy1g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '*'
@@ -1773,27 +1765,14 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/typescript-estree@8.12.2':
-    resolution: {integrity: sha512-mME5MDwGe30Pq9zKPvyduyU86PH7aixwqYR2grTglAdB+AN8xXQ1vFGpYaUSJ5o5P/5znsSBeNcs5g5/2aQwow==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@typescript-eslint/utils@8.12.2':
-    resolution: {integrity: sha512-UTTuDIX3fkfAz6iSVa5rTuSfWIYZ6ATtEocQ/umkRSyC9O919lbZ8dcH7mysshrCdrAM03skJOEYaBugxN+M6A==}
+  '@typescript-eslint/utils@8.13.0':
+    resolution: {integrity: sha512-A1EeYOND6Uv250nybnLZapeXpYMl8tkzYUxqmoKAWnI4sei3ihf2XdZVd+vVOmHGcp3t+P7yRrNsyyiXTvShFQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
 
-  '@typescript-eslint/visitor-keys@8.11.0':
-    resolution: {integrity: sha512-EaewX6lxSjRJnc+99+dqzTeoDZUfyrA52d2/HRrkI830kgovWsmIiTfmr0NZorzqic7ga+1bS60lRBUgR3n/Bw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/visitor-keys@8.12.2':
-    resolution: {integrity: sha512-PChz8UaKQAVNHghsHcPyx1OMHoFRUEA7rJSK/mDhdq85bk+PLsUHUBqTQTFt18VJZbmxBovM65fezlheQRsSDA==}
+  '@typescript-eslint/visitor-keys@8.13.0':
+    resolution: {integrity: sha512-7N/+lztJqH4Mrf0lb10R/CbI1EaAMMGyF5y0oJvFoAhafwgiRA7TXyd8TFn8FC8k5y2dTsYogg238qavRGNnlw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript/vfs@1.6.0':
@@ -1903,8 +1882,8 @@ packages:
   '@vitest/eslint-plugin@1.1.7':
     resolution: {integrity: sha512-pTWGW3y6lH2ukCuuffpan6kFxG6nIuoesbhMiQxskyQMRcCN5t9SXsKrNHvEw3p8wcCsgJoRqFZVkOTn6TjclA==}
     peerDependencies:
-      '@typescript-eslint/utils': ^8.12.2
-      eslint: ^9.12.0
+      '@typescript-eslint/utils': ^8.13.0
+      eslint: '>= 8.57.0'
       typescript: '>= 5.0.0'
       vitest: ^2.1.4
     peerDependenciesMeta:
@@ -4181,7 +4160,7 @@ packages:
   twoslash@0.2.12:
     resolution: {integrity: sha512-tEHPASMqi7kqwfJbkk7hc/4EhlrKCSLcur+TcvYki3vhIfaRMXnXjaYFgXpoZRbT6GdprD4tGuVBEmTpUgLBsw==}
     peerDependencies:
-      typescript: ^5.6.2
+      typescript: '*'
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -4604,16 +4583,16 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@antfu/eslint-config@3.8.0(@typescript-eslint/utils@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(@vue/compiler-sfc@3.5.12)(eslint-plugin-format@0.1.2(eslint@9.13.0(jiti@2.3.3)))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)(vitest@2.1.4)':
+  '@antfu/eslint-config@3.8.0(@typescript-eslint/utils@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(@vue/compiler-sfc@3.5.12)(eslint-plugin-format@0.1.2(eslint@9.13.0(jiti@2.3.3)))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)(vitest@2.1.4)':
     dependencies:
       '@antfu/install-pkg': 0.4.1
       '@clack/prompts': 0.7.0
       '@eslint-community/eslint-plugin-eslint-comments': 4.4.0(eslint@9.13.0(jiti@2.3.3))
       '@eslint/markdown': 6.2.0
       '@stylistic/eslint-plugin': 2.9.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
-      '@typescript-eslint/eslint-plugin': 8.11.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
-      '@typescript-eslint/parser': 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
-      '@vitest/eslint-plugin': 1.1.7(@typescript-eslint/utils@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)(vitest@2.1.4)
+      '@typescript-eslint/eslint-plugin': 8.13.0(@typescript-eslint/parser@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@vitest/eslint-plugin': 1.1.7(@typescript-eslint/utils@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)(vitest@2.1.4)
       eslint: 9.13.0(jiti@2.3.3)
       eslint-config-flat-gitignore: 0.3.0(eslint@9.13.0(jiti@2.3.3))
       eslint-flat-config-utils: 0.4.0
@@ -4629,7 +4608,7 @@ snapshots:
       eslint-plugin-regexp: 2.6.0(eslint@9.13.0(jiti@2.3.3))
       eslint-plugin-toml: 0.11.1(eslint@9.13.0(jiti@2.3.3))
       eslint-plugin-unicorn: 56.0.0(eslint@9.13.0(jiti@2.3.3))
-      eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.11.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))
+      eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.13.0(@typescript-eslint/parser@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))
       eslint-plugin-vue: 9.30.0(eslint@9.13.0(jiti@2.3.3))
       eslint-plugin-yml: 1.14.0(eslint@9.13.0(jiti@2.3.3))
       eslint-processor-vue-blocks: 0.1.2(@vue/compiler-sfc@3.5.12)(eslint@9.13.0(jiti@2.3.3))
@@ -5443,7 +5422,7 @@ snapshots:
 
   '@stylistic/eslint-plugin@2.9.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
       eslint: 9.13.0(jiti@2.3.3)
       eslint-visitor-keys: 4.2.0
       espree: 10.3.0
@@ -5522,14 +5501,14 @@ snapshots:
 
   '@types/web-bluetooth@0.0.20': {}
 
-  '@typescript-eslint/eslint-plugin@8.11.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)':
+  '@typescript-eslint/eslint-plugin@8.13.0(@typescript-eslint/parser@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
-      '@typescript-eslint/scope-manager': 8.11.0
-      '@typescript-eslint/type-utils': 8.11.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
-      '@typescript-eslint/visitor-keys': 8.11.0
+      '@typescript-eslint/parser': 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/scope-manager': 8.13.0
+      '@typescript-eslint/type-utils': 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/visitor-keys': 8.13.0
       eslint: 9.13.0(jiti@2.3.3)
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -5540,12 +5519,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)':
+  '@typescript-eslint/parser@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.12.2
-      '@typescript-eslint/types': 8.12.2
-      '@typescript-eslint/typescript-estree': 8.12.2(typescript@5.6.3)
-      '@typescript-eslint/visitor-keys': 8.12.2
+      '@typescript-eslint/scope-manager': 8.13.0
+      '@typescript-eslint/types': 8.13.0
+      '@typescript-eslint/typescript-estree': 8.13.0(typescript@5.6.3)
+      '@typescript-eslint/visitor-keys': 8.13.0
       debug: 4.3.7
       eslint: 9.13.0(jiti@2.3.3)
     optionalDependencies:
@@ -5553,20 +5532,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.11.0':
+  '@typescript-eslint/scope-manager@8.13.0':
     dependencies:
-      '@typescript-eslint/types': 8.11.0
-      '@typescript-eslint/visitor-keys': 8.11.0
+      '@typescript-eslint/types': 8.13.0
+      '@typescript-eslint/visitor-keys': 8.13.0
 
-  '@typescript-eslint/scope-manager@8.12.2':
+  '@typescript-eslint/type-utils@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/types': 8.12.2
-      '@typescript-eslint/visitor-keys': 8.12.2
-
-  '@typescript-eslint/type-utils@8.11.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)':
-    dependencies:
-      '@typescript-eslint/typescript-estree': 8.11.0(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 8.13.0(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
       debug: 4.3.7
       ts-api-utils: 1.3.0(typescript@5.6.3)
     optionalDependencies:
@@ -5575,14 +5549,12 @@ snapshots:
       - eslint
       - supports-color
 
-  '@typescript-eslint/types@8.11.0': {}
+  '@typescript-eslint/types@8.13.0': {}
 
-  '@typescript-eslint/types@8.12.2': {}
-
-  '@typescript-eslint/typescript-estree@8.11.0(typescript@5.6.3)':
+  '@typescript-eslint/typescript-estree@8.13.0(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/types': 8.11.0
-      '@typescript-eslint/visitor-keys': 8.11.0
+      '@typescript-eslint/types': 8.13.0
+      '@typescript-eslint/visitor-keys': 8.13.0
       debug: 4.3.7
       fast-glob: 3.3.2
       is-glob: 4.0.3
@@ -5594,40 +5566,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.12.2(typescript@5.6.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.12.2
-      '@typescript-eslint/visitor-keys': 8.12.2
-      debug: 4.3.7
-      fast-glob: 3.3.2
-      is-glob: 4.0.3
-      minimatch: 9.0.5
-      semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.6.3)
-    optionalDependencies:
-      typescript: 5.6.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)':
+  '@typescript-eslint/utils@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.13.0(jiti@2.3.3))
-      '@typescript-eslint/scope-manager': 8.12.2
-      '@typescript-eslint/types': 8.12.2
-      '@typescript-eslint/typescript-estree': 8.12.2(typescript@5.6.3)
+      '@typescript-eslint/scope-manager': 8.13.0
+      '@typescript-eslint/types': 8.13.0
+      '@typescript-eslint/typescript-estree': 8.13.0(typescript@5.6.3)
       eslint: 9.13.0(jiti@2.3.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/visitor-keys@8.11.0':
+  '@typescript-eslint/visitor-keys@8.13.0':
     dependencies:
-      '@typescript-eslint/types': 8.11.0
-      eslint-visitor-keys: 3.4.3
-
-  '@typescript-eslint/visitor-keys@8.12.2':
-    dependencies:
-      '@typescript-eslint/types': 8.12.2
+      '@typescript-eslint/types': 8.13.0
       eslint-visitor-keys: 3.4.3
 
   '@typescript/vfs@1.6.0(typescript@5.6.3)':
@@ -5813,9 +5765,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/eslint-plugin@1.1.7(@typescript-eslint/utils@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)(vitest@2.1.4)':
+  '@vitest/eslint-plugin@1.1.7(@typescript-eslint/utils@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)(vitest@2.1.4)':
     dependencies:
-      '@typescript-eslint/utils': 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
       eslint: 9.13.0(jiti@2.3.3)
     optionalDependencies:
       typescript: 5.6.3
@@ -6547,7 +6499,7 @@ snapshots:
 
   eslint-plugin-import-x@4.3.1(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3):
     dependencies:
-      '@typescript-eslint/utils': 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
       debug: 4.3.7
       doctrine: 3.0.0
       eslint: 9.13.0(jiti@2.3.3)
@@ -6606,8 +6558,8 @@ snapshots:
 
   eslint-plugin-perfectionist@3.9.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)(vue-eslint-parser@9.4.3(eslint@9.13.0(jiti@2.3.3))):
     dependencies:
-      '@typescript-eslint/types': 8.12.2
-      '@typescript-eslint/utils': 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/types': 8.13.0
+      '@typescript-eslint/utils': 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
       eslint: 9.13.0(jiti@2.3.3)
       minimatch: 9.0.5
       natural-compare-lite: 1.4.0
@@ -6658,11 +6610,11 @@ snapshots:
       semver: 7.6.3
       strip-indent: 3.0.0
 
-  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.11.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3)):
+  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.13.0(@typescript-eslint/parser@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3)):
     dependencies:
       eslint: 9.13.0(jiti@2.3.3)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.11.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/eslint-plugin': 8.13.0(@typescript-eslint/parser@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
 
   eslint-plugin-vue@9.30.0(eslint@9.13.0(jiti@2.3.3)):
     dependencies:
@@ -6719,7 +6671,7 @@ snapshots:
     dependencies:
       '@antfu/utils': 0.7.10
       '@types/eslint': 9.6.1
-      '@typescript-eslint/utils': 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
       eslint: 9.13.0(jiti@2.3.3)
       vitest: 2.1.4(@types/node@22.8.4)(@vitest/ui@2.1.4)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,8 +29,8 @@ catalog:
   '@types/node': ^22.8.4
   '@types/picomatch': ^3.0.1
   '@types/semver': ^7.5.8
-  '@typescript-eslint/parser': ^8.12.2
-  '@typescript-eslint/utils': ^8.12.2
+  '@typescript-eslint/parser': ^8.13.0
+  '@typescript-eslint/utils': ^8.13.0
   '@unocss/reset': ^0.63.6
   '@vitest/coverage-v8': ^2.1.4
   '@vitest/ui': ^2.1.4


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR modifies the `comma-dangle` rule to add support for import attributes.
Specifically, the rule now check for trailing commas in import attributes and dynamic imports.
(Trailing commas in dynamic imports are allowed since ES2025)
I added `importAttributes` and `dynamicImports` options to specify your preferences for how they behave.



### Linked Issues

#578

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

~~The type annotation on `ImportExpression#options` seems to be missing.~~
~~https://github.com/typescript-eslint/typescript-eslint/issues/10236~~

Done
