### PR TITLE
feat: add `module.exports` named export for `require(esm)` compatibility

### DIFF
--- a/packages/eslint-plugin-js/src/index.ts
+++ b/packages/eslint-plugin-js/src/index.ts
@@ -3,4 +3,9 @@ import plugin from './plugin'
 
 export type * from '../dts'
 
-export default Object.assign(plugin, { configs })
+const index = Object.assign(plugin, { configs })
+
+export {
+  index as default,
+  index as 'module.exports',
+}

--- a/packages/eslint-plugin-jsx/src/index.ts
+++ b/packages/eslint-plugin-jsx/src/index.ts
@@ -3,4 +3,9 @@ import plugin from './plugin'
 
 export type * from '../dts'
 
-export default Object.assign(plugin, { configs })
+const index = Object.assign(plugin, { configs })
+
+export {
+  index as default,
+  index as 'module.exports',
+}

--- a/packages/eslint-plugin-migrate/src/index.ts
+++ b/packages/eslint-plugin-migrate/src/index.ts
@@ -3,11 +3,16 @@ import migrateJs from './rules/migrate-js'
 import migrateJsx from './rules/migrate-jsx'
 import migrateTs from './rules/migrate-ts'
 
-export default {
+const index = {
   rules: {
     migrate,
     'migrate-ts': migrateTs,
     'migrate-js': migrateJs,
     'migrate-jsx': migrateJsx,
   },
+}
+
+export {
+  index as default,
+  index as 'module.exports',
 }

--- a/packages/eslint-plugin-plus/src/index.ts
+++ b/packages/eslint-plugin-plus/src/index.ts
@@ -2,6 +2,9 @@ import rules from '../rules'
 
 export type * from '../dts'
 
-export default {
-  rules,
+const index = { rules }
+
+export {
+  index as default,
+  index as 'module.exports',
 }

--- a/packages/eslint-plugin-ts/src/index.ts
+++ b/packages/eslint-plugin-ts/src/index.ts
@@ -3,4 +3,9 @@ import plugin from './plugin'
 
 export type * from '../dts'
 
-export default Object.assign(plugin, { configs })
+const index = Object.assign(plugin, { configs })
+
+export {
+  index as default,
+  index as 'module.exports',
+}

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -3,4 +3,9 @@ import plugin from './plugin'
 
 export type * from '../dts'
 
-export default Object.assign(plugin, { configs })
+const index = Object.assign(plugin, { configs })
+
+export {
+  index as default,
+  index as 'module.exports',
+}

--- a/rollup.config.base.mjs
+++ b/rollup.config.base.mjs
@@ -71,7 +71,9 @@ export function createConfig(cwd) {
       ],
       plugins: [
         commonjs(),
-        esbuild(),
+        esbuild({
+          target: 'esnext',
+        }),
         resolve(),
         aliasPlugin(),
       ],


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This makes it possible to use v4+ in CJS-contexts with `require(esm)` without any downstream code changes, by adding a special named export that `require(esm)` will favor instead of the usual `{ __esModule: true, default: ... }` result.

### Linked Issues

Relates to #661

### Additional context

Because of how ESM works compared to CJS, by default `require(esm)` results in an object with the `default export` mapped to a `default` property rather than returning the `default` directly in order to allow access to named exports.

This means that while technically we can now use ESM-only packages in CJS contexts, because `require` is usually expected to be equivalent to importing the `default` it's not quite a "drop-in" because the `require`'er needs to account for the ESM/CJS interop to actually get that `default` value.

To account for this, `require(esm)` has a preference for a `module.exports` export which it will return if found, allowing upstream packages to explicitly define that named export to enable "drop-in" usage; this comes at the cost of preventing access to other named exports, but there are multiple easy ways to handle that including ensuring those properties are available on the `module.exports` value and/or making the named exports available via another file - I also don't think it's likely that these packages specifically will ever have named exports (even if there were some utilities or such, I'd expect they'd end up in a dedicated package since this is a monorepo).

Also see:
  - https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require
  - https://github.com/nodejs/node/pull/54563

---

And as a fun little side fact, this code is actually pretty close to what `rollup` generates anyway:

```
var index = Object.assign(plugin, { configs });

export { index as default };
```