### PR TITLE
feat(quotes): Option to allow template literals only to avoid escape

### DIFF
--- a/packages/eslint-plugin/rules/quotes/README._js_.md
+++ b/packages/eslint-plugin/rules/quotes/README._js_.md
@@ -38,10 +38,13 @@ String option:
 Object option:
 
 - `"avoidEscape": true` allows strings to use single-quotes, double-quotes, or template literals so long as the string contains a quote that would have to be escaped otherwise
-- `"allowTemplateLiterals": true` allows strings to use backticks
+- `"allowTemplateLiterals": "always"` allows strings to use backticks in all cases
+- `"allowTemplateLiterals": "avoidEscape"` allows strings to use backticks only if necessary to avoid escaping a string
 - `"ignoreStringLiterals": true` don’t report string literals, only template strings
 
 **Deprecated**: The object property `avoid-escape` is deprecated; please use the object property `avoidEscape` instead.
+
+**Deprecated**: Boolean values for `allowTemplateLiterals` are deprecated. `true` equates to `"always"` and false equates to `"never"`.
 
 ### double
 

--- a/packages/eslint-plugin/rules/quotes/README._js_.md
+++ b/packages/eslint-plugin/rules/quotes/README._js_.md
@@ -37,14 +37,15 @@ String option:
 
 Object option:
 
-- `"avoidEscape": true` allows strings to use single-quotes, double-quotes, or template literals so long as the string contains a quote that would have to be escaped otherwise
+- `"avoidEscape": true` allows strings to use single-quotes, double-quotes, or template literals so long as the string contains a quote that would have to be escaped otherwise (default: `false`)
 - `"allowTemplateLiterals": "always"` allows strings to use backticks in all cases
 - `"allowTemplateLiterals": "avoidEscape"` allows strings to use backticks only if necessary to avoid escaping a string
-- `"ignoreStringLiterals": true` don’t report string literals, only template strings
+- `"allowTemplateLiterals": "never"` (default) disallows strings to use backtick in all cases
+- `"ignoreStringLiterals": true` don’t report string literals, only template strings (default: `false`)
 
 **Deprecated**: The object property `avoid-escape` is deprecated; please use the object property `avoidEscape` instead.
 
-**Deprecated**: Boolean values for `allowTemplateLiterals` are deprecated. `true` equates to `"always"` and false equates to `"never"`.
+**Deprecated**: Boolean values for `allowTemplateLiterals` are deprecated. `true` equates to `"always"` and `false` equates to `"never"`.
 
 ### double
 

