### PR TITLE
refactor: replace deprecated `isSpaceBetweenTokens` with `isSpaceBetween`

### DIFF
--- a/packages/eslint-plugin/rules/array-bracket-spacing/array-bracket-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/array-bracket-spacing/array-bracket-spacing._js_.ts
@@ -199,18 +199,18 @@ export default createRule<RuleOptions, MessageIds>({
                   ? !options.spaced : options.spaced
 
       if (isTokenOnSameLine(first, second)) {
-        if (openingBracketMustBeSpaced && !sourceCode.isSpaceBetweenTokens(first, second))
+        if (openingBracketMustBeSpaced && !sourceCode.isSpaceBetween(first, second))
           reportRequiredBeginningSpace(node, first)
 
-        if (!openingBracketMustBeSpaced && sourceCode.isSpaceBetweenTokens(first, second))
+        if (!openingBracketMustBeSpaced && sourceCode.isSpaceBetween(first, second))
           reportNoBeginningSpace(node, first)
       }
 
       if (first !== penultimate && isTokenOnSameLine(penultimate, last)) {
-        if (closingBracketMustBeSpaced && !sourceCode.isSpaceBetweenTokens(penultimate, last))
+        if (closingBracketMustBeSpaced && !sourceCode.isSpaceBetween(penultimate, last))
           reportRequiredEndingSpace(node, last)
 
-        if (!closingBracketMustBeSpaced && sourceCode.isSpaceBetweenTokens(penultimate, last))
+        if (!closingBracketMustBeSpaced && sourceCode.isSpaceBetween(penultimate, last))
           reportNoEndingSpace(node, last)
       }
     }

--- a/packages/eslint-plugin/rules/block-spacing/block-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/block-spacing/block-spacing._js_.ts
@@ -68,7 +68,7 @@ export default createRule<RuleOptions, MessageIds>({
     function isValid(left: Token, right: Token): boolean {
       return (
         !isTokenOnSameLine(left, right)
-        || sourceCode.isSpaceBetweenTokens(left, right) === always
+        || sourceCode.isSpaceBetween(left, right) === always
       )
     }
 

--- a/packages/eslint-plugin/rules/comma-spacing/comma-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/comma-spacing/comma-spacing._js_.ts
@@ -144,7 +144,7 @@ export default createRule<RuleOptions, MessageIds>({
             && !commaTokensToIgnore.includes(token)
 
             && isTokenOnSameLine(previousToken, token)
-            && options.before !== sourceCode.isSpaceBetweenTokens(previousToken, token)
+            && options.before !== sourceCode.isSpaceBetween(previousToken, token)
           ) {
             report(token, 'before', previousToken)
           }
@@ -157,7 +157,7 @@ export default createRule<RuleOptions, MessageIds>({
             && !isClosingBraceToken(nextToken) // controlled by object-curly-spacing
             && !(!options.after && nextToken.type === 'Line') // special case, allow space before line comment
             && isTokenOnSameLine(token, nextToken)
-            && options.after !== sourceCode.isSpaceBetweenTokens(token, nextToken)
+            && options.after !== sourceCode.isSpaceBetween(token, nextToken)
           ) {
             report(token, 'after', nextToken)
           }

--- a/packages/eslint-plugin/rules/computed-property-spacing/computed-property-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/computed-property-spacing/computed-property-spacing._js_.ts
@@ -153,22 +153,22 @@ export default createRule<RuleOptions, MessageIds>({
 
         if (isTokenOnSameLine(before, first)) {
           if (propertyNameMustBeSpaced) {
-            if (!sourceCode.isSpaceBetweenTokens(before, first) && isTokenOnSameLine(before, first))
+            if (!sourceCode.isSpaceBetween(before, first) && isTokenOnSameLine(before, first))
               reportRequiredBeginningSpace(node, before)
           }
           else {
-            if (sourceCode.isSpaceBetweenTokens(before, first))
+            if (sourceCode.isSpaceBetween(before, first))
               reportNoBeginningSpace(node, before, first)
           }
         }
 
         if (isTokenOnSameLine(last, after)) {
           if (propertyNameMustBeSpaced) {
-            if (!sourceCode.isSpaceBetweenTokens(last, after) && isTokenOnSameLine(last, after))
+            if (!sourceCode.isSpaceBetween(last, after) && isTokenOnSameLine(last, after))
               reportRequiredEndingSpace(node, after)
           }
           else {
-            if (sourceCode.isSpaceBetweenTokens(last, after))
+            if (sourceCode.isSpaceBetween(last, after))
               reportNoEndingSpace(node, after, last)
           }
         }

--- a/packages/eslint-plugin/rules/jsx-curly-spacing/jsx-curly-spacing._jsx_.ts
+++ b/packages/eslint-plugin/rules/jsx-curly-spacing/jsx-curly-spacing._jsx_.ts
@@ -363,12 +363,12 @@ export default createRule<RuleOptions, MessageIds>({
       const isObjectLiteral = first.value === second.value
       const spacing = isObjectLiteral ? config.objectLiteralSpaces : config.when
       if (spacing === SPACING.always) {
-        if (!sourceCode.isSpaceBetweenTokens(first, second))
+        if (!sourceCode.isSpaceBetween(first, second))
           reportRequiredBeginningSpace(node, first)
         else if (!config.allowMultiline && isMultiline(first, second))
           reportNoBeginningNewline(node, first, spacing)
 
-        if (!sourceCode.isSpaceBetweenTokens(penultimate, last))
+        if (!sourceCode.isSpaceBetween(penultimate, last))
           reportRequiredEndingSpace(node, last)
         else if (!config.allowMultiline && isMultiline(penultimate, last))
           reportNoEndingNewline(node, last, spacing)
@@ -378,14 +378,14 @@ export default createRule<RuleOptions, MessageIds>({
           if (!config.allowMultiline)
             reportNoBeginningNewline(node, first, spacing)
         }
-        else if (sourceCode.isSpaceBetweenTokens(first, second)) {
+        else if (sourceCode.isSpaceBetween(first, second)) {
           reportNoBeginningSpace(node, first)
         }
         if (isMultiline(penultimate, last)) {
           if (!config.allowMultiline)
             reportNoEndingNewline(node, last, spacing)
         }
-        else if (sourceCode.isSpaceBetweenTokens(penultimate, last)) {
+        else if (sourceCode.isSpaceBetween(penultimate, last)) {
           reportNoEndingSpace(node, last)
         }
       }

--- a/packages/eslint-plugin/rules/jsx-equals-spacing/jsx-equals-spacing._jsx_.ts
+++ b/packages/eslint-plugin/rules/jsx-equals-spacing/jsx-equals-spacing._jsx_.ts
@@ -45,8 +45,8 @@ export default createRule<RuleOptions, MessageIds>({
 
           const sourceCode = context.sourceCode
           const equalToken = sourceCode.getTokenAfter(attrNode.name)!
-          const spacedBefore = sourceCode.isSpaceBetweenTokens(attrNode.name as unknown as Token, equalToken)
-          const spacedAfter = sourceCode.isSpaceBetweenTokens(equalToken, attrNode.value as unknown as Token)
+          const spacedBefore = sourceCode.isSpaceBetween(attrNode.name as unknown as Token, equalToken)
+          const spacedAfter = sourceCode.isSpaceBetween(equalToken, attrNode.value as unknown as Token)
 
           if (config === 'never') {
             if (spacedBefore) {

--- a/packages/eslint-plugin/rules/jsx-one-expression-per-line/jsx-one-expression-per-line._jsx_.ts
+++ b/packages/eslint-plugin/rules/jsx-one-expression-per-line/jsx-one-expression-per-line._jsx_.ts
@@ -192,13 +192,13 @@ export default createRule<RuleOptions, MessageIds>({
           const spaceBetweenPrev = () => {
             return ((prevChild!.type === 'Literal' || prevChild!.type === 'JSXText') && prevChild!.raw.endsWith(' '))
               || ((child.type === 'Literal' || child.type === 'JSXText') && child.raw.startsWith(' '))
-              || context.sourceCode.isSpaceBetweenTokens(prevChild as unknown as Token, child as unknown as Token)
+              || context.sourceCode.isSpaceBetween(prevChild as unknown as Token, child as unknown as Token)
           }
 
           const spaceBetweenNext = () => {
             return ((nextChild!.type === 'Literal' || nextChild!.type === 'JSXText') && nextChild!.raw.startsWith(' '))
               || ((child.type === 'Literal' || child.type === 'JSXText') && child.raw.endsWith(' '))
-              || context.sourceCode.isSpaceBetweenTokens(child as unknown as Token, nextChild as unknown as Token)
+              || context.sourceCode.isSpaceBetween(child as unknown as Token, nextChild as unknown as Token)
           }
 
           const source = context.sourceCode.getText(child)

--- a/packages/eslint-plugin/rules/jsx-one-expression-per-line/jsx-one-expression-per-line._jsx_.ts
+++ b/packages/eslint-plugin/rules/jsx-one-expression-per-line/jsx-one-expression-per-line._jsx_.ts
@@ -3,7 +3,7 @@
  * @author Mark Ivan Allen <Vydia.com>
  */
 
-import type { ASTNode, Token, Tree } from '#types'
+import type { ASTNode, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
 import { isWhiteSpaces } from '#utils/ast/jsx'
 import { createRule } from '#utils/create-rule'
@@ -190,15 +190,19 @@ export default createRule<RuleOptions, MessageIds>({
             return
 
           const spaceBetweenPrev = () => {
+            // There must only be one token at most
+            const tokenBetweenNodes = context.sourceCode.getTokensBetween(prevChild!, child)[0]
             return ((prevChild!.type === 'Literal' || prevChild!.type === 'JSXText') && prevChild!.raw.endsWith(' '))
               || ((child.type === 'Literal' || child.type === 'JSXText') && child.raw.startsWith(' '))
-              || context.sourceCode.isSpaceBetween(prevChild as unknown as Token, child as unknown as Token)
+              || isWhiteSpaces(tokenBetweenNodes?.value)
           }
 
           const spaceBetweenNext = () => {
+            // There must only be one token at most
+            const tokenBetweenNodes = context.sourceCode.getTokensBetween(child, nextChild!)[0]
             return ((nextChild!.type === 'Literal' || nextChild!.type === 'JSXText') && nextChild!.raw.startsWith(' '))
               || ((child.type === 'Literal' || child.type === 'JSXText') && child.raw.endsWith(' '))
-              || context.sourceCode.isSpaceBetween(child as unknown as Token, nextChild as unknown as Token)
+              || isWhiteSpaces(tokenBetweenNodes?.value)
           }
 
           const source = context.sourceCode.getText(child)

--- a/packages/eslint-plugin/rules/jsx-tag-spacing/jsx-tag-spacing._jsx_.ts
+++ b/packages/eslint-plugin/rules/jsx-tag-spacing/jsx-tag-spacing._jsx_.ts
@@ -38,7 +38,7 @@ function validateClosingSlash(
   if ('selfClosing' in node && node.selfClosing) {
     const lastTokens = sourceCode.getLastTokens(node, 2)
 
-    adjacent = !sourceCode.isSpaceBetweenTokens(lastTokens[0], lastTokens[1])
+    adjacent = !sourceCode.isSpaceBetween(lastTokens[0], lastTokens[1])
 
     if (option === 'never') {
       if (!adjacent) {
@@ -72,7 +72,7 @@ function validateClosingSlash(
   else {
     const firstTokens = sourceCode.getFirstTokens(node, 2)
 
-    adjacent = !sourceCode.isSpaceBetweenTokens(firstTokens[0], firstTokens[1])
+    adjacent = !sourceCode.isSpaceBetween(firstTokens[0], firstTokens[1])
 
     if (option === 'never') {
       if (!adjacent) {
@@ -131,7 +131,7 @@ function validateBeforeSelfClosing(
   if (leftToken.loc.end.line !== closingSlash.loc.start.line)
     return
 
-  const adjacent = !sourceCode.isSpaceBetweenTokens(leftToken as unknown as Token, closingSlash)
+  const adjacent = !sourceCode.isSpaceBetween(leftToken as unknown as Token, closingSlash)
 
   if ((option === 'always' || option === 'proportional-always') && adjacent) {
     context.report({
@@ -169,7 +169,7 @@ function validateAfterOpening(
       return
   }
 
-  const adjacent = !sourceCode.isSpaceBetweenTokens(openingToken, node.name as unknown as Token)
+  const adjacent = !sourceCode.isSpaceBetween(openingToken, node.name as unknown as Token)
 
   if (option === 'never' || option === 'allow-multiline') {
     if (!adjacent) {
@@ -231,7 +231,7 @@ function validateBeforeClosing(
     if (leftToken.loc.start.line !== closingToken.loc.start.line)
       return
 
-    const adjacent = !sourceCode.isSpaceBetweenTokens(leftToken as unknown as Token, closingToken)
+    const adjacent = !sourceCode.isSpaceBetween(leftToken as unknown as Token, closingToken)
 
     if (option === 'never' && !adjacent) {
       context.report({

--- a/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._js_.ts
@@ -108,7 +108,7 @@ export default createRule<RuleOptions, MessageIds>({
         && !isOpenParenOfTemplate(prevToken)
         && !tokensToIgnore.has(prevToken)
         && isTokenOnSameLine(prevToken, token)
-        && !sourceCode.isSpaceBetweenTokens(prevToken, token)
+        && !sourceCode.isSpaceBetween(prevToken, token)
       ) {
         context.report({
           loc: token.loc,
@@ -135,7 +135,7 @@ export default createRule<RuleOptions, MessageIds>({
         && !isOpenParenOfTemplate(prevToken)
         && !tokensToIgnore.has(prevToken)
         && isTokenOnSameLine(prevToken, token)
-        && sourceCode.isSpaceBetweenTokens(prevToken, token)
+        && sourceCode.isSpaceBetween(prevToken, token)
       ) {
         context.report({
           loc: { start: prevToken.loc.end, end: token.loc.start },
@@ -162,7 +162,7 @@ export default createRule<RuleOptions, MessageIds>({
         && !isCloseParenOfTemplate(nextToken)
         && !tokensToIgnore.has(nextToken)
         && isTokenOnSameLine(token, nextToken)
-        && !sourceCode.isSpaceBetweenTokens(token, nextToken)
+        && !sourceCode.isSpaceBetween(token, nextToken)
       ) {
         context.report({
           loc: token.loc,
@@ -189,7 +189,7 @@ export default createRule<RuleOptions, MessageIds>({
         && !isCloseParenOfTemplate(nextToken)
         && !tokensToIgnore.has(nextToken)
         && isTokenOnSameLine(token, nextToken)
-        && sourceCode.isSpaceBetweenTokens(token, nextToken)
+        && sourceCode.isSpaceBetween(token, nextToken)
       ) {
         context.report({
           loc: { start: token.loc.end, end: nextToken.loc.start },

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.ts
@@ -376,7 +376,7 @@ export default createRule<RuleOptions, MessageIds>({
       const tokenBeforeRightParen = sourceCode.getLastToken(node)!
 
       return rightParenToken && tokenAfterRightParen
-        && !sourceCode.isSpaceBetweenTokens(rightParenToken, tokenAfterRightParen)
+        && !sourceCode.isSpaceBetween(rightParenToken, tokenAfterRightParen)
         && !canTokensBeAdjacent(tokenBeforeRightParen, tokenAfterRightParen)
     }
 

--- a/packages/eslint-plugin/rules/no-whitespace-before-property/no-whitespace-before-property._js_.ts
+++ b/packages/eslint-plugin/rules/no-whitespace-before-property/no-whitespace-before-property._js_.ts
@@ -85,7 +85,7 @@ export default createRule<RuleOptions, MessageIds>({
           leftToken = sourceCode.getTokenBefore(rightToken, 1)!
         }
 
-        if (sourceCode.isSpaceBetweenTokens(leftToken, rightToken))
+        if (sourceCode.isSpaceBetween(leftToken, rightToken))
           reportError(node, leftToken, rightToken)
       },
     }

--- a/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing._js_.ts
@@ -157,7 +157,7 @@ export default createRule<RuleOptions, MessageIds>({
      */
     function validateBraceSpacing(node: ASTNode, first: Token, second: Token, penultimate: Token, last: Token) {
       if (isTokenOnSameLine(first, second)) {
-        const firstSpaced = sourceCode.isSpaceBetweenTokens(first, second)
+        const firstSpaced = sourceCode.isSpaceBetween(first, second)
 
         if (options.spaced && !firstSpaced)
           reportRequiredBeginningSpace(node, first)
@@ -178,7 +178,7 @@ export default createRule<RuleOptions, MessageIds>({
           || options.objectsInObjectsException && (penultimateType === 'ObjectExpression' || penultimateType === 'ObjectPattern')
         ) ? !options.spaced : options.spaced
 
-        const lastSpaced = sourceCode.isSpaceBetweenTokens(penultimate, last)
+        const lastSpaced = sourceCode.isSpaceBetween(penultimate, last)
 
         if (closingCurlyBraceMustBeSpaced && !lastSpaced)
           reportRequiredEndingSpace(node, last)

--- a/packages/eslint-plugin/rules/rest-spread-spacing/rest-spread-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/rest-spread-spacing/rest-spread-spacing._js_.ts
@@ -47,7 +47,7 @@ export default createRule<RuleOptions, MessageIds>({
     ) {
       const operator = sourceCode.getFirstToken(node)!
       const nextToken = sourceCode.getTokenAfter(operator)!
-      const hasWhitespace = sourceCode.isSpaceBetweenTokens(operator, nextToken)
+      const hasWhitespace = sourceCode.isSpaceBetween(operator, nextToken)
       let type
 
       switch (node.type) {

--- a/packages/eslint-plugin/rules/semi-spacing/semi-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/semi-spacing/semi-spacing._js_.ts
@@ -64,7 +64,7 @@ export default createRule<RuleOptions, MessageIds>({
     function hasLeadingSpace(token: Token) {
       const tokenBefore = sourceCode.getTokenBefore(token)
 
-      return tokenBefore && isTokenOnSameLine(tokenBefore, token) && sourceCode.isSpaceBetweenTokens(tokenBefore, token)
+      return tokenBefore && isTokenOnSameLine(tokenBefore, token) && sourceCode.isSpaceBetween(tokenBefore, token)
     }
 
     /**
@@ -75,7 +75,7 @@ export default createRule<RuleOptions, MessageIds>({
     function hasTrailingSpace(token: Token) {
       const tokenAfter = sourceCode.getTokenAfter(token)
 
-      return tokenAfter && isTokenOnSameLine(token, tokenAfter) && sourceCode.isSpaceBetweenTokens(token, tokenAfter)
+      return tokenAfter && isTokenOnSameLine(token, tokenAfter) && sourceCode.isSpaceBetween(token, tokenAfter)
     }
 
     /**

--- a/packages/eslint-plugin/rules/space-before-blocks/space-before-blocks._js_.ts
+++ b/packages/eslint-plugin/rules/space-before-blocks/space-before-blocks._js_.ts
@@ -133,7 +133,7 @@ export default createRule<RuleOptions, MessageIds>({
 
       if (precedingToken && !isConflicted(precedingToken, node) && isTokenOnSameLine(precedingToken, node)) {
         // @ts-expect-error type cast
-        const hasSpace = sourceCode.isSpaceBetweenTokens(precedingToken, node)
+        const hasSpace = sourceCode.isSpaceBetween(precedingToken, node)
         let requireSpace
         let requireNoSpace
 

--- a/packages/eslint-plugin/rules/space-before-blocks/space-before-blocks._js_.ts
+++ b/packages/eslint-plugin/rules/space-before-blocks/space-before-blocks._js_.ts
@@ -132,7 +132,6 @@ export default createRule<RuleOptions, MessageIds>({
       const precedingToken = sourceCode.getTokenBefore(node)
 
       if (precedingToken && !isConflicted(precedingToken, node) && isTokenOnSameLine(precedingToken, node)) {
-        // @ts-expect-error type cast
         const hasSpace = sourceCode.isSpaceBetween(precedingToken, node)
         let requireSpace
         let requireNoSpace

--- a/packages/eslint-plugin/rules/space-before-function-paren/space-before-function-paren._js_.ts
+++ b/packages/eslint-plugin/rules/space-before-function-paren/space-before-function-paren._js_.ts
@@ -130,7 +130,7 @@ export default createRule<RuleOptions, MessageIds>({
 
       const rightToken = sourceCode.getFirstToken(node, isOpeningParenToken)!
       const leftToken = sourceCode.getTokenBefore(rightToken)!
-      const hasSpacing = sourceCode.isSpaceBetweenTokens(leftToken, rightToken)
+      const hasSpacing = sourceCode.isSpaceBetween(leftToken, rightToken)
 
       if (hasSpacing && functionConfig === 'never') {
         context.report({

--- a/packages/eslint-plugin/rules/space-in-parens/space-in-parens._js_.ts
+++ b/packages/eslint-plugin/rules/space-in-parens/space-in-parens._js_.ts
@@ -132,7 +132,7 @@ export default createRule<RuleOptions, MessageIds>({
      * @returns True if the opening paren is missing a required space
      */
     function openerMissingSpace(openingParenToken: Token, tokenAfterOpeningParen: Token) {
-      if (sourceCode.isSpaceBetweenTokens(openingParenToken, tokenAfterOpeningParen))
+      if (sourceCode.isSpaceBetween(openingParenToken, tokenAfterOpeningParen))
         return false
 
       if (!options.empty && isClosingParenToken(tokenAfterOpeningParen))
@@ -157,7 +157,7 @@ export default createRule<RuleOptions, MessageIds>({
       if (tokenAfterOpeningParen.type === 'Line')
         return false
 
-      if (!sourceCode.isSpaceBetweenTokens(openingParenToken, tokenAfterOpeningParen))
+      if (!sourceCode.isSpaceBetween(openingParenToken, tokenAfterOpeningParen))
         return false
 
       if (ALWAYS)
@@ -173,7 +173,7 @@ export default createRule<RuleOptions, MessageIds>({
      * @returns True if the closing paren is missing a required space
      */
     function closerMissingSpace(tokenBeforeClosingParen: Token, closingParenToken: Token) {
-      if (sourceCode.isSpaceBetweenTokens(tokenBeforeClosingParen, closingParenToken))
+      if (sourceCode.isSpaceBetween(tokenBeforeClosingParen, closingParenToken))
         return false
 
       if (!options.empty && isOpeningParenToken(tokenBeforeClosingParen))
@@ -195,7 +195,7 @@ export default createRule<RuleOptions, MessageIds>({
       if (!isTokenOnSameLine(tokenBeforeClosingParen, closingParenToken))
         return false
 
-      if (!sourceCode.isSpaceBetweenTokens(tokenBeforeClosingParen, closingParenToken))
+      if (!sourceCode.isSpaceBetween(tokenBeforeClosingParen, closingParenToken))
         return false
 
       if (ALWAYS)

--- a/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops._js_.ts
+++ b/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops._js_.ts
@@ -55,7 +55,7 @@ export default createRule<RuleOptions, MessageIds>({
       const prev = sourceCode.getTokenBefore(operator)!
       const next = sourceCode.getTokenAfter(operator)!
 
-      if (!sourceCode.isSpaceBetweenTokens(prev, operator) || !sourceCode.isSpaceBetweenTokens(operator, next))
+      if (!sourceCode.isSpaceBetween(prev, operator) || !sourceCode.isSpaceBetween(operator, next))
         return operator
       return null
     }
@@ -175,8 +175,8 @@ export default createRule<RuleOptions, MessageIds>({
         const rightToken = sourceCode.getTokenAfter(operatorToken)!
 
         if (
-          !sourceCode.isSpaceBetweenTokens(leftToken, operatorToken)
-          || !sourceCode.isSpaceBetweenTokens(operatorToken, rightToken)
+          !sourceCode.isSpaceBetween(leftToken, operatorToken)
+          || !sourceCode.isSpaceBetween(operatorToken, rightToken)
         ) {
           report(node, operatorToken)
         }

--- a/packages/eslint-plugin/rules/switch-colon-spacing/switch-colon-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/switch-colon-spacing/switch-colon-spacing._js_.ts
@@ -54,7 +54,7 @@ export default createRule<RuleOptions, MessageIds>({
       return (
         isClosingBraceToken(right)
         || !isTokenOnSameLine(left, right)
-        || sourceCode.isSpaceBetweenTokens(left, right) === expected
+        || sourceCode.isSpaceBetween(left, right) === expected
       )
     }
 

--- a/packages/eslint-plugin/rules/template-tag-spacing/template-tag-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/template-tag-spacing/template-tag-spacing._js_.ts
@@ -43,7 +43,7 @@ export default createRule<RuleOptions, MessageIds>({
     function checkSpacing(node: Tree.TaggedTemplateExpression) {
       const tagToken = sourceCode.getTokenBefore(node.quasi)!
       const literalToken = sourceCode.getFirstToken(node.quasi)!
-      const hasWhitespace = sourceCode.isSpaceBetweenTokens(tagToken, literalToken)
+      const hasWhitespace = sourceCode.isSpaceBetween(tagToken, literalToken)
 
       if (never && hasWhitespace) {
         context.report({

--- a/packages/eslint-plugin/rules/yield-star-spacing/yield-star-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/yield-star-spacing/yield-star-spacing._js_.ts
@@ -69,7 +69,7 @@ export default createRule<RuleOptions, MessageIds>({
      *     token if side is "after".
      */
     function checkSpacing(side: 'before' | 'after', leftToken: Token, rightToken: Token) {
-      if (sourceCode.isSpaceBetweenTokens(leftToken, rightToken) !== mode[side]) {
+      if (sourceCode.isSpaceBetween(leftToken, rightToken) !== mode[side]) {
         const after = leftToken.value === '*'
         const spaceRequired = mode[side]
         const node = after ? leftToken : rightToken


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

`isSpaceBetweenTokens` has been deprecated in [ESLint v6.7.0](https://github.com/eslint/eslint/releases/tag/v6.7.0) in https://github.com/eslint/eslint/pull/12519.

But it has changed the behavior of the `isSpaceBetweenTokens()` method about `JSXText` tokens that contain only spaces.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Related to:

- https://github.com/eslint/eslint/pull/12519
- https://github.com/eslint/eslint/issues/12614

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
