### PR TITLE
fix(indent-binary-ops): handle `{` for left token check

### DIFF
--- a/packages/eslint-plugin/rules/indent-binary-ops/indent-binary-ops._plus_.test.ts
+++ b/packages/eslint-plugin/rules/indent-binary-ops/indent-binary-ops._plus_.test.ts
@@ -111,6 +111,28 @@ run({
         || c
         || d;
     `,
+    $`
+      { aaaaa &&
+        bbbbb &&
+        ccccc }
+    `,
+    $`
+      {
+        aaaaa &&
+        bbbbb &&
+        ccccc
+      }
+    `,
+    $`
+      if (condition1 &&
+        condition2 &&
+        condition3
+      ) {
+        a &&
+        b() &&
+        c()
+      }
+    `,
   ],
   invalid: [],
 })
@@ -580,4 +602,17 @@ it('snapshots', async () => {
       || 2
       || 3;"
   `)
+
+  expect.soft(
+    fix($`
+      { aaaaa &&
+            bbbbb &&
+          ccccc }
+    `),
+  ).toMatchInlineSnapshot(`
+      "{ aaaaa &&
+        bbbbb &&
+        ccccc }"
+    `,
+  )
 })

--- a/packages/eslint-plugin/rules/indent-binary-ops/indent-binary-ops._plus_.ts
+++ b/packages/eslint-plugin/rules/indent-binary-ops/indent-binary-ops._plus_.ts
@@ -135,9 +135,9 @@ export default createRule<RuleOptions, MessageIds>({
         // End of line is a opening bracket (`[`, `(`),
         //  or the expression is an assignment
         || [':', '[', '(', '<'].concat(ASSIGNMENT_OPERATOR).includes(lastTokenOfLineLeft?.value || '')
-        // Before the left token is a opening bracket (`[`, `(`),
+        // Before the left token is a opening bracket (`[`, `(`, `{`),
         //  or the expression is an assignment
-        || (['[', '(', '=>', ':'].concat(ASSIGNMENT_OPERATOR).includes(tokenBeforeAll?.value || '') && firstTokenOfLineLeft?.loc.start.line === tokenBeforeAll?.loc.start.line)
+        || (['[', '(', '{', '=>', ':'].concat(ASSIGNMENT_OPERATOR).includes(tokenBeforeAll?.value || '') && firstTokenOfLineLeft?.loc.start.line === tokenBeforeAll?.loc.start.line)
 
       const needSubtractionIndent = false
         // End of line is a closing bracket


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
This pr fixes a regression due to #645. 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
Fixes #692 

### Additional context
This rule needs more test cases to prevent similar issues.
eh, help wanted

<!-- e.g. is there anything you'd like reviewers to focus on? -->
