### PR TITLE
feat(generic-spacing): remove spaces in type param instantiation

### DIFF
--- a/packages/eslint-plugin/rules/type-generic-spacing/type-generic-spacing._plus_.test.ts
+++ b/packages/eslint-plugin/rules/type-generic-spacing/type-generic-spacing._plus_.test.ts
@@ -5,6 +5,7 @@ run({
   name: 'type-generic-spacing',
   rule,
   valid: [
+    'const foo: Array<number> = []',
     'type Foo<T = true> = T',
     'type Foo<T extends true = true> = T',
     'type Foo<T = (true)> = T',
@@ -40,6 +41,9 @@ run({
     `const toSortedImplementation = Array.prototype.toSorted || function <T>(name: T): void {}`,
   ],
   invalid: ([
+    ['const val: Set< string> = new Set()', 'const val: Set<string> = new Set()'],
+    ['const val: Array<  number > = []', 'const val: Array<number> = []', 2],
+    ['const val = callback< string  >(() => \'foo\')', 'const val = callback<string>(() => \'foo\')', 2],
     ['type Foo< T> = T', 'type Foo<T> = T'],
     ['type Foo<T > = T', 'type Foo<T> = T'],
     ['type Foo< T > = T', 'type Foo<T> = T', 2],


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR essentially brings the exact same feature than #667, but for type param instantiation, so:
```ts
const val: Array<  number > = []
```
would become:
```ts
const val: Array<number> = []
```
