### PR TITLE
feat(comma-style): add support for more syntax

### DIFF
--- a/packages/eslint-plugin/rules/comma-style/README._js_.md
+++ b/packages/eslint-plugin/rules/comma-style/README._js_.md
@@ -42,13 +42,34 @@ This rule also accepts an additional `exceptions` object:
   - `"CallExpression": true` ignores comma style in the arguments of function calls
   - `"FunctionDeclaration": true` ignores comma style in the parameters of function declarations
   - `"FunctionExpression": true` ignores comma style in the parameters of function expressions
-  - `"ImportDeclaration": true` ignores comma style in the specifiers of import declarations
+  - `"ImportDeclaration": true` ignores comma style in the specifiers / import attributes of import declarations
   - `"ObjectExpression": true` ignores comma style in object literals
   - `"ObjectPattern": true` ignores comma style in object patterns of destructuring
   - `"VariableDeclaration": true` ignores comma style in variable declarations
   - `"NewExpression": true` ignores comma style in the parameters of constructor expressions
+  - `"ExportAllDeclaration": true` ignores comma style in the import attributes of export all declarations
+  - `"ExportNamedDeclaration": true` ignores comma style in the specifiers / import attributes of export named declarations
+  - `"ImportExpression": true` ignores comma style in the arguments of import expressions
+  - `"SequenceExpression": true` ignores comma style in sequence expressions
+  - `"ClassDeclaration": true` ignores comma style in the TypeScript implements of class declarations
+  - `"ClassExpression": true` ignores comma style in the TypeScript implements of class declarations
+  - `"TSDeclareFunction": true` ignores comma style in the parameters of TypeScript declare functions
+  - `"TSFunctionType": true` ignores comma style in the parameters of TypeScript function types
+  - `"TSConstructorType": true` ignores comma style in the parameters of TypeScript constructor types
+  - `"TSEmptyBodyFunctionExpression": true` ignores comma style in the parameters of TypeScript empty body function expressions
+  - `"TSMethodSignature": true` ignores comma style in the parameters of TypeScript method signatures
+  - `"TSCallSignatureDeclaration": true` ignores comma style in the parameters of TypeScript call signature declarations
+  - `"TSConstructSignatureDeclaration": true` ignores comma style in the parameters of TypeScript construct signature declarations
+  - `"TSEnumBody": true` ignores comma style in the members of TypeScript enums
+  - `"TSTypeLiteral": true` ignores comma style in the members of TypeScript type literals
+  - `"TSInterfaceBody": true` ignores comma style in the members of TypeScript interfaces
+  - `"TSIndexSignature": true` ignores comma style in the key parameters of TypeScript index signatures
+  - `"TSInterfaceDeclaration": true` ignores comma style in the extend classes of TypeScript interfaces
+  - `"TSTupleType": true` ignores comma style in the elements of TypeScript tuple types
+  - `"TSTypeParameterDeclaration": true` ignores comma style in the type parameters of TypeScript type parameter declarations
+  - `"TSTypeParameterInstantiation": true` ignores comma style in the type arguments of TypeScript type parameter instantiations
 
