### PR TITLE
docs(func-call-spacing): fixing broken links

### DIFF
--- a/packages/eslint-plugin-js/rules/func-call-spacing/README.md
+++ b/packages/eslint-plugin-js/rules/func-call-spacing/README.md
@@ -1,3 +1,3 @@
 # js/func-call-spacing
 
-This rule is renamed to [`function-call-spacing`](./function-call-spacing)
+This rule was renamed to [`function-call-spacing`](/rules/default/function-call-spacing)

--- a/packages/eslint-plugin-ts/rules/func-call-spacing/README.md
+++ b/packages/eslint-plugin-ts/rules/func-call-spacing/README.md
@@ -1,3 +1,3 @@
 # ts/func-call-spacing
 
-This rule is renamed to [`function-call-spacing`](./function-call-spacing)
+This rule was renamed to [`function-call-spacing`](/rules/ts/function-call-spacing)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixes broken links to `function-call-spacing` on these pages:
- https://eslint.style/packages/eslint-plugin-js/rules/func-call-spacing/README#js-func-call-spacing
- https://eslint.style/packages/eslint-plugin-ts/rules/func-call-spacing/README#ts-func-call-spacing

