### PR TITLE
Corrected `key-spacing` typos in README file

### DIFF
--- a/packages/eslint-plugin/rules/key-spacing/README._js_.md
+++ b/packages/eslint-plugin/rules/key-spacing/README._js_.md
@@ -317,13 +317,13 @@ Examples of **correct** code for this rule with sample `{ "ignoredNodes": [] }` 
 ::: correct
 
 ```js
-/*eslint "key-spacing": [2, { "ignoredNodes": ["ObjectExpression"] }]*/
+/*eslint key-spacing: [2, { "ignoredNodes": ["ObjectExpression"] }]*/
 var obj = {
     a: 1,
     b : 2,
     c :3,
 }
-/*eslint "key-spacing": [2, { "ignoredNodes": ["ObjectPattern"] }]*/
+/*eslint key-spacing: [2, { "ignoredNodes": ["ObjectPattern"] }]*/
 var {
     a: b,
     c : d,
@@ -416,7 +416,7 @@ Examples of **correct** code for this rule with sample `{ "singleLine": { }, "mu
 ::: correct
 
 ```js
-/*eslint "key-spacing": [2, {
+/*eslint key-spacing: [2, {
     "singleLine": {
         "beforeColon": false,
         "afterColon": true


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This resolves a typo in the only README file where I found `/*eslint "`. I believe the other README files are free of this issue.

### Linked Issues

Based on a comment I made in Pull request : [640](https://github.com/eslint-stylistic/eslint-stylistic/pull/640#issuecomment-2556474515)

### Additional context

A picture is worth more than a description:

<img width="743" alt="stylistic" src="https://github.com/user-attachments/assets/06619912-db5e-44cc-be3e-95ca5253ebe6" />

Link to the `key-spacing` rule : [documentation](https://eslint.style/rules/js/key-spacing#ignorednodes)