### PR TITLE
fix(key-spacing): crash for import without attributes when using `align` option

### DIFF
--- a/packages/eslint-plugin/rules/key-spacing/key-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/key-spacing/key-spacing._js_.test.ts
@@ -1227,6 +1227,30 @@ run({
         align: 'colon',
       }],
     },
+    {
+      code: $`
+        import foo from "./foo"
+      `,
+      options: [{ align: 'colon' }],
+    },
+    {
+      code: $`
+        import "./foo"
+      `,
+      options: [{ align: 'colon' }],
+    },
+    {
+      code: $`
+        export {foo} from "./foo"
+      `,
+      options: [{ align: 'colon' }],
+    },
+    {
+      code: $`
+        export * from "./foo"
+      `,
+      options: [{ align: 'colon' }],
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/rules/key-spacing/key-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/key-spacing/key-spacing._js_.ts
@@ -680,6 +680,8 @@ export default createRule<RuleOptions, MessageIds>({
       if (!node.attributes)
         // The old parser's AST does not have attributes.
         return
+      if (!node.attributes.length)
+        return
       if (isSingleLineImportAttributes(node, sourceCode))
         verifyListSpacing(node.attributes, singleLineOptions)
       else


### PR DESCRIPTION


<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

fixes #592

### Linked Issues

#592

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