--- a/packages/eslint-plugin/rules/quotes/quotes._js_.test.ts
+++ b/packages/eslint-plugin/rules/quotes/quotes._js_.test.ts
@@ -22,7 +22,11 @@ run({
     { code: 'var foo = "\'";', options: ['single', { avoidEscape: true }] },
     { code: 'var foo = \'"\';', options: ['double', { avoidEscape: true }] },
     { code: 'var foo = `\'`;', options: ['single', { avoidEscape: true, allowTemplateLiterals: true }] },
+    { code: 'var foo = `\'`;', options: ['single', { avoidEscape: true, allowTemplateLiterals: 'always' }] },
+    { code: 'var foo = `\'`;', options: ['single', { avoidEscape: true, allowTemplateLiterals: 'avoidEscape' }] },
     { code: 'var foo = `"`;', options: ['double', { avoidEscape: true, allowTemplateLiterals: true }] },
+    { code: 'var foo = `"`;', options: ['double', { avoidEscape: true, allowTemplateLiterals: 'always' }] },
+    { code: 'var foo = `"`;', options: ['double', { avoidEscape: true, allowTemplateLiterals: 'avoidEscape' }] },
     { code: 'var foo = <>Hello world</>;', options: ['single'], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
     { code: 'var foo = <>Hello world</>;', options: ['double'], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
     { code: 'var foo = <>Hello world</>;', options: ['double', { avoidEscape: true }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
@@ -57,8 +61,11 @@ run({
 
     // Backticks are also okay if allowTemplateLiterals
     { code: 'var foo = `bar \'foo\' baz` + \'bar\';', options: ['single', { allowTemplateLiterals: true }], parserOptions: { ecmaVersion: 6 } },
+    { code: 'var foo = `bar \'foo\' baz` + \'bar\';', options: ['single', { allowTemplateLiterals: 'always' }], parserOptions: { ecmaVersion: 6 } },
     { code: 'var foo = `bar \'foo\' baz` + "bar";', options: ['double', { allowTemplateLiterals: true }], parserOptions: { ecmaVersion: 6 } },
+    { code: 'var foo = `bar \'foo\' baz` + "bar";', options: ['double', { allowTemplateLiterals: 'always' }], parserOptions: { ecmaVersion: 6 } },
     { code: 'var foo = `bar \'foo\' baz` + `bar`;', options: ['backtick', { allowTemplateLiterals: true }], parserOptions: { ecmaVersion: 6 } },
+    { code: 'var foo = `bar \'foo\' baz` + `bar`;', options: ['backtick', { allowTemplateLiterals: 'always' }], parserOptions: { ecmaVersion: 6 } },
 
     // `backtick` should not warn the directive prologues.
     { code: '"use strict"; var foo = `backtick`;', options: ['backtick'], parserOptions: { ecmaVersion: 6 } },
@@ -252,9 +259,29 @@ run({
       }],
     },
     {
+      code: 'var foo = "bar";',
+      output: 'var foo = \'bar\';',
+      options: ['single', { allowTemplateLiterals: 'always' }],
+      errors: [{
+        messageId: 'wrongQuotes',
+        data: { description: 'singlequote' },
+        type: 'Literal',
+      }],
+    },
+    {
       code: 'var foo = \'bar\';',
       output: 'var foo = "bar";',
       options: ['double', { allowTemplateLiterals: true }],
+      errors: [{
+        messageId: 'wrongQuotes',
+        data: { description: 'doublequote' },
+        type: 'Literal',
+      }],
+    },
+    {
+      code: 'var foo = \'bar\';',
+      output: 'var foo = "bar";',
+      options: ['double', { allowTemplateLiterals: 'always' }],
       errors: [{
         messageId: 'wrongQuotes',
         data: { description: 'doublequote' },
@@ -807,6 +834,38 @@ run({
         {
           avoidEscape: true,
           allowTemplateLiterals: false,
+        },
+      ],
+      errors: [{
+        messageId: 'wrongQuotes',
+        data: { description: 'doublequote' },
+        type: 'TemplateLiteral',
+      }],
+    },
+    {
+      code: 'var foo = `"bar"`',
+      output: 'var foo = "\\"bar\\""',
+      options: [
+        'double',
+        {
+          avoidEscape: true,
+          allowTemplateLiterals: 'never',
+        },
+      ],
+      errors: [{
+        messageId: 'wrongQuotes',
+        data: { description: 'doublequote' },
+        type: 'TemplateLiteral',
+      }],
+    },
+    {
+      code: 'var foo = `bar`',
+      output: 'var foo = "bar"',
+      options: [
+        'double',
+        {
+          avoidEscape: true,
+          allowTemplateLiterals: 'avoidEscape',
         },
       ],
       errors: [{

--- a/packages/eslint-plugin/rules/quotes/quotes._js_.ts
+++ b/packages/eslint-plugin/rules/quotes/quotes._js_.ts
@@ -135,7 +135,7 @@ export default createRule<RuleOptions, MessageIds>({
         allowTemplateLiteralsAlways = options.allowTemplateLiterals === 'always'
         allowTemplateLiteralsToAvoidEscape = allowTemplateLiteralsAlways || options.allowTemplateLiterals === 'avoidEscape'
       }
-      else if (typeof (options.allowTemplateLiterals) === 'boolean') {
+      else if (typeof (options.allowTemplateLiterals) === 'boolean') { // deprecated
         allowTemplateLiteralsAlways = options.allowTemplateLiterals === true
         allowTemplateLiteralsToAvoidEscape = options.allowTemplateLiterals === true
       }

--- a/packages/eslint-plugin/rules/quotes/quotes._ts_.ts
+++ b/packages/eslint-plugin/rules/quotes/quotes._ts_.ts
@@ -23,7 +23,7 @@ export default createRule<RuleOptions, MessageIds>({
   defaultOptions: [
     'double',
     {
-      allowTemplateLiterals: false,
+      allowTemplateLiterals: 'never',
       avoidEscape: false,
       ignoreStringLiterals: false,
     },

--- a/packages/eslint-plugin/rules/quotes/types.d.ts
+++ b/packages/eslint-plugin/rules/quotes/types.d.ts
@@ -1,6 +1,6 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: 6dfSzlZQG3 */
+/* @checksum: 4GFgaFKvmu */
 
 export type QuotesSchema0 = 'single' | 'double' | 'backtick'
 
@@ -8,7 +8,9 @@ export type QuotesSchema1 =
   | 'avoid-escape'
   | {
     avoidEscape?: boolean
-    allowTemplateLiterals?: boolean
+    allowTemplateLiterals?:
+      | boolean
+      | ('never' | 'avoidEscape' | 'always')
     ignoreStringLiterals?: boolean
   }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

In the quotes rule, allowTemplateLiterals is too complicated to represent as a boolean. Some people want template literals to always be allowed regardless of which quote type has been chosen. Some people want template literals to never be allowed. Some people want template literals to be allowed only if necessary to avoid escaping quotes in a string.

This change deprecates the boolean form of allowTemplateLiterals and adds a new string form that can be `always`, `never`, or `avoidEscape`. This allows users to configure the rule with any of the behaviors described above.

### Linked Issues

Fixes #554
Relates to #542 and #544

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
