### PR TITLE
feat(indent): introduce `offsetTernaryExpressionsOffsetCallExpressions` options

### DIFF
--- a/packages/eslint-plugin/rules/function-call-spacing/types._ts_.d.ts
+++ b/packages/eslint-plugin/rules/function-call-spacing/types._ts_.d.ts
@@ -1,6 +1,6 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: FtXazQV3Wp */
+/* @checksum: m5GCegSIt6 */
 
 export type FunctionCallSpacingSchema0 =
   | []

--- a/packages/eslint-plugin/rules/function-call-spacing/types.d.ts
+++ b/packages/eslint-plugin/rules/function-call-spacing/types.d.ts
@@ -1,6 +1,6 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: FtXazQV3Wp */
+/* @checksum: m5GCegSIt6 */
 
 export type FunctionCallSpacingSchema0 =
   | []

--- a/packages/eslint-plugin/rules/indent/README._js_.md
+++ b/packages/eslint-plugin/rules/indent/README._js_.md
@@ -1,6 +1,7 @@
 ---
 title: indent
 rule_type: layout
+outline: deep
 ---
 
 # js/indent
@@ -101,6 +102,7 @@ This rule has an object option:
 - `"ImportDeclaration"` (default: 1) enforces indentation level for import statements. It can be set to the string `"first"`, indicating that all imported members from a module should be aligned with the first member in the list. This can also be set to `"off"` to disable checking for imported module members.
 - `"flatTernaryExpressions": true` (`false` by default) requires no indentation for ternary expressions which are nested in other ternary expressions.
 - `"offsetTernaryExpressions": true` (`false` by default) requires indentation for values of ternary expressions.
+- `"offsetTernaryExpressionsOffsetFunctionCalls": true` (`true` by default), handles an edge case for call expressions nested in ternary. It's only effective when `offsetTernaryExpressions` is set to `true`.
 - `"ignoreComments"` (default: false) can be used when comments do not need to be aligned with nodes on the previous or next line.
 - `"tabLength"` (default: 4) when using tabbed indentation, the indentation used to calculate the insertion value of the template string
 
@@ -1051,6 +1053,52 @@ condition
     : () => {
         return false
       }
