### PR TITLE
fix(indent): consider `CallExpression` when `offsetTernaryExpressions` is true

### DIFF
--- a/packages/eslint-plugin/rules/comma-spacing/comma-spacing._ts_.ts
+++ b/packages/eslint-plugin/rules/comma-spacing/comma-spacing._ts_.ts
@@ -118,9 +118,9 @@ export default createRule<RuleOptions, MessageIds>({
             spaceBefore
               ? fixer.insertTextBefore(commaToken, ' ')
               : fixer.replaceTextRange(
-                [prevToken.range[1], commaToken.range[0]],
-                '',
-              ),
+                  [prevToken.range[1], commaToken.range[0]],
+                  '',
+                ),
         })
       }
 
@@ -143,9 +143,9 @@ export default createRule<RuleOptions, MessageIds>({
             spaceAfter
               ? fixer.insertTextAfter(commaToken, ' ')
               : fixer.replaceTextRange(
-                [commaToken.range[1], nextToken.range[0]],
-                '',
-              ),
+                  [commaToken.range[1], nextToken.range[0]],
+                  '',
+                ),
         })
       }
     }

--- a/packages/eslint-plugin/rules/indent/indent._js_.test.ts
+++ b/packages/eslint-plugin/rules/indent/indent._js_.test.ts
@@ -2249,6 +2249,48 @@ run({
       `,
       options: ['tab', { offsetTernaryExpressions: true }],
     },
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/621
+    {
+      code: $`
+        const _obj = {
+          condition:
+            list.length > 3
+              ? t('string', {
+                  num: list.length,
+                })
+              : '',
+        };
+      `,
+      options: [2, { offsetTernaryExpressions: true }],
+    },
+    {
+      code: $`
+        const _obj = {
+          condition:
+            list.length > 3
+              ? t('string', {
+                num: list.length,
+              })
+              : '',
+        };
+      `,
+      options: [2, { offsetTernaryExpressions: false }],
+    },
+    {
+      code: $`
+        condition1
+          ? condition2
+            ? t()
+            : t({
+                foo,
+              })
+          : () => {
+              t()
+            }
+      `,
+      options: [2, { offsetTernaryExpressions: true }],
+    },
+
     $`
       [
           foo ?

--- a/packages/eslint-plugin/rules/indent/indent._js_.ts
+++ b/packages/eslint-plugin/rules/indent/indent._js_.ts
@@ -1166,7 +1166,10 @@ export default createRule<RuleOptions, MessageIds>({
           offsets.setDesiredOffset(
             firstConsequentToken,
             firstToken,
-            firstConsequentToken.type === 'Punctuator' && options.offsetTernaryExpressions ? 2 : 1,
+            (
+              firstConsequentToken.type === 'Punctuator'
+              || node.consequent.type === 'CallExpression'
+            ) && options.offsetTernaryExpressions ? 2 : 1,
           )
 
           /**
@@ -1192,8 +1195,14 @@ export default createRule<RuleOptions, MessageIds>({
              * If `baz` were aligned with `bar` rather than being offset by 1 from `foo`, `baz` would end up
              * having no expected indentation.
              */
-            offsets.setDesiredOffset(firstAlternateToken, firstToken, firstAlternateToken.type === 'Punctuator'
-            && options.offsetTernaryExpressions ? 2 : 1)
+            offsets.setDesiredOffset(
+              firstAlternateToken,
+              firstToken,
+              (
+                firstAlternateToken.type === 'Punctuator'
+                || node.alternate.type === 'CallExpression'
+              ) && options.offsetTernaryExpressions ? 2 : 1,
+            )
           }
         }
       },

--- a/packages/eslint-plugin/rules/jsx-curly-newline/jsx-curly-newline._jsx_.ts
+++ b/packages/eslint-plugin/rules/jsx-curly-newline/jsx-curly-newline._jsx_.ts
@@ -154,9 +154,9 @@ export default createRule<RuleOptions, MessageIds>({
               .trim()
               ? null // If there is a comment between the last element and the }, don't do a fix.
               : fixer.removeRange([
-                tokenBeforeRightCurly!.range[1],
-                rightCurly.range[0],
-              ])
+                  tokenBeforeRightCurly!.range[1],
+                  rightCurly.range[0],
+                ])
           },
         })
       }


### PR DESCRIPTION

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Closes #621 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
