### PR TITLE
Corrected key-spacing layout issue in README file

### DIFF
--- a/packages/eslint-plugin/rules/key-spacing/README._js_.md
+++ b/packages/eslint-plugin/rules/key-spacing/README._js_.md
@@ -323,6 +323,13 @@ var obj = {
     b : 2,
     c :3,
 }
+```
+
+:::
+
+::: correct
+
+```js
 /*eslint key-spacing: [2, { "ignoredNodes": ["ObjectPattern"] }]*/
 var {
     a: b,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This resolves a layout issue in the `key-spacing` README file where I should have split the block into two separated correct blocks . Sorry about that.

### Linked Issues

Based on Pull request [662](https://github.com/eslint-stylistic/eslint-stylistic/pull/662)

### Additional context

A picture is worth more than a description:


<img width="758" alt="Capture d’écran 2025-01-15 à 11 44 19" src="https://github.com/user-attachments/assets/113544c3-250e-412d-b8ca-52b3d5ca7549" />
