### PR TITLE
feat(function-call-spacing): auto-fix optional chain when option is `never`

### DIFF
--- a/packages/eslint-plugin/rules/function-call-spacing/function-call-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/function-call-spacing/function-call-spacing._ts_.test.ts
@@ -531,8 +531,7 @@ run({
             },
           ],
           code,
-          // apply no fixers to it
-          output: null,
+          output: 'f?.();',
         },
       )
 

--- a/packages/eslint-plugin/rules/function-call-spacing/function-call-spacing._ts_.ts
+++ b/packages/eslint-plugin/rules/function-call-spacing/function-call-spacing._ts_.ts
@@ -94,15 +94,17 @@ export default createRule<RuleOptions, MessageIds>({
             loc: leftToken.loc.start,
             messageId: 'unexpectedWhitespace',
             fix(fixer) {
+              if (isOptionalCall) {
+                return fixer.replaceTextRange([
+                  leftToken.range[1],
+                  rightToken.range[0],
+                ], '?.')
+              }
               /**
                * Only autofix if there is no newline
                * https://github.com/eslint/eslint/issues/7787
                */
-              if (
-                !hasNewline
-                // don't fix optional calls
-                && !isOptionalCall
-              ) {
+              if (!hasNewline) {
                 return fixer.removeRange([
                   leftToken.range[1],
                   rightToken.range[0],


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

part of #565 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
