### PR TITLE
fix(jsx-wrap-multilines): keep all text before replacement node parentheses

### DIFF
--- a/packages/eslint-plugin/rules/jsx-wrap-multilines/jsx-wrap-multilines._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-wrap-multilines/jsx-wrap-multilines._jsx_.test.ts
@@ -1487,5 +1487,46 @@ const obj = {
       options: [{ propertyValue: 'parens' }],
       errors: [{ messageId: 'missingParens' }],
     },
+    {
+      code: `
+    const MissingParenWIthCOmment = () =>
+      // Something about this line
+      <>
+        <input />
+      </>
+          `,
+      output: `
+    const MissingParenWIthCOmment = () => (
+      // Something about this line
+      <>
+        <input />
+      </>
+    )
+          `,
+      options: [{ arrow: 'parens-new-line' }],
+      errors: [{ messageId: 'missingParens' }],
+    },
+    {
+      code: `
+    var hello = {
+      foo:
+        // Something about this line
+        <div>
+          <p>Hello</p>
+        </div>
+    };
+          `,
+      output: `
+    var hello = {
+      foo: (
+        // Something about this line
+        <div>
+          <p>Hello</p>
+        </div>
+      )};
+          `,
+      options: [{ propertyValue: 'parens-new-line' }],
+      errors: [{ messageId: 'missingParens' }],
+    },
   ),
 })

--- a/packages/eslint-plugin/rules/jsx-wrap-multilines/jsx-wrap-multilines._jsx_.ts
+++ b/packages/eslint-plugin/rules/jsx-wrap-multilines/jsx-wrap-multilines._jsx_.ts
@@ -121,7 +121,7 @@ export default createRule<RuleOptions, MessageIds>({
       return node.loc.start.line !== node.loc.end.line
     }
 
-    function trimTokenBeforeNewline(node: ASTNode, tokenBefore: Token) {
+    function trimTokenBeforeNewline(tokenBefore: Token) {
       // if the token before the jsx is a bracket or curly brace
       // we don't want a space between the opening parentheses and the multiline jsx
       const isBracket = tokenBefore.value === '{' || tokenBefore.value === '['
@@ -145,10 +145,12 @@ export default createRule<RuleOptions, MessageIds>({
 
       if (option === 'parens-new-line' && isMultilines(node)) {
         if (!isParenthesized(node, context.sourceCode)) {
-          const tokenBefore = sourceCode.getTokenBefore(node, { includeComments: true })!
-          const tokenAfter = sourceCode.getTokenAfter(node, { includeComments: true })!
+          const tokenBefore = sourceCode.getTokenBefore(node)!
+          const tokenAfter = sourceCode.getTokenAfter(node)!
           const start = node.loc.start
           if (tokenBefore.loc.end.line < start.line) {
+            const textBetween = sourceCode.getText().slice(tokenBefore.range[1], node.range[0]).trim()
+            const indent = start.column > 0 ? ' '.repeat(start.column) : ''
             // Strip newline after operator if parens newline is specified
             context.report({
               node,
@@ -158,7 +160,7 @@ export default createRule<RuleOptions, MessageIds>({
                   tokenBefore.range[0],
                   tokenAfter && (tokenAfter.value === ';' || tokenAfter.value === '}') ? tokenAfter.range[0] : node.range[1],
                 ],
-                `${trimTokenBeforeNewline(node, tokenBefore)}(\n${start.column > 0 ? ' '.repeat(start.column) : ''}${sourceCode.getText(node)}\n${start.column > 0 ? ' '.repeat(start.column - 2) : ''})`,
+                `${trimTokenBeforeNewline(tokenBefore)}(\n${indent}${textBetween}${textBetween.length > 0 ? `\n${indent}` : ''}${sourceCode.getText(node)}\n${start.column > 0 ? ' '.repeat(start.column - 2) : ''})`,
               ),
             })
           }


### PR DESCRIPTION
…parentheses

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

close #552 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