+```
+
+:::
+
+### offsetTernaryExpressionsOffsetCallExpressions
+
+> This option is only effective when `offsetTernaryExpressions` is set to `true`.
+
+Since v2.12.0, we [introduced a fix](https://github.com/eslint-stylistic/eslint-stylistic/pull/625) to call expressions handling inside ternary. With the new version, the rule now expect the following code to be correct:
+
+::: correct
+
+```js
+/*eslint indent: ["error", 2, { "offsetTernaryExpressions": true }]*/
+
+condition
+  ? gerUser({
+      name: 'foo',
+      age: 20,
+    })
+  : condition2
+    ? gerUser({
+        id: 'bar',
+      })
+    : undefined
+```
+
+:::
+
+Due to the new fix introduced changes to some existing codebase, we introduced this `offsetTernaryExpressionsOffsetCallExpressions` option to toggle the behaviors. It's set to `true` by default, where you can set it to `false` to use the previous behavior.
+
+::: correct
+
+```js
+/*eslint indent: ["error", 2, { "offsetTernaryExpressions": true, "offsetTernaryExpressionsOffsetCallExpressions": false }]*/
+
+condition
+  ? gerUser({
+    name: 'foo',
+    age: 20,
+  })
+  : condition2
+    ? gerUser({
+      id: 'bar',
+    })
+    : undefined
 ```
 
 :::

--- a/packages/eslint-plugin/rules/indent/indent._js_.test.ts
+++ b/packages/eslint-plugin/rules/indent/indent._js_.test.ts
@@ -2290,6 +2290,40 @@ run({
       `,
       options: [2, { offsetTernaryExpressions: true }],
     },
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/633
+    {
+      code: $`
+        const _obj = {
+          condition:
+            list.length > 3
+              ? t('string', {
+                num: list.length,
+              })
+              : '',
+        };
+      `,
+      options: [2, {
+        offsetTernaryExpressions: true,
+        offsetTernaryExpressionsOffsetCallExpressions: false,
+      }],
+    },
+    {
+      code: $`
+        condition1
+          ? condition2
+            ? t()
+            : t({
+              foo,
+            })
+          : () => {
+              t()
+            }
+      `,
+      options: [2, {
+        offsetTernaryExpressions: true,
+        offsetTernaryExpressionsOffsetCallExpressions: false,
+      }],
+    },
 
     $`
       [

--- a/packages/eslint-plugin/rules/indent/indent._js_.ts
+++ b/packages/eslint-plugin/rules/indent/indent._js_.ts
@@ -597,6 +597,10 @@ export default createRule<RuleOptions, MessageIds>({
             type: 'boolean',
             default: false,
           },
+          offsetTernaryExpressionsOffsetCallExpressions: {
+            type: 'boolean',
+            default: true,
+          },
           ignoredNodes: {
             type: 'array',
             items: {
@@ -661,6 +665,7 @@ export default createRule<RuleOptions, MessageIds>({
       ignoredNodes: [],
       ignoreComments: false,
       offsetTernaryExpressions: false,
+      offsetTernaryExpressionsOffsetCallExpressions: true,
       tabLength: 4,
     }
 
@@ -1163,13 +1168,18 @@ export default createRule<RuleOptions, MessageIds>({
           offsets.setDesiredOffset(questionMarkToken, firstToken, 1)
           offsets.setDesiredOffset(colonToken, firstToken, 1)
 
+          let offset = 1
+          if (options.offsetTernaryExpressions) {
+            if (firstConsequentToken.type === 'Punctuator')
+              offset = 2
+            if (options.offsetTernaryExpressionsOffsetCallExpressions && node.consequent.type === 'CallExpression')
+              offset = 2
+          }
+
           offsets.setDesiredOffset(
             firstConsequentToken,
             firstToken,
-            (
-              firstConsequentToken.type === 'Punctuator'
-              || node.consequent.type === 'CallExpression'
-            ) && options.offsetTernaryExpressions ? 2 : 1,
+            offset,
           )
 
           /**
@@ -1186,6 +1196,13 @@ export default createRule<RuleOptions, MessageIds>({
             offsets.setDesiredOffset(firstAlternateToken, firstConsequentToken, 0)
           }
           else {
+            let offset = 1
+            if (options.offsetTernaryExpressions) {
+              if (firstAlternateToken.type === 'Punctuator')
+                offset = 2
+              if (options.offsetTernaryExpressionsOffsetCallExpressions && node.alternate.type === 'CallExpression')
+                offset = 2
+            }
             /**
              * If the alternate and consequent do not share part of a line, offset the alternate from the first
              * token of the conditional expression. For example:
@@ -1198,10 +1215,7 @@ export default createRule<RuleOptions, MessageIds>({
             offsets.setDesiredOffset(
               firstAlternateToken,
               firstToken,
-              (
-                firstAlternateToken.type === 'Punctuator'
-                || node.alternate.type === 'CallExpression'
-              ) && options.offsetTernaryExpressions ? 2 : 1,
+              offset,
             )
           }
         }

--- a/packages/eslint-plugin/rules/indent/types.d.ts
+++ b/packages/eslint-plugin/rules/indent/types.d.ts
@@ -1,6 +1,6 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: IlsCRoaVnx */
+/* @checksum: zdiMvtTqyx */
 
 export type IndentSchema0 = 'tab' | number
 
@@ -34,6 +34,7 @@ export interface IndentSchema1 {
   ImportDeclaration?: number | ('first' | 'off')
   flatTernaryExpressions?: boolean
   offsetTernaryExpressions?: boolean
+  offsetTernaryExpressionsOffsetCallExpressions?: boolean
   ignoredNodes?: string[]
   ignoreComments?: boolean
   tabLength?: number


### PR DESCRIPTION
Resolves: https://github.com/eslint-stylistic/eslint-stylistic/issues/633

This PR introduces the new `offsetTernaryExpressionsOffsetCallExpressions` option for `indent` for users to switch back to the behavior in 2.11 before the fix of https://github.com/eslint-stylistic/eslint-stylistic/pull/625