### PR TITLE
docs: add `flat: true` to flat config customize example

### DIFF
--- a/docs/guide/config-presets.md
+++ b/docs/guide/config-presets.md
@@ -20,6 +20,7 @@ import stylistic from '@stylistic/eslint-plugin'
 
 export default [
   stylistic.configs.customize({
+    flat: true, // required for flat config
     // the following options are the default values
     indent: 2,
     quotes: 'single',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When using the config factory to add customizations in a flat config, it seems like the options param should include a  `flat` property set to `true` in order to properly return the type `Linter.Config`.

Without the `flat` property, the factory returns `Linter.BaseConfig` which causes type errors in flat configs.

This PR just updates the flat config example in the docs to show that.

### Linked Issues

### Additional context

https://github.com/eslint-stylistic/eslint-stylistic/blob/dd40b057bcec2309c8c0697429990dee838915c2/packages/eslint-plugin/configs/customize.ts#L15-L17

<!-- e.g. is there anything you'd like reviewers to focus on? -->