-A way to determine the node types as defined by [ESTree](https://github.com/estree/estree) is to use [AST Explorer](https://astexplorer.net/) with the espree parser.
+A way to determine the node types as defined by [ESTree](https://github.com/estree/estree) and [@typescript-eslint/parser](https://typescript-eslint.io/packages/parser/) is to use [AST Explorer](https://astexplorer.net/) with the espree parser or @typescript-eslint/parser.
 
 ### last
 

--- a/packages/eslint-plugin/rules/comma-style/comma-style._js_.test.ts
+++ b/packages/eslint-plugin/rules/comma-style/comma-style._js_.test.ts
@@ -3,7 +3,7 @@
  * @author Vignesh Anand aka vegetableman
  */
 
-import { run } from '#test'
+import { $, run } from '#test'
 import rule from '.'
 
 run({
@@ -262,7 +262,211 @@ run({
         ecmaVersion: 6,
       },
     },
-
+    {
+      // exception
+      code: $`
+        import {
+          A,
+          B
+          , C
+        } from 'module3' with {
+          a: 'v',
+          b: 'v'
+          , c: 'v'
+        };
+        import 'module4' with {
+          a: 'v',
+          b: 'v'
+          , c: 'v'
+        };
+      `,
+    },
+    {
+      // exception
+      code: $`
+        let a, b, c;
+        export {
+          a,
+          b
+          , c
+        };
+        export {
+          A,
+          B
+          , C
+        } from 'module1' with {
+          a: 'v',
+          b: 'v'
+          , c: 'v'
+        };
+        export * from 'module2' with {
+          a: 'v',
+          b: 'v'
+          , c: 'v'
+        };
+      `,
+    },
+    {
+      // exception
+      code: $`
+        import(
+          a,
+          b
+        );
+        import(
+          c
+          , d
+        );
+      `,
+    },
+    {
+      code: $`
+        import(
+          a,
+        );
+        import(
+          b, c,
+        );
+      `,
+      options: ['first', { exceptions: { ImportExpression: false } }],
+    },
+    {
+      // exception
+      code: $`
+        const x = (
+          a,
+          b
+          , c
+        );
+      `,
+    },
+    {
+      // exception
+      code: $`
+        class MyClass implements
+          A,
+          B
+        , C {
+        }
+        const a = class implements
+          A,
+          B
+        , C {
+        }
+      `,
+    },
+    {
+      code: $`
+        function f(
+          a,
+          b
+          , c
+        )
+        type a = (
+          a,
+          b
+          , c
+        ) => r
+        type a = new (
+          a,
+          b
+          , c
+        ) => r
+        abstract class Base {
+          f(
+            a,
+            b
+            , c
+          );
+        }
+      `,
+    },
+    {
+      // exception
+      code: $`
+        enum MyEnum {
+          A,
+          B
+          , C
+        }
+      `,
+    },
+    {
+      // exception
+      code: $`
+        type foo = {
+          a: string,
+          b: string
+          , c: string
+        }
+      `,
+    },
+    {
+      // exception
+      code: $`
+        type foo = {
+          new (
+            a,
+            b
+            , c
+          ): any,
+          (
+            a,
+            b
+            , c
+          ): any,
+          [
+            a: string,
+            b: string
+            , c: string
+          ]: string,
+        
+          f(
+            a: string,
+            b: string
+            , c: string
+          ): number,
+        }
+      `,
+    },
+    {
+      // exception
+      code: $`
+        interface Foo extends
+          A,
+          B
+          , C
+        {
+          a: string,
+          b: string
+          , c: string
+        }
+      `,
+    },
+    {
+      // exception
+      code: $`
+        type Foo = [
+          "A",
+          "B"
+          , "C"
+        ];
+      `,
+    },
+    {
+      // exception
+      code: $`
+        type Foo<
+          A,
+          B
+          , C
+        > = Bar<
+          A,
+          B
+          , C
+        >;
+      `,
+    },
   ],
 
   invalid: [
@@ -654,6 +858,825 @@ run({
       code: '[foo//\n,/*block\ncomment*/];',
       output: '[foo,//\n/*block\ncomment*/];',
       errors: [{ messageId: 'unexpectedLineBeforeAndAfterComma' }],
+    },
+    {
+      code: $`
+        import {
+          A,
+          B
+          , C
+        } from 'module3' with {
+          a: 'v',
+          b: 'v'
+          , c: 'v'
+        };
+        import 'module4' with {
+          a: 'v',
+          b: 'v'
+          , c: 'v'
+        };
+      `,
+      output: $`
+        import {
+          A,
+          B,
+           C
+        } from 'module3' with {
+          a: 'v',
+          b: 'v',
+           c: 'v'
+        };
+        import 'module4' with {
+          a: 'v',
+          b: 'v',
+           c: 'v'
+        };
+      `,
+      options: ['last', { exceptions: { ImportDeclaration: false } }],
+      errors: [
+        { messageId: 'expectedCommaLast' },
+        { messageId: 'expectedCommaLast' },
+        { messageId: 'expectedCommaLast' },
+      ],
+    },
+    {
+      code: $`
+        import {
+          A,
+          B
+          , C
+        } from 'module3' with {
+          a: 'v',
+          b: 'v'
+          , c: 'v'
+        };
+        import 'module4' with {
+          a: 'v',
+          b: 'v'
+          , c: 'v'
+        };
+      `,
+      output: $`
+        import {
+          A
+          ,B
+          , C
+        } from 'module3' with {
+          a: 'v'
+          ,b: 'v'
+          , c: 'v'
+        };
+        import 'module4' with {
+          a: 'v'
+          ,b: 'v'
+          , c: 'v'
+        };
+      `,
+      options: ['first', { exceptions: { ImportDeclaration: false } }],
+      errors: [
+        { messageId: 'expectedCommaFirst' },
+        { messageId: 'expectedCommaFirst' },
+        { messageId: 'expectedCommaFirst' },
+      ],
+    },
+    {
+      code: $`
+        let a, b, c;
+        export {
+          a,
+          b
+          , c
+        };
+        export {
+          A,
+          B
+          , C
+        } from 'module1' with {
+          a: 'v',
+          b: 'v'
+          , c: 'v'
+        };
+        export * from 'module2' with {
+          a: 'v',
+          b: 'v'
+          , c: 'v'
+        };
+      `,
+      output: $`
+        let a, b, c;
+        export {
+          a,
+          b,
+           c
+        };
+        export {
+          A,
+          B,
+           C
+        } from 'module1' with {
+          a: 'v',
+          b: 'v',
+           c: 'v'
+        };
+        export * from 'module2' with {
+          a: 'v',
+          b: 'v',
+           c: 'v'
+        };
+      `,
+      options: ['last', { exceptions: { ExportAllDeclaration: false, ExportNamedDeclaration: false } }],
+      errors: [
+        { messageId: 'expectedCommaLast' },
+        { messageId: 'expectedCommaLast' },
+        { messageId: 'expectedCommaLast' },
+        { messageId: 'expectedCommaLast' },
+      ],
+    },
+    {
+      code: $`
+        let a, b, c;
+        export {
+          a,
+          b
+          , c
+        };
+        export {
+          A,
+          B
+          , C
+        } from 'module1' with {
+          a: 'v',
+          b: 'v'
+          , c: 'v'
+        };
+        export * from 'module2' with {
+          a: 'v',
+          b: 'v'
+          , c: 'v'
+        };
+      `,
+      output: $`
+        let a, b, c;
+        export {
+          a
+          ,b
+          , c
+        };
+        export {
+          A
+          ,B
+          , C
+        } from 'module1' with {
+          a: 'v'
+          ,b: 'v'
+          , c: 'v'
+        };
+        export * from 'module2' with {
+          a: 'v'
+          ,b: 'v'
+          , c: 'v'
+        };
+      `,
+      options: ['first', { exceptions: { ExportAllDeclaration: false, ExportNamedDeclaration: false } }],
+      errors: [
+        { messageId: 'expectedCommaFirst' },
+        { messageId: 'expectedCommaFirst' },
+        { messageId: 'expectedCommaFirst' },
+        { messageId: 'expectedCommaFirst' },
+      ],
+    },
+    {
+      code: $`
+        const x = (
+          a,
+          b
+          , c
+        );
+      `,
+      output: $`
+        const x = (
+          a,
+          b,
+           c
+        );
+      `,
+      options: ['last', { exceptions: { SequenceExpression: false } }],
+      errors: [{ messageId: 'expectedCommaLast' }],
+    },
+    {
+      code: $`
+        const x = (
+          a,
+          b
+          , c
+        );
+      `,
+      output: $`
+        const x = (
+          a
+          ,b
+          , c
+        );
+      `,
+      options: ['first', { exceptions: { SequenceExpression: false } }],
+      errors: [{ messageId: 'expectedCommaFirst' }],
+    },
+    {
+      code: $`
+        import(
+          a,
+          b
+        );
+        import(
+          c
+          , d
+        );
+      `,
+      output: $`
+        import(
+          a,
+          b
+        );
+        import(
+          c,
+           d
+        );
+      `,
+      options: ['last', { exceptions: { ImportExpression: false } }],
+      errors: [{ messageId: 'expectedCommaLast' }],
+    },
+    {
+      code: $`
+        import(
+          a,
+          b
+        );
+        import(
+          c
+          , d
+        );
+      `,
+      output: $`
+        import(
+          a
+          ,b
+        );
+        import(
+          c
+          , d
+        );
+      `,
+      options: ['first', { exceptions: { ImportExpression: false } }],
+      errors: [{ messageId: 'expectedCommaFirst' }],
+    },
+    {
+      code: $`
+        class MyClass implements
+          A,
+          B
+        , C {
+        }
+        const a = class implements
+          A,
+          B
+        , C {
+        }
+      `,
+      output: $`
+        class MyClass implements
+          A,
+          B,
+         C {
+        }
+        const a = class implements
+          A,
+          B,
+         C {
+        }
+      `,
+      options: ['last', { exceptions: { ClassDeclaration: false, ClassExpression: false } }],
+      errors: [{ messageId: 'expectedCommaLast' }, { messageId: 'expectedCommaLast' }],
+    },
+    {
+      code: $`
+        class MyClass implements
+          A,
+          B
+        , C {
+        }
+        const a = class implements
+          A,
+          B
+        , C {
+        }
+      `,
+      output: $`
+        class MyClass implements
+          A
+          ,B
+        , C {
+        }
+        const a = class implements
+          A
+          ,B
+        , C {
+        }
+      `,
+      options: ['first', { exceptions: { ClassDeclaration: false, ClassExpression: false } }],
+      errors: [{ messageId: 'expectedCommaFirst' }, { messageId: 'expectedCommaFirst' }],
+    },
+    {
+      code: $`
+        function f(
+          a,
+          b
+          , c
+        )
+        type a = (
+          a,
+          b
+          , c
+        ) => r
+        type a = new (
+          a,
+          b
+          , c
+        ) => r
+        abstract class Base {
+          f(
+            a,
+            b
+            , c
+          );
+        }
+      `,
+      output: $`
+        function f(
+          a,
+          b,
+           c
+        )
+        type a = (
+          a,
+          b,
+           c
+        ) => r
+        type a = new (
+          a,
+          b,
+           c
+        ) => r
+        abstract class Base {
+          f(
+            a,
+            b,
+             c
+          );
+        }
+      `,
+      options: ['last', {
+        exceptions: {
+          TSDeclareFunction: false,
+          TSFunctionType: false,
+          TSConstructorType: false,
+          TSEmptyBodyFunctionExpression: false,
+        },
+      }],
+      errors: [
+        { messageId: 'expectedCommaLast' },
+        { messageId: 'expectedCommaLast' },
+        { messageId: 'expectedCommaLast' },
+        { messageId: 'expectedCommaLast' },
+      ],
+    },
+    {
+      code: $`
+        function f(
+          a,
+          b
+          , c
+        )
+        type a = (
+          a,
+          b
+          , c
+        ) => r
+        type a = new (
+          a,
+          b
+          , c
+        ) => r
+        abstract class Base {
+          f(
+            a,
+            b
+            , c
+          );
+        }
+      `,
+      output: $`
+        function f(
+          a
+          ,b
+          , c
+        )
+        type a = (
+          a
+          ,b
+          , c
+        ) => r
+        type a = new (
+          a
+          ,b
+          , c
+        ) => r
+        abstract class Base {
+          f(
+            a
+            ,b
+            , c
+          );
+        }
+      `,
+      options: ['first', {
+        exceptions: {
+          TSDeclareFunction: false,
+          TSFunctionType: false,
+          TSConstructorType: false,
+          TSEmptyBodyFunctionExpression: false,
+        },
+      }],
+      errors: [
+        { messageId: 'expectedCommaFirst' },
+        { messageId: 'expectedCommaFirst' },
+        { messageId: 'expectedCommaFirst' },
+        { messageId: 'expectedCommaFirst' },
+      ],
+    },
+    {
+      code: $`
+        enum MyEnum {
+          A,
+          B
+          , C
+        }
+      `,
+      output: $`
+        enum MyEnum {
+          A,
+          B,
+           C
+        }
+      `,
+      options: ['last', { exceptions: { TSEnumBody: false } }],
+      errors: [{ messageId: 'expectedCommaLast' }],
+    },
+    {
+      code: $`
+        enum MyEnum {
+          A,
+          B
+          , C
+        }
+      `,
+      output: $`
+        enum MyEnum {
+          A
+          ,B
+          , C
+        }
+      `,
+      options: ['first', { exceptions: { TSEnumBody: false } }],
+      errors: [{ messageId: 'expectedCommaFirst' }],
+    },
+    {
+      code: $`
+        type foo = {
+          a: string,
+          b: string
+          , c: string
+        }
+      `,
+      output: $`
+        type foo = {
+          a: string,
+          b: string,
+           c: string
+        }
+      `,
+      options: ['last', { exceptions: { TSTypeLiteral: false } }],
+      errors: [{ messageId: 'expectedCommaLast' }],
+    },
+    {
+      code: $`
+        type foo = {
+          a: string,
+          b: string
+          , c: string
+        }
+      `,
+      output: $`
+        type foo = {
+          a: string
+          ,b: string
+          , c: string
+        }
+      `,
+      options: ['first', { exceptions: { TSTypeLiteral: false } }],
+      errors: [{ messageId: 'expectedCommaFirst' }],
+    },
+    {
+      code: $`
+        type foo = {
+          new (
+            a,
+            b
+            , c
+          ): any,
+          (
+            a,
+            b
+            , c
+          ): any,
+          [
+            a: string,
+            b: string
+            , c: string
+          ]: string,
+        
+          f(
+            a: string,
+            b: string
+            , c: string
+          ): number,
+        }
+      `,
+      output: $`
+        type foo = {
+          new (
+            a,
+            b,
+             c
+          ): any,
+          (
+            a,
+            b,
+             c
+          ): any,
+          [
+            a: string,
+            b: string,
+             c: string
+          ]: string,
+        
+          f(
+            a: string,
+            b: string,
+             c: string
+          ): number,
+        }
+      `,
+      options: ['last', {
+        exceptions: {
+          TSTypeLiteral: false,
+          TSCallSignatureDeclaration: false,
+          TSConstructSignatureDeclaration: false,
+          TSIndexSignature: false,
+          TSMethodSignature: false,
+        },
+      }],
+      errors: [
+        { messageId: 'expectedCommaLast' },
+        { messageId: 'expectedCommaLast' },
+        { messageId: 'expectedCommaLast' },
+        { messageId: 'expectedCommaLast' },
+      ],
+    },
+    {
+      code: $`
+        type foo = {
+          new (
+            a,
+            b
+            , c
+          ): any,
+          (
+            a,
+            b
+            , c
+          ): any,
+          [
+            a: string,
+            b: string
+            , c: string
+          ]: string,
+        
+          f(
+            a: string,
+            b: string
+            , c: string
+          ): number,
+        }
+      `,
+      output: $`
+        type foo = {
+          new (
+            a
+            ,b
+            , c
+          ): any
+          ,(
+            a
+            ,b
+            , c
+          ): any
+          ,[
+            a: string
+            ,b: string
+            , c: string
+          ]: string
+        
+          ,f(
+            a: string
+            ,b: string
+            , c: string
+          ): number,
+        }
+      `,
+      options: ['first', {
+        exceptions: {
+          TSTypeLiteral: false,
+          TSCallSignatureDeclaration: false,
+          TSConstructSignatureDeclaration: false,
+          TSIndexSignature: false,
+          TSMethodSignature: false,
+        },
+      }],
+      errors: [
+        { messageId: 'expectedCommaFirst' },
+        { messageId: 'expectedCommaFirst' },
+        { messageId: 'expectedCommaFirst' },
+        { messageId: 'expectedCommaFirst' },
+        { messageId: 'expectedCommaFirst' },
+        { messageId: 'expectedCommaFirst' },
+        { messageId: 'expectedCommaFirst' },
+      ],
+    },
+    {
+      code: $`
+        interface Foo extends
+          A,
+          B
+          , C
+        {
+          a: string,
+          b: string
+          , c: string
+        }
+      `,
+      output: $`
+        interface Foo extends
+          A,
+          B,
+           C
+        {
+          a: string,
+          b: string,
+           c: string
+        }
+      `,
+      options: ['last', {
+        exceptions: {
+          TSInterfaceBody: false,
+          TSInterfaceDeclaration: false,
+        },
+      }],
+      errors: [
+        { messageId: 'expectedCommaLast' },
+        { messageId: 'expectedCommaLast' },
+      ],
+    },
+    {
+      code: $`
+        interface Foo extends
+          A,
+          B
+          , C
+        {
+          a: string,
+          b: string
+          , c: string
+        }
+      `,
+      output: $`
+        interface Foo extends
+          A
+          ,B
+          , C
+        {
+          a: string
+          ,b: string
+          , c: string
+        }
+      `,
+      options: ['first', {
+        exceptions: {
+          TSInterfaceBody: false,
+          TSInterfaceDeclaration: false,
+        },
+      }],
+      errors: [
+        { messageId: 'expectedCommaFirst' },
+        { messageId: 'expectedCommaFirst' },
+      ],
+    },
+    {
+      code: $`
+        type Foo = [
+          "A",
+          "B"
+          , "C"
+        ];
+      `,
+      output: $`
+        type Foo = [
+          "A",
+          "B",
+           "C"
+        ];
+      `,
+      options: ['last', { exceptions: { TSTupleType: false } }],
+      errors: [{ messageId: 'expectedCommaLast' }],
+    },
+    {
+      code: $`
+        type Foo = [
+          "A",
+          "B"
+          , "C"
+        ];
+      `,
+      output: $`
+        type Foo = [
+          "A"
+          ,"B"
+          , "C"
+        ];
+      `,
+      options: ['first', { exceptions: { TSTupleType: false } }],
+      errors: [{ messageId: 'expectedCommaFirst' }],
+    },
+    {
+      code: $`
+        type Foo<
+          A,
+          B
+          , C
+        > = Bar<
+          A,
+          B
+          , C
+        >;
+      `,
+      output: $`
+        type Foo<
+          A,
+          B,
+           C
+        > = Bar<
+          A,
+          B,
+           C
+        >;
+      `,
+      options: ['last', { exceptions: { TSTypeParameterDeclaration: false, TSTypeParameterInstantiation: false } }],
+      errors: [{ messageId: 'expectedCommaLast' }, { messageId: 'expectedCommaLast' }],
+    },
+    {
+      code: $`
+        type Foo<
+          A,
+          B
+          , C
+        > = Bar<
+          A,
+          B
+          , C
+        >;
+      `,
+      output: $`
+        type Foo<
+          A
+          ,B
+          , C
+        > = Bar<
+          A
+          ,B
+          , C
+        >;
+      `,
+      options: ['first', { exceptions: { TSTypeParameterDeclaration: false, TSTypeParameterInstantiation: false } }],
+      errors: [{ messageId: 'expectedCommaFirst' }, { messageId: 'expectedCommaFirst' }],
     },
   ],
 })

--- a/packages/eslint-plugin/rules/comma-style/comma-style._js_.ts
+++ b/packages/eslint-plugin/rules/comma-style/comma-style._js_.ts
@@ -437,6 +437,9 @@ export default createRule<RuleOptions, MessageIds>({
     }
     /** Checks the comma placement in import attributes. */
     function visitImportAttributes(node: Tree.ImportDeclaration | Tree.ExportAllDeclaration | Tree.ExportNamedDeclaration) {
+      if (!node.attributes)
+        // The old parser's AST does not have attributes.
+        return
       validateComma(node, node.attributes)
     }
     /** Checks the comma placement in module specifiers. */

--- a/packages/eslint-plugin/rules/comma-style/comma-style._js_.ts
+++ b/packages/eslint-plugin/rules/comma-style/comma-style._js_.ts
@@ -449,6 +449,9 @@ export default createRule<RuleOptions, MessageIds>({
 
     /** Checks the comma placement in TypeScript class implements. */
     function visitClassImplements(node: Tree.ClassDeclaration | Tree.ClassExpression) {
+      if (!node.implements)
+        // The js parser's AST does not have implements.
+        return
       validateComma(node, node.implements)
     }
     /** Checks the comma placement in TypeScript enum/literal members. */

--- a/packages/eslint-plugin/rules/comma-style/comma-style._js_.ts
+++ b/packages/eslint-plugin/rules/comma-style/comma-style._js_.ts
@@ -58,6 +58,27 @@ export default createRule<RuleOptions, MessageIds>({
       ImportDeclaration: true,
       ObjectPattern: true,
       NewExpression: true,
+      ExportAllDeclaration: true,
+      ExportNamedDeclaration: true,
+      ImportExpression: true,
+      SequenceExpression: true,
+      ClassDeclaration: true,
+      ClassExpression: true,
+      TSDeclareFunction: true,
+      TSFunctionType: true,
+      TSConstructorType: true,
+      TSEmptyBodyFunctionExpression: true,
+      TSEnumBody: true,
+      TSTypeLiteral: true,
+      TSIndexSignature: true,
+      TSMethodSignature: true,
+      TSCallSignatureDeclaration: true,
+      TSConstructSignatureDeclaration: true,
+      TSInterfaceBody: true,
+      TSInterfaceDeclaration: true,
+      TSTupleType: true,
+      TSTypeParameterDeclaration: true,
+      TSTypeParameterInstantiation: true,
     } as Record<NodeTypes, boolean>
 
     if (context.options.length === 2 && Object.prototype.hasOwnProperty.call(context.options[1], 'exceptions')) {
@@ -120,7 +141,7 @@ export default createRule<RuleOptions, MessageIds>({
      * @param reportItem The item to use when reporting an error.
      * @private
      */
-    function validateCommaItemSpacing(previousItemToken: Token, commaToken: Token, currentItemToken: Token, reportItem: Token): void {
+    function validateCommaItemSpacing(previousItemToken: Token, commaToken: Token, currentItemToken: Token, reportItem: ASTNode | Token): void {
       // if single line
       if (isTokenOnSameLine(commaToken, currentItemToken)
         && isTokenOnSameLine(previousItemToken, commaToken)) {
@@ -164,11 +185,10 @@ export default createRule<RuleOptions, MessageIds>({
     /**
      * Checks the comma placement with regards to a declaration/property/element
      * @param node The binary expression node to check
-     * @param property The property of the node containing child nodes.
+     * @param items The child nodes.
      * @private
      */
-    function validateComma<T extends NodeType, const K extends keyof T>(node: T, property: K): void {
-      const items = node[property] as (Tree.Token | ASTNode)[]
+    function validateComma<T extends NodeType>(node: T, items: (ASTNode | null)[]): void {
       const arrayLiteral = (node.type === 'ArrayExpression' || node.type === 'ArrayPattern')
 
       if (items.length > 1 || arrayLiteral) {
@@ -177,7 +197,7 @@ export default createRule<RuleOptions, MessageIds>({
 
         items.forEach((item) => {
           const commaToken = item ? sourceCode.getTokenBefore(item)! : previousItemToken
-          const currentItemToken = item ? sourceCode.getFirstToken(item as ASTNode)! : sourceCode.getTokenAfter(commaToken)!
+          const currentItemToken = item ? sourceCode.getFirstToken(item)! : sourceCode.getTokenAfter(commaToken)!
           const reportItem = item || currentItemToken
 
           /**
@@ -195,14 +215,21 @@ export default createRule<RuleOptions, MessageIds>({
            * they are always valid regardless of an undefined item.
            */
           if (isCommaToken(commaToken))
-            validateCommaItemSpacing(previousItemToken, commaToken, currentItemToken!, reportItem as Tree.Token)
+            validateCommaItemSpacing(previousItemToken, commaToken, currentItemToken!, reportItem)
 
           if (item) {
-            const tokenAfterItem = sourceCode.getTokenAfter(item, isNotClosingParenToken)
+            const tokenLastItem = sourceCode.getLastToken(item)
+            if (tokenLastItem && isCommaToken(tokenLastItem)) {
+              // TypeElement such as TSPropertySignature may have a comma at the end of the node.
+              previousItemToken = sourceCode.getTokenBefore(tokenLastItem)!
+            }
+            else {
+              const tokenAfterItem = sourceCode.getTokenAfter(item, isNotClosingParenToken)
 
-            previousItemToken = tokenAfterItem
-              ? sourceCode.getTokenBefore(tokenAfterItem)!
-              : sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1] as ReturnType<typeof sourceCode.getLastToken>
+              previousItemToken = tokenAfterItem
+                ? sourceCode.getTokenBefore(tokenAfterItem)!
+                : sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1] as ReturnType<typeof sourceCode.getLastToken>
+            }
           }
           else {
             previousItemToken = currentItemToken
@@ -243,65 +270,194 @@ export default createRule<RuleOptions, MessageIds>({
       | Tree.ImportDeclaration
       | Tree.NewExpression
       | Tree.ArrowFunctionExpression
+      | Tree.ExportAllDeclaration
+      | Tree.ExportNamedDeclaration
+      | Tree.ImportExpression
+      | Tree.SequenceExpression
+      | Tree.ClassDeclaration
+      | Tree.ClassExpression
+      | Tree.TSDeclareFunction
+      | Tree.TSFunctionType
+      | Tree.TSConstructorType
+      | Tree.TSEmptyBodyFunctionExpression
+      | Tree.TSEnumBody
+      | Tree.TSTypeLiteral
+      | Tree.TSIndexSignature
+      | Tree.TSMethodSignature
+      | Tree.TSCallSignatureDeclaration
+      | Tree.TSConstructSignatureDeclaration
+      | Tree.TSInterfaceBody
+      | Tree.TSInterfaceDeclaration
+      | Tree.TSTupleType
+      | Tree.TSTypeParameterDeclaration
+      | Tree.TSTypeParameterInstantiation
 
     const nodes: RuleListener = {}
 
     if (!exceptions.VariableDeclaration) {
-      nodes.VariableDeclaration = function (node) {
-        validateComma(node, 'declarations')
-      }
+      nodes.VariableDeclaration = node =>
+        validateComma(node, node.declarations)
     }
     if (!exceptions.ObjectExpression) {
-      nodes.ObjectExpression = function (node) {
-        validateComma(node, 'properties')
-      }
+      nodes.ObjectExpression = validateObjectProperties
     }
     if (!exceptions.ObjectPattern) {
-      nodes.ObjectPattern = function (node) {
-        validateComma(node, 'properties')
-      }
+      nodes.ObjectPattern = validateObjectProperties
     }
     if (!exceptions.ArrayExpression) {
-      nodes.ArrayExpression = function (node) {
-        validateComma(node, 'elements')
-      }
+      nodes.ArrayExpression = validateArrayElements
     }
     if (!exceptions.ArrayPattern) {
-      nodes.ArrayPattern = function (node) {
-        validateComma(node, 'elements')
-      }
+      nodes.ArrayPattern = validateArrayElements
     }
     if (!exceptions.FunctionDeclaration) {
-      nodes.FunctionDeclaration = function (node) {
-        validateComma(node, 'params')
-      }
+      nodes.FunctionDeclaration = validateFunctionParams
     }
     if (!exceptions.FunctionExpression) {
-      nodes.FunctionExpression = function (node) {
-        validateComma(node, 'params')
-      }
+      nodes.FunctionExpression = validateFunctionParams
     }
     if (!exceptions.ArrowFunctionExpression) {
-      nodes.ArrowFunctionExpression = function (node) {
-        validateComma(node, 'params')
-      }
+      nodes.ArrowFunctionExpression = validateFunctionParams
     }
     if (!exceptions.CallExpression) {
-      nodes.CallExpression = function (node) {
-        validateComma(node, 'arguments')
-      }
+      nodes.CallExpression = validateCallArguments
     }
     if (!exceptions.ImportDeclaration) {
-      nodes.ImportDeclaration = function (node) {
-        validateComma(node, 'specifiers')
+      nodes.ImportDeclaration = (node) => {
+        visitModulesSpecifiers(node)
+        visitImportAttributes(node)
       }
     }
     if (!exceptions.NewExpression) {
-      nodes.NewExpression = function (node) {
-        validateComma(node, 'arguments')
+      nodes.NewExpression = validateCallArguments
+    }
+    if (!exceptions.ExportAllDeclaration) {
+      nodes.ExportAllDeclaration = visitImportAttributes
+    }
+    if (!exceptions.ExportNamedDeclaration) {
+      nodes.ExportNamedDeclaration = (node) => {
+        visitModulesSpecifiers(node)
+        visitImportAttributes(node)
       }
+    }
+    if (!exceptions.ImportExpression) {
+      nodes.ImportExpression = (node) => {
+        if (node.options)
+          validateComma(node, [node.source, node.options])
+      }
+    }
+    if (!exceptions.SequenceExpression) {
+      nodes.SequenceExpression = node =>
+        validateComma(node, node.expressions)
+    }
+    if (!exceptions.ClassDeclaration) {
+      nodes.ClassDeclaration = visitClassImplements
+    }
+    if (!exceptions.ClassExpression) {
+      nodes.ClassExpression = visitClassImplements
+    }
+    if (!exceptions.TSDeclareFunction) {
+      nodes.TSDeclareFunction = validateFunctionParams
+    }
+    if (!exceptions.TSFunctionType) {
+      nodes.TSFunctionType = validateFunctionParams
+    }
+    if (!exceptions.TSConstructorType) {
+      nodes.TSConstructorType = validateFunctionParams
+    }
+    if (!exceptions.TSEmptyBodyFunctionExpression) {
+      nodes.TSEmptyBodyFunctionExpression = validateFunctionParams
+    }
+    if (!exceptions.TSMethodSignature) {
+      nodes.TSMethodSignature = validateFunctionParams
+    }
+    if (!exceptions.TSCallSignatureDeclaration) {
+      nodes.TSCallSignatureDeclaration = validateFunctionParams
+    }
+    if (!exceptions.TSConstructSignatureDeclaration) {
+      nodes.TSConstructSignatureDeclaration = validateFunctionParams
+    }
+    if (!exceptions.TSTypeParameterDeclaration) {
+      nodes.TSTypeParameterDeclaration = validateTypeParams
+    }
+    if (!exceptions.TSTypeParameterInstantiation) {
+      nodes.TSTypeParameterInstantiation = validateTypeParams
+    }
+    if (!exceptions.TSEnumBody) {
+      nodes.TSEnumBody = visitMembers
+    }
+    if (!exceptions.TSTypeLiteral) {
+      nodes.TSTypeLiteral = visitMembers
+    }
+    if (!exceptions.TSIndexSignature) {
+      nodes.TSIndexSignature = node =>
+        validateComma(node, node.parameters)
+    }
+    if (!exceptions.TSInterfaceDeclaration) {
+      nodes.TSInterfaceDeclaration = node =>
+        validateComma(node, node.extends)
+    }
+    if (!exceptions.TSInterfaceBody) {
+      nodes.TSInterfaceBody = node =>
+        validateComma(node, node.body)
+    }
+    if (!exceptions.TSTupleType) {
+      nodes.TSTupleType = node =>
+        validateComma(node, node.elementTypes)
     }
 
     return nodes
+
+    /** Checks the comma placement in object properties. */
+    function validateObjectProperties(node: Tree.ObjectExpression | Tree.ObjectPattern) {
+      validateComma(node, node.properties)
+    }
+    /** Checks the comma placement in array elements. */
+    function validateArrayElements(node: Tree.ArrayExpression | Tree.ArrayPattern) {
+      validateComma(node, node.elements)
+    }
+    /** Checks the comma placement in function parameters. */
+    function validateFunctionParams(
+      node: Tree.FunctionDeclaration
+        | Tree.FunctionExpression
+        | Tree.ArrowFunctionExpression
+        | Tree.TSDeclareFunction
+        | Tree.TSFunctionType
+        | Tree.TSConstructorType
+        | Tree.TSEmptyBodyFunctionExpression
+        | Tree.TSMethodSignature
+        | Tree.TSCallSignatureDeclaration
+        | Tree.TSConstructSignatureDeclaration,
+    ) {
+      validateComma(node, node.params)
+    }
+    /** Checks the comma placement in call arguments. */
+    function validateCallArguments(node: Tree.CallExpression | Tree.NewExpression) {
+      validateComma(node, node.arguments)
+    }
+    /** Checks the comma placement in import attributes. */
+    function visitImportAttributes(node: Tree.ImportDeclaration | Tree.ExportAllDeclaration | Tree.ExportNamedDeclaration) {
+      validateComma(node, node.attributes)
+    }
+    /** Checks the comma placement in module specifiers. */
+    function visitModulesSpecifiers(node: Tree.ImportDeclaration | Tree.ExportNamedDeclaration) {
+      validateComma(node, node.specifiers)
+    }
+
+    /** Checks the comma placement in TypeScript class implements. */
+    function visitClassImplements(node: Tree.ClassDeclaration | Tree.ClassExpression) {
+      validateComma(node, node.implements)
+    }
+    /** Checks the comma placement in TypeScript enum/literal members. */
+    function visitMembers(node: Tree.TSEnumBody | Tree.TSTypeLiteral) {
+      validateComma(node, node.members)
+    }
+    /** Checks the comma placement in type parameters. */
+    function validateTypeParams(
+      node: Tree.TSTypeParameterDeclaration
+        | Tree.TSTypeParameterInstantiation,
+    ) {
+      validateComma(node, node.params)
+    }
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ catalogs:
       specifier: ^7.5.8
       version: 7.5.8
     '@typescript-eslint/parser':
-      specifier: ^8.12.2
-      version: 8.12.2
+      specifier: ^8.13.0
+      version: 8.13.0
     '@unocss/reset':
       specifier: ^0.63.6
       version: 0.63.6
@@ -215,7 +215,7 @@ catalogs:
       version: 1.4.2
 
 overrides:
-  '@typescript-eslint/utils': ^8.12.2
+  '@typescript-eslint/utils': ^8.13.0
   rollup: ^4.24.3
   twoslash-eslint: ^0.2.12
   unbuild: ^2.0.0
@@ -230,7 +230,7 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: 'catalog:'
-        version: 3.8.0(@typescript-eslint/utils@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(@vue/compiler-sfc@3.5.12)(eslint-plugin-format@0.1.2(eslint@9.13.0(jiti@2.3.3)))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)(vitest@2.1.4)
+        version: 3.8.0(@typescript-eslint/utils@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(@vue/compiler-sfc@3.5.12)(eslint-plugin-format@0.1.2(eslint@9.13.0(jiti@2.3.3)))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)(vitest@2.1.4)
       '@antfu/eslint-define-config':
         specifier: 'catalog:'
         version: 1.23.0-2
@@ -317,10 +317,10 @@ importers:
         version: 7.5.8
       '@typescript-eslint/parser':
         specifier: 'catalog:'
-        version: 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+        version: 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
       '@typescript-eslint/utils':
-        specifier: ^8.12.2
-        version: 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+        specifier: ^8.13.0
+        version: 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 2.1.4(vitest@2.1.4)
@@ -488,8 +488,8 @@ importers:
   packages/eslint-plugin:
     dependencies:
       '@typescript-eslint/utils':
-        specifier: ^8.12.2
-        version: 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+        specifier: ^8.13.0
+        version: 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
       eslint:
         specifier: '>=8.40.0'
         version: 9.13.0(jiti@2.3.3)
@@ -542,8 +542,8 @@ importers:
         specifier: workspace:*
         version: link:../metadata
       '@typescript-eslint/utils':
-        specifier: ^8.12.2
-        version: 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+        specifier: ^8.13.0
+        version: 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
 
   packages/eslint-plugin-plus:
     dependencies:
@@ -554,8 +554,8 @@ importers:
   packages/eslint-plugin-ts:
     dependencies:
       '@typescript-eslint/utils':
-        specifier: ^8.12.2
-        version: 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+        specifier: ^8.13.0
+        version: 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
       eslint:
         specifier: '>=8.40.0'
         version: 9.13.0(jiti@2.3.3)
@@ -1718,8 +1718,8 @@ packages:
   '@types/web-bluetooth@0.0.20':
     resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==}
 
-  '@typescript-eslint/eslint-plugin@8.11.0':
-    resolution: {integrity: sha512-KhGn2LjW1PJT2A/GfDpiyOfS4a8xHQv2myUagTM5+zsormOmBlYsnQ6pobJ8XxJmh6hnHwa2Mbe3fPrDJoDhbA==}
+  '@typescript-eslint/eslint-plugin@8.13.0':
+    resolution: {integrity: sha512-nQtBLiZYMUPkclSeC3id+x4uVd1SGtHuElTxL++SfP47jR0zfkZBJHc+gL4qPsgTuypz0k8Y2GheaDYn6Gy3rg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
@@ -1729,8 +1729,8 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/parser@8.12.2':
-    resolution: {integrity: sha512-MrvlXNfGPLH3Z+r7Tk+Z5moZAc0dzdVjTgUgwsdGweH7lydysQsnSww3nAmsq8blFuRD5VRlAr9YdEFw3e6PBw==}
+  '@typescript-eslint/parser@8.13.0':
+    resolution: {integrity: sha512-w0xp+xGg8u/nONcGw1UXAr6cjCPU1w0XVyBs6Zqaj5eLmxkKQAByTdV/uGgNN5tVvN/kKpoQlP2cL7R+ajZZIQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -1739,16 +1739,12 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/scope-manager@8.11.0':
-    resolution: {integrity: sha512-Uholz7tWhXmA4r6epo+vaeV7yjdKy5QFCERMjs1kMVsLRKIrSdM6o21W2He9ftp5PP6aWOVpD5zvrvuHZC0bMQ==}
+  '@typescript-eslint/scope-manager@8.13.0':
+    resolution: {integrity: sha512-XsGWww0odcUT0gJoBZ1DeulY1+jkaHUciUq4jKNv4cpInbvvrtDoyBH9rE/n2V29wQJPk8iCH1wipra9BhmiMA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/scope-manager@8.12.2':
-    resolution: {integrity: sha512-gPLpLtrj9aMHOvxJkSbDBmbRuYdtiEbnvO25bCMza3DhMjTQw0u7Y1M+YR5JPbMsXXnSPuCf5hfq0nEkQDL/JQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/type-utils@8.11.0':
-    resolution: {integrity: sha512-ItiMfJS6pQU0NIKAaybBKkuVzo6IdnAhPFZA/2Mba/uBjuPQPet/8+zh5GtLHwmuFRShZx+8lhIs7/QeDHflOg==}
+  '@typescript-eslint/type-utils@8.13.0':
+    resolution: {integrity: sha512-Rqnn6xXTR316fP4D2pohZenJnp+NwQ1mo7/JM+J1LWZENSLkJI8ID8QNtlvFeb0HnFSK94D6q0cnMX6SbE5/vA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '*'
@@ -1756,16 +1752,12 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/types@8.11.0':
-    resolution: {integrity: sha512-tn6sNMHf6EBAYMvmPUaKaVeYvhUsrE6x+bXQTxjQRp360h1giATU0WvgeEys1spbvb5R+VpNOZ+XJmjD8wOUHw==}
+  '@typescript-eslint/types@8.13.0':
+    resolution: {integrity: sha512-4cyFErJetFLckcThRUFdReWJjVsPCqyBlJTi6IDEpc1GWCIIZRFxVppjWLIMcQhNGhdWJJRYFHpHoDWvMlDzng==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.12.2':
-    resolution: {integrity: sha512-VwDwMF1SZ7wPBUZwmMdnDJ6sIFk4K4s+ALKLP6aIQsISkPv8jhiw65sAK6SuWODN/ix+m+HgbYDkH+zLjrzvOA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.11.0':
-    resolution: {integrity: sha512-yHC3s1z1RCHoCz5t06gf7jH24rr3vns08XXhfEqzYpd6Hll3z/3g23JRi0jM8A47UFKNc3u/y5KIMx8Ynbjohg==}
+  '@typescript-eslint/typescript-estree@8.13.0':
+    resolution: {integrity: sha512-v7SCIGmVsRK2Cy/LTLGN22uea6SaUIlpBcO/gnMGT/7zPtxp90bphcGf4fyrCQl3ZtiBKqVTG32hb668oIYy1g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '*'
@@ -1773,27 +1765,14 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/typescript-estree@8.12.2':
-    resolution: {integrity: sha512-mME5MDwGe30Pq9zKPvyduyU86PH7aixwqYR2grTglAdB+AN8xXQ1vFGpYaUSJ5o5P/5znsSBeNcs5g5/2aQwow==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@typescript-eslint/utils@8.12.2':
-    resolution: {integrity: sha512-UTTuDIX3fkfAz6iSVa5rTuSfWIYZ6ATtEocQ/umkRSyC9O919lbZ8dcH7mysshrCdrAM03skJOEYaBugxN+M6A==}
+  '@typescript-eslint/utils@8.13.0':
+    resolution: {integrity: sha512-A1EeYOND6Uv250nybnLZapeXpYMl8tkzYUxqmoKAWnI4sei3ihf2XdZVd+vVOmHGcp3t+P7yRrNsyyiXTvShFQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
 
-  '@typescript-eslint/visitor-keys@8.11.0':
-    resolution: {integrity: sha512-EaewX6lxSjRJnc+99+dqzTeoDZUfyrA52d2/HRrkI830kgovWsmIiTfmr0NZorzqic7ga+1bS60lRBUgR3n/Bw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/visitor-keys@8.12.2':
-    resolution: {integrity: sha512-PChz8UaKQAVNHghsHcPyx1OMHoFRUEA7rJSK/mDhdq85bk+PLsUHUBqTQTFt18VJZbmxBovM65fezlheQRsSDA==}
+  '@typescript-eslint/visitor-keys@8.13.0':
+    resolution: {integrity: sha512-7N/+lztJqH4Mrf0lb10R/CbI1EaAMMGyF5y0oJvFoAhafwgiRA7TXyd8TFn8FC8k5y2dTsYogg238qavRGNnlw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript/vfs@1.6.0':
@@ -1903,8 +1882,8 @@ packages:
   '@vitest/eslint-plugin@1.1.7':
     resolution: {integrity: sha512-pTWGW3y6lH2ukCuuffpan6kFxG6nIuoesbhMiQxskyQMRcCN5t9SXsKrNHvEw3p8wcCsgJoRqFZVkOTn6TjclA==}
     peerDependencies:
-      '@typescript-eslint/utils': ^8.12.2
-      eslint: ^9.12.0
+      '@typescript-eslint/utils': ^8.13.0
+      eslint: '>= 8.57.0'
       typescript: '>= 5.0.0'
       vitest: ^2.1.4
     peerDependenciesMeta:
@@ -4181,7 +4160,7 @@ packages:
   twoslash@0.2.12:
     resolution: {integrity: sha512-tEHPASMqi7kqwfJbkk7hc/4EhlrKCSLcur+TcvYki3vhIfaRMXnXjaYFgXpoZRbT6GdprD4tGuVBEmTpUgLBsw==}
     peerDependencies:
-      typescript: ^5.6.2
+      typescript: '*'
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -4604,16 +4583,16 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@antfu/eslint-config@3.8.0(@typescript-eslint/utils@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(@vue/compiler-sfc@3.5.12)(eslint-plugin-format@0.1.2(eslint@9.13.0(jiti@2.3.3)))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)(vitest@2.1.4)':
+  '@antfu/eslint-config@3.8.0(@typescript-eslint/utils@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(@vue/compiler-sfc@3.5.12)(eslint-plugin-format@0.1.2(eslint@9.13.0(jiti@2.3.3)))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)(vitest@2.1.4)':
     dependencies:
       '@antfu/install-pkg': 0.4.1
       '@clack/prompts': 0.7.0
       '@eslint-community/eslint-plugin-eslint-comments': 4.4.0(eslint@9.13.0(jiti@2.3.3))
       '@eslint/markdown': 6.2.0
       '@stylistic/eslint-plugin': 2.9.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
-      '@typescript-eslint/eslint-plugin': 8.11.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
-      '@typescript-eslint/parser': 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
-      '@vitest/eslint-plugin': 1.1.7(@typescript-eslint/utils@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)(vitest@2.1.4)
+      '@typescript-eslint/eslint-plugin': 8.13.0(@typescript-eslint/parser@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@vitest/eslint-plugin': 1.1.7(@typescript-eslint/utils@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)(vitest@2.1.4)
       eslint: 9.13.0(jiti@2.3.3)
       eslint-config-flat-gitignore: 0.3.0(eslint@9.13.0(jiti@2.3.3))
       eslint-flat-config-utils: 0.4.0
@@ -4629,7 +4608,7 @@ snapshots:
       eslint-plugin-regexp: 2.6.0(eslint@9.13.0(jiti@2.3.3))
       eslint-plugin-toml: 0.11.1(eslint@9.13.0(jiti@2.3.3))
       eslint-plugin-unicorn: 56.0.0(eslint@9.13.0(jiti@2.3.3))
-      eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.11.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))
+      eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.13.0(@typescript-eslint/parser@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))
       eslint-plugin-vue: 9.30.0(eslint@9.13.0(jiti@2.3.3))
       eslint-plugin-yml: 1.14.0(eslint@9.13.0(jiti@2.3.3))
       eslint-processor-vue-blocks: 0.1.2(@vue/compiler-sfc@3.5.12)(eslint@9.13.0(jiti@2.3.3))
@@ -5443,7 +5422,7 @@ snapshots:
 
   '@stylistic/eslint-plugin@2.9.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
       eslint: 9.13.0(jiti@2.3.3)
       eslint-visitor-keys: 4.2.0
       espree: 10.3.0
@@ -5522,14 +5501,14 @@ snapshots:
 
   '@types/web-bluetooth@0.0.20': {}
 
-  '@typescript-eslint/eslint-plugin@8.11.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)':
+  '@typescript-eslint/eslint-plugin@8.13.0(@typescript-eslint/parser@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
-      '@typescript-eslint/scope-manager': 8.11.0
-      '@typescript-eslint/type-utils': 8.11.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
-      '@typescript-eslint/visitor-keys': 8.11.0
+      '@typescript-eslint/parser': 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/scope-manager': 8.13.0
+      '@typescript-eslint/type-utils': 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/visitor-keys': 8.13.0
       eslint: 9.13.0(jiti@2.3.3)
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -5540,12 +5519,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)':
+  '@typescript-eslint/parser@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.12.2
-      '@typescript-eslint/types': 8.12.2
-      '@typescript-eslint/typescript-estree': 8.12.2(typescript@5.6.3)
-      '@typescript-eslint/visitor-keys': 8.12.2
+      '@typescript-eslint/scope-manager': 8.13.0
+      '@typescript-eslint/types': 8.13.0
+      '@typescript-eslint/typescript-estree': 8.13.0(typescript@5.6.3)
+      '@typescript-eslint/visitor-keys': 8.13.0
       debug: 4.3.7
       eslint: 9.13.0(jiti@2.3.3)
     optionalDependencies:
@@ -5553,20 +5532,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.11.0':
+  '@typescript-eslint/scope-manager@8.13.0':
     dependencies:
-      '@typescript-eslint/types': 8.11.0
-      '@typescript-eslint/visitor-keys': 8.11.0
+      '@typescript-eslint/types': 8.13.0
+      '@typescript-eslint/visitor-keys': 8.13.0
 
-  '@typescript-eslint/scope-manager@8.12.2':
+  '@typescript-eslint/type-utils@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/types': 8.12.2
-      '@typescript-eslint/visitor-keys': 8.12.2
-
-  '@typescript-eslint/type-utils@8.11.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)':
-    dependencies:
-      '@typescript-eslint/typescript-estree': 8.11.0(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 8.13.0(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
       debug: 4.3.7
       ts-api-utils: 1.3.0(typescript@5.6.3)
     optionalDependencies:
@@ -5575,14 +5549,12 @@ snapshots:
       - eslint
       - supports-color
 
-  '@typescript-eslint/types@8.11.0': {}
+  '@typescript-eslint/types@8.13.0': {}
 
-  '@typescript-eslint/types@8.12.2': {}
-
-  '@typescript-eslint/typescript-estree@8.11.0(typescript@5.6.3)':
+  '@typescript-eslint/typescript-estree@8.13.0(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/types': 8.11.0
-      '@typescript-eslint/visitor-keys': 8.11.0
+      '@typescript-eslint/types': 8.13.0
+      '@typescript-eslint/visitor-keys': 8.13.0
       debug: 4.3.7
       fast-glob: 3.3.2
       is-glob: 4.0.3
@@ -5594,40 +5566,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.12.2(typescript@5.6.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.12.2
-      '@typescript-eslint/visitor-keys': 8.12.2
-      debug: 4.3.7
-      fast-glob: 3.3.2
-      is-glob: 4.0.3
-      minimatch: 9.0.5
-      semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.6.3)
-    optionalDependencies:
-      typescript: 5.6.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)':
+  '@typescript-eslint/utils@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.13.0(jiti@2.3.3))
-      '@typescript-eslint/scope-manager': 8.12.2
-      '@typescript-eslint/types': 8.12.2
-      '@typescript-eslint/typescript-estree': 8.12.2(typescript@5.6.3)
+      '@typescript-eslint/scope-manager': 8.13.0
+      '@typescript-eslint/types': 8.13.0
+      '@typescript-eslint/typescript-estree': 8.13.0(typescript@5.6.3)
       eslint: 9.13.0(jiti@2.3.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/visitor-keys@8.11.0':
+  '@typescript-eslint/visitor-keys@8.13.0':
     dependencies:
-      '@typescript-eslint/types': 8.11.0
-      eslint-visitor-keys: 3.4.3
-
-  '@typescript-eslint/visitor-keys@8.12.2':
-    dependencies:
-      '@typescript-eslint/types': 8.12.2
+      '@typescript-eslint/types': 8.13.0
       eslint-visitor-keys: 3.4.3
 
   '@typescript/vfs@1.6.0(typescript@5.6.3)':
@@ -5813,9 +5765,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/eslint-plugin@1.1.7(@typescript-eslint/utils@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)(vitest@2.1.4)':
+  '@vitest/eslint-plugin@1.1.7(@typescript-eslint/utils@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)(vitest@2.1.4)':
     dependencies:
-      '@typescript-eslint/utils': 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
       eslint: 9.13.0(jiti@2.3.3)
     optionalDependencies:
       typescript: 5.6.3
@@ -6547,7 +6499,7 @@ snapshots:
 
   eslint-plugin-import-x@4.3.1(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3):
     dependencies:
-      '@typescript-eslint/utils': 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
       debug: 4.3.7
       doctrine: 3.0.0
       eslint: 9.13.0(jiti@2.3.3)
@@ -6606,8 +6558,8 @@ snapshots:
 
   eslint-plugin-perfectionist@3.9.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)(vue-eslint-parser@9.4.3(eslint@9.13.0(jiti@2.3.3))):
     dependencies:
-      '@typescript-eslint/types': 8.12.2
-      '@typescript-eslint/utils': 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/types': 8.13.0
+      '@typescript-eslint/utils': 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
       eslint: 9.13.0(jiti@2.3.3)
       minimatch: 9.0.5
       natural-compare-lite: 1.4.0
@@ -6658,11 +6610,11 @@ snapshots:
       semver: 7.6.3
       strip-indent: 3.0.0
 
-  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.11.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3)):
+  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.13.0(@typescript-eslint/parser@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3)):
     dependencies:
       eslint: 9.13.0(jiti@2.3.3)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.11.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/eslint-plugin': 8.13.0(@typescript-eslint/parser@8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
 
   eslint-plugin-vue@9.30.0(eslint@9.13.0(jiti@2.3.3)):
     dependencies:
@@ -6719,7 +6671,7 @@ snapshots:
     dependencies:
       '@antfu/utils': 0.7.10
       '@types/eslint': 9.6.1
-      '@typescript-eslint/utils': 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.13.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3)
       eslint: 9.13.0(jiti@2.3.3)
       vitest: 2.1.4(@types/node@22.8.4)(@vitest/ui@2.1.4)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,8 +29,8 @@ catalog:
   '@types/node': ^22.8.4
   '@types/picomatch': ^3.0.1
   '@types/semver': ^7.5.8
-  '@typescript-eslint/parser': ^8.12.2
-  '@typescript-eslint/utils': ^8.12.2
+  '@typescript-eslint/parser': ^8.13.0
+  '@typescript-eslint/utils': ^8.13.0
   '@unocss/reset': ^0.63.6
   '@vitest/coverage-v8': ^2.1.4
   '@vitest/ui': ^2.1.4


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR adds support for more syntax to `comma-style` rule.

(I would like to change the default for the `exceptions` option to empty, but that would be a breaking change and I will not do so in this PR.)

### Linked Issues

close #596

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

~~The type annotation on ImportExpression#options seems to be missing.~~
~~https://github.com/typescript-eslint/typescript-eslint/issues/10236~~

Done
