### PR TITLE
fix(indent-binary-ops): disabled to lower the indention when left token start with close bracket

### DIFF
--- a/packages/eslint-plugin/rules/indent-binary-ops/indent-binary-ops._plus_.test.ts
+++ b/packages/eslint-plugin/rules/indent-binary-ops/indent-binary-ops._plus_.test.ts
@@ -336,4 +336,34 @@ it('snapshots', async () => {
         || (g && h)
     }"
   `)
+
+  expect.soft(
+    fix($`
+      type Type =
+        | ({
+          type: 'a';
+        } & A)
+        | ({
+          type: 'b';
+          } & B)
+        | ({
+          type: 'c';
+        } & {
+          c: string;
+        });
+    `),
+  ).toMatchInlineSnapshot(`
+    "type Type =
+      | ({
+        type: 'a';
+      } & A)
+      | ({
+        type: 'b';
+        } & B)
+        | ({
+        type: 'c';
+      } & {
+        c: string;
+      });"
+  `)
 })

--- a/packages/eslint-plugin/rules/indent-binary-ops/indent-binary-ops._plus_.ts
+++ b/packages/eslint-plugin/rules/indent-binary-ops/indent-binary-ops._plus_.ts
@@ -83,10 +83,6 @@ export default createRule<RuleOptions, MessageIds>({
       return openBracketCount < closeBracketCount
     }
 
-    function hasExclusivelyCloseBracketOfLine(line: number) {
-      return !sourceCode.tokensAndComments.some(token => token.loc.start.line === line && ![')', '}', ']'].includes(token.value))
-    }
-
     function handler(node: ASTNode, right: ASTNode) {
       if (node.loc.start.line === node.loc.end.line)
         return
@@ -128,7 +124,7 @@ export default createRule<RuleOptions, MessageIds>({
         || (
           lastTokenOfLineLeft?.value === ')'
           && isGreaterThanCloseBracketOfLine(tokenLeft.loc.start.line)
-          && !hasExclusivelyCloseBracketOfLine(tokenLeft.loc.start.line)
+          && ![']', ')', '}'].includes(firstTokenOfLineLeft?.value || '')
         )
 
       const indentLeft = getIndentOfLine(tokenLeft.loc.start.line)


### PR DESCRIPTION
### Description
Some of the #576 changes were missing.

```ts
// input
type Type =
  | ({
    type: 'a';
  } & A)
  | ({
    type: 'b';
  } & B)

// output
type Type =
  | ({
    type: 'a'
  } & { a: number })
| ({
  type: 'b'
} & { b: number })

// expect
type Type =
  | ({
    type: 'a';
  } & A)
  | ({
    type: 'b';
  } & B)
```
Based on this, if the left token begins with a closing parenthesis, the indentation is not lowered.

### Linked Issues
https://github.com/eslint-stylistic/eslint-stylistic/pull/576

### Additional context
