### PR TITLE
chore: Update utils for ESM changes

### DIFF
--- a/packages/eslint-plugin-js/package.json
+++ b/packages/eslint-plugin-js/package.json
@@ -16,6 +16,7 @@
   "exports": {
     ".": {
       "types": "./dist/dts/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./define-config-support": {

--- a/packages/eslint-plugin-jsx/package.json
+++ b/packages/eslint-plugin-jsx/package.json
@@ -16,6 +16,7 @@
   "exports": {
     ".": {
       "types": "./dist/dts/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./define-config-support": {

--- a/packages/eslint-plugin-plus/package.json
+++ b/packages/eslint-plugin-plus/package.json
@@ -16,6 +16,7 @@
   "exports": {
     ".": {
       "types": "./dist/dts/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./define-config-support": {

--- a/packages/eslint-plugin-ts/package.json
+++ b/packages/eslint-plugin-ts/package.json
@@ -16,6 +16,7 @@
   "exports": {
     ".": {
       "types": "./dist/dts/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./define-config-support": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -16,6 +16,7 @@
   "exports": {
     ".": {
       "types": "./dist/dts/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./define-config-support": {

--- a/scripts/update/utils.ts
+++ b/scripts/update/utils.ts
@@ -6,11 +6,10 @@ import { pascalCase } from 'change-case'
 import fg from 'fast-glob'
 
 import fs from 'fs-extra'
-// @ts-expect-error https://github.com/privatenumber/tsx/issues/38
-import config from '../../packages/eslint-plugin/configs/customize'
+import { customize } from '../../packages/eslint-plugin/configs/customize'
 import { GEN_HEADER, ROOT, RULE_ALIAS, RULE_ORIGINAL_ID_MAP } from './meta'
 
-export const rulesInSharedConfig = new Set<string>(Object.keys(config.customize().rules))
+export const rulesInSharedConfig = new Set<string>(Object.keys(customize().rules!))
 
 export async function readPackage(path: string): Promise<PackageInfo> {
   const dir = relative(join(ROOT, 'packages'), path)
@@ -182,7 +181,7 @@ export async function updateExports(pkg: PackageInfo) {
   pkgJson.exports = {
     '.': {
       types: './dist/dts/index.d.ts',
-      require: './dist/index.js',
+      import: './dist/index.js',
       default: './dist/index.js',
     },
     './define-config-support': {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fix ESM compatibility of `scripts/utils.ts`, without this changes the script does not work as the exports are only named exports but no default export.
Probably a leftover of 3145d5082191505f319e576cc30da51b907c380e by @antfu 

Before this:
> > esno scripts/update.ts && pnpm run lint --fix
>
> /home/ferdinand/Dokumente/Projekte/nextcloud/eslint-stylistic/scripts/update/utils.ts:10
> import config from '../../packages/eslint-plugin/configs/customize'
>        ^
> 
> SyntaxError: The requested module '../../packages/eslint-plugin/configs/customize' does not provide an export named 'default'
>     at ModuleJob._instantiate (node:internal/modules/esm/module_job:180:21)
>     at async ModuleJob.run (node:internal/modules/esm/module_job:263:5)
>     at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:547:26)
>     at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:116:5)
> 
> Node.js v22.13.1
>  ELIFECYCLE  Command failed with exit code 1.
>  ELIFECYCLE  Command failed with exit code 1.

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
