### PR TITLE
docs: support eslint v9 parser

### DIFF
--- a/docs/packages/ts.md
+++ b/docs/packages/ts.md
@@ -27,7 +27,9 @@ export default [
     plugins: {
       '@stylistic/ts': stylisticTs // [!code ++]
     },
-    parser: parserTs,
+    languageOptions: {
+      parser: parserTs,
+    },
     rules: {
       '@typescript-eslint/indent': ['error', 2], // [!code --]
       '@stylistic/ts/indent': ['error', 2], // [!code ++]


### PR DESCRIPTION
### Description

Tried to follow the [docs for es-lint-plugin](https://eslint.style/packages/ts).
When using the suggested flat config I got this


```sh
Oops! Something went wrong! :(

ESLint: 9.16.0

A config object is using the "parser" key, which is not supported in flat config system.

Flat config uses "languageOptions.parser" to override the default parser.

Please see the following page for information on how to convert your config object into the correct format:
https://eslint.org/docs/latest/use/configure/migration-guide#custom-parsers

If you're not using "parser" directly (it may be coming from a plugin), please see the following:
```

Switching from 

```js
    parser: parserTs,
```
to
```js
    languageOptions: {
      parser: parserTs,
    },
```
solved the issue.



### Additional context

Related packages from `package.json`:
```
    "@eslint/js": "^9.16.0",
    "@stylistic/eslint-plugin": "^2.11.0",
    "@stylistic/eslint-plugin-js": "^2.11.0",
    "@stylistic/eslint-plugin-ts": "^2.11.0",
    "@typescript-eslint/parser": "^8.17.0",
    "eslint": "^9.16.0",
    "eslint-plugin-react": "^7.37.2",
```