### PR TITLE
chore: Add recommended metadata to rules

### DIFF
--- a/packages/eslint-plugin/rules/array-bracket-spacing/array-bracket-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/array-bracket-spacing/array-bracket-spacing._js_.ts
@@ -16,6 +16,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce consistent spacing inside array brackets',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/arrow-parens/arrow-parens._js_.ts
+++ b/packages/eslint-plugin/rules/arrow-parens/arrow-parens._js_.ts
@@ -25,6 +25,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Require parentheses around arrow function arguments',
+      recommended: true,
     },
 
     fixable: 'code',

--- a/packages/eslint-plugin/rules/arrow-spacing/arrow-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/arrow-spacing/arrow-spacing._js_.ts
@@ -16,6 +16,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce consistent spacing before and after the arrow in arrow functions',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/block-spacing/block-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/block-spacing/block-spacing._js_.ts
@@ -19,6 +19,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Disallow or enforce spaces inside of blocks after opening block and before closing block',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/brace-style/brace-style._js_.ts
+++ b/packages/eslint-plugin/rules/brace-style/brace-style._js_.ts
@@ -19,6 +19,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce consistent brace style for blocks',
+      recommended: true,
     },
 
     schema: [

--- a/packages/eslint-plugin/rules/brace-style/brace-style._ts_.ts
+++ b/packages/eslint-plugin/rules/brace-style/brace-style._ts_.ts
@@ -10,10 +10,8 @@ export default createRule<RuleOptions, MessageIds>({
   name: 'brace-style',
   package: 'ts',
   meta: {
-    type: 'layout',
-    docs: {
-      description: 'Enforce consistent brace style for blocks',
-    },
+    type: baseRule.meta.type,
+    docs: baseRule.meta.docs,
     messages: baseRule.meta.messages,
     fixable: baseRule.meta.fixable,
     hasSuggestions: baseRule.meta.hasSuggestions,

--- a/packages/eslint-plugin/rules/comma-dangle/comma-dangle._js_.ts
+++ b/packages/eslint-plugin/rules/comma-dangle/comma-dangle._js_.ts
@@ -96,6 +96,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Require or disallow trailing commas',
+      recommended: true,
     },
 
     fixable: 'code',

--- a/packages/eslint-plugin/rules/comma-dangle/comma-dangle._ts_.ts
+++ b/packages/eslint-plugin/rules/comma-dangle/comma-dangle._ts_.ts
@@ -42,9 +42,7 @@ export default createRule<RuleOptions, MessageIds>({
   package: 'ts',
   meta: {
     type: 'layout',
-    docs: {
-      description: 'Require or disallow trailing commas',
-    },
+    docs: baseRule.meta.docs,
     schema: {
       $defs: {
         value: {

--- a/packages/eslint-plugin/rules/comma-spacing/comma-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/comma-spacing/comma-spacing._js_.ts
@@ -16,6 +16,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce consistent spacing before and after commas',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/comma-spacing/comma-spacing._ts_.ts
+++ b/packages/eslint-plugin/rules/comma-spacing/comma-spacing._ts_.ts
@@ -18,6 +18,7 @@ export default createRule<RuleOptions, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Enforce consistent spacing before and after commas',
+      recommended: true,
     },
     fixable: 'whitespace',
     schema: [

--- a/packages/eslint-plugin/rules/comma-style/comma-style._js_.ts
+++ b/packages/eslint-plugin/rules/comma-style/comma-style._js_.ts
@@ -24,6 +24,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce consistent comma style',
+      recommended: true,
     },
 
     fixable: 'code',

--- a/packages/eslint-plugin/rules/computed-property-spacing/computed-property-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/computed-property-spacing/computed-property-spacing._js_.ts
@@ -16,6 +16,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce consistent spacing inside computed property brackets',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/dot-location/dot-location._js_.ts
+++ b/packages/eslint-plugin/rules/dot-location/dot-location._js_.ts
@@ -16,6 +16,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce consistent newlines before and after dots',
+      recommended: true,
     },
 
     schema: [

--- a/packages/eslint-plugin/rules/eol-last/eol-last._js_.ts
+++ b/packages/eslint-plugin/rules/eol-last/eol-last._js_.ts
@@ -14,6 +14,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Require or disallow newline at the end of files',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/indent-binary-ops/indent-binary-ops._plus_.ts
+++ b/packages/eslint-plugin/rules/indent-binary-ops/indent-binary-ops._plus_.ts
@@ -10,6 +10,7 @@ export default createRule<RuleOptions, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Indentation for binary operators',
+      recommended: true,
     },
     fixable: 'whitespace',
     schema: [

--- a/packages/eslint-plugin/rules/indent/indent._js_.ts
+++ b/packages/eslint-plugin/rules/indent/indent._js_.ts
@@ -484,6 +484,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce consistent indentation',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/indent/indent._ts_.ts
+++ b/packages/eslint-plugin/rules/indent/indent._ts_.ts
@@ -89,7 +89,7 @@ export default createRule<RuleOptions, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Enforce consistent indentation',
-      // too opinionated to be recommended
+      recommended: true,
     },
     fixable: 'whitespace',
     hasSuggestions: baseRule.meta.hasSuggestions,

--- a/packages/eslint-plugin/rules/jsx-closing-bracket-location/jsx-closing-bracket-location._jsx_.ts
+++ b/packages/eslint-plugin/rules/jsx-closing-bracket-location/jsx-closing-bracket-location._jsx_.ts
@@ -18,6 +18,7 @@ export default createRule<RuleOptions, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Enforce closing bracket location in JSX',
+      recommended: true,
     },
     fixable: 'code',
 

--- a/packages/eslint-plugin/rules/jsx-closing-tag-location/jsx-closing-tag-location._jsx_.ts
+++ b/packages/eslint-plugin/rules/jsx-closing-tag-location/jsx-closing-tag-location._jsx_.ts
@@ -28,6 +28,7 @@ export default createRule<RuleOptions, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Enforce closing tag location for multiline JSX',
+      recommended: true,
     },
     fixable: 'whitespace',
     messages,

--- a/packages/eslint-plugin/rules/jsx-curly-brace-presence/jsx-curly-brace-presence._jsx_.ts
+++ b/packages/eslint-plugin/rules/jsx-curly-brace-presence/jsx-curly-brace-presence._jsx_.ts
@@ -32,6 +32,7 @@ export default createRule<RuleOptions, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Disallow unnecessary JSX expressions when literals alone are sufficient or enforce JSX expressions on literals in JSX children or attributes',
+      recommended: true,
     },
     fixable: 'code',
 

--- a/packages/eslint-plugin/rules/jsx-curly-newline/jsx-curly-newline._jsx_.ts
+++ b/packages/eslint-plugin/rules/jsx-curly-newline/jsx-curly-newline._jsx_.ts
@@ -44,6 +44,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce consistent linebreaks in curly braces in JSX attributes and expressions',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/jsx-curly-spacing/jsx-curly-spacing._jsx_.ts
+++ b/packages/eslint-plugin/rules/jsx-curly-spacing/jsx-curly-spacing._jsx_.ts
@@ -35,6 +35,7 @@ export default createRule<RuleOptions, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Enforce or disallow spaces inside of curly braces in JSX attributes and expressions',
+      recommended: true,
     },
     fixable: 'code',
 

--- a/packages/eslint-plugin/rules/jsx-equals-spacing/jsx-equals-spacing._jsx_.ts
+++ b/packages/eslint-plugin/rules/jsx-equals-spacing/jsx-equals-spacing._jsx_.ts
@@ -21,6 +21,7 @@ export default createRule<RuleOptions, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Enforce or disallow spaces around equal signs in JSX attributes',
+      recommended: true,
     },
     fixable: 'code',
 

--- a/packages/eslint-plugin/rules/jsx-first-prop-new-line/jsx-first-prop-new-line._jsx_.ts
+++ b/packages/eslint-plugin/rules/jsx-first-prop-new-line/jsx-first-prop-new-line._jsx_.ts
@@ -20,6 +20,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce proper position of the first property in JSX',
+      recommended: true,
     },
     fixable: 'code',
 

--- a/packages/eslint-plugin/rules/jsx-function-call-newline/jsx-function-call-newline._jsx_.ts
+++ b/packages/eslint-plugin/rules/jsx-function-call-newline/jsx-function-call-newline._jsx_.ts
@@ -28,6 +28,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce line breaks before and after JSX elements when they are used as arguments to a function.',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/jsx-indent-props/jsx-indent-props._jsx_.ts
+++ b/packages/eslint-plugin/rules/jsx-indent-props/jsx-indent-props._jsx_.ts
@@ -47,6 +47,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce props indentation in JSX',
+      recommended: true,
     },
     fixable: 'code',
 

--- a/packages/eslint-plugin/rules/jsx-max-props-per-line/jsx-max-props-per-line._jsx_.ts
+++ b/packages/eslint-plugin/rules/jsx-max-props-per-line/jsx-max-props-per-line._jsx_.ts
@@ -25,6 +25,7 @@ export default createRule<RuleOptions, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Enforce maximum of props on a single line in JSX',
+      recommended: true,
     },
     fixable: 'code',
 

--- a/packages/eslint-plugin/rules/jsx-one-expression-per-line/jsx-one-expression-per-line._jsx_.ts
+++ b/packages/eslint-plugin/rules/jsx-one-expression-per-line/jsx-one-expression-per-line._jsx_.ts
@@ -26,6 +26,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Require one JSX element per line',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/jsx-quotes/jsx-quotes._js_.ts
+++ b/packages/eslint-plugin/rules/jsx-quotes/jsx-quotes._js_.ts
@@ -39,6 +39,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce the consistent use of either double or single quotes in JSX attributes',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/jsx-tag-spacing/jsx-tag-spacing._jsx_.ts
+++ b/packages/eslint-plugin/rules/jsx-tag-spacing/jsx-tag-spacing._jsx_.ts
@@ -290,6 +290,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce whitespace in and around the JSX opening and closing brackets',
+      recommended: true,
     },
     fixable: 'whitespace',
 

--- a/packages/eslint-plugin/rules/jsx-wrap-multilines/jsx-wrap-multilines._jsx_.ts
+++ b/packages/eslint-plugin/rules/jsx-wrap-multilines/jsx-wrap-multilines._jsx_.ts
@@ -33,6 +33,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Disallow missing parentheses around multiline JSX',
+      recommended: true,
     },
 
     fixable: 'code',

--- a/packages/eslint-plugin/rules/key-spacing/key-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/key-spacing/key-spacing._js_.ts
@@ -157,6 +157,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce consistent spacing between keys and values in object literal properties',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/key-spacing/key-spacing._ts_.ts
+++ b/packages/eslint-plugin/rules/key-spacing/key-spacing._ts_.ts
@@ -26,10 +26,7 @@ export default createRule<RuleOptions, MessageIds>({
   package: 'ts',
   meta: {
     type: 'layout',
-    docs: {
-      description:
-        'Enforce consistent spacing between property names and type annotations in types and interfaces',
-    },
+    docs: baseRule.meta.docs,
     fixable: 'whitespace',
     hasSuggestions: baseRule.meta.hasSuggestions,
     schema: [baseSchema],

--- a/packages/eslint-plugin/rules/key-spacing/key-spacing._ts_.ts
+++ b/packages/eslint-plugin/rules/key-spacing/key-spacing._ts_.ts
@@ -26,7 +26,10 @@ export default createRule<RuleOptions, MessageIds>({
   package: 'ts',
   meta: {
     type: 'layout',
-    docs: baseRule.meta.docs,
+    docs: {
+      description: 'Enforce consistent spacing between property names and type annotations in types and interfaces',
+      recommended: true,
+    },
     fixable: 'whitespace',
     hasSuggestions: baseRule.meta.hasSuggestions,
     schema: [baseSchema],

--- a/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._js_.ts
@@ -53,6 +53,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce consistent spacing before and after keywords',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._ts_.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._ts_.ts
@@ -31,9 +31,7 @@ export default createRule<RuleOptions, MessageIds>({
   package: 'ts',
   meta: {
     type: 'layout',
-    docs: {
-      description: 'Enforce consistent spacing before and after keywords',
-    },
+    docs: baseRule.meta.docs,
     fixable: 'whitespace',
     hasSuggestions: baseRule.meta.hasSuggestions,
     schema: [schema],

--- a/packages/eslint-plugin/rules/lines-between-class-members/lines-between-class-members._js_.ts
+++ b/packages/eslint-plugin/rules/lines-between-class-members/lines-between-class-members._js_.ts
@@ -35,6 +35,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Require or disallow an empty line between class members',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/lines-between-class-members/lines-between-class-members._ts_.ts
+++ b/packages/eslint-plugin/rules/lines-between-class-members/lines-between-class-members._ts_.ts
@@ -29,9 +29,7 @@ export default createRule<RuleOptions, MessageIds>({
   package: 'ts',
   meta: {
     type: 'layout',
-    docs: {
-      description: 'Require or disallow an empty line between class members',
-    },
+    docs: baseRule.meta.docs,
     fixable: 'whitespace',
     hasSuggestions: baseRule.meta.hasSuggestions,
     schema,

--- a/packages/eslint-plugin/rules/max-statements-per-line/max-statements-per-line._js_.ts
+++ b/packages/eslint-plugin/rules/max-statements-per-line/max-statements-per-line._js_.ts
@@ -42,6 +42,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce a maximum number of statements allowed per line',
+      recommended: true,
     },
 
     schema: [

--- a/packages/eslint-plugin/rules/member-delimiter-style/member-delimiter-style._ts_.ts
+++ b/packages/eslint-plugin/rules/member-delimiter-style/member-delimiter-style._ts_.ts
@@ -134,6 +134,7 @@ export default createRule<Options, MessageIds>({
     docs: {
       description:
         'Require a specific member delimiter style for interfaces and type literals',
+        recommended: true,
     },
     fixable: 'whitespace',
     messages: {

--- a/packages/eslint-plugin/rules/member-delimiter-style/member-delimiter-style._ts_.ts
+++ b/packages/eslint-plugin/rules/member-delimiter-style/member-delimiter-style._ts_.ts
@@ -134,7 +134,7 @@ export default createRule<Options, MessageIds>({
     docs: {
       description:
         'Require a specific member delimiter style for interfaces and type literals',
-        recommended: true,
+      recommended: true,
     },
     fixable: 'whitespace',
     messages: {

--- a/packages/eslint-plugin/rules/multiline-ternary/multiline-ternary._js_.ts
+++ b/packages/eslint-plugin/rules/multiline-ternary/multiline-ternary._js_.ts
@@ -15,6 +15,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce newlines between operands of ternary expressions',
+      recommended: true,
     },
 
     schema: [

--- a/packages/eslint-plugin/rules/new-parens/new-parens._js_.ts
+++ b/packages/eslint-plugin/rules/new-parens/new-parens._js_.ts
@@ -15,6 +15,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce or disallow parentheses when invoking a constructor with no arguments',
+      recommended: true,
     },
 
     fixable: 'code',

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.ts
@@ -30,6 +30,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Disallow unnecessary parentheses',
+      recommended: true,
     },
 
     fixable: 'code',

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
@@ -16,7 +16,7 @@ export default createRule<RuleOptions, MessageIds>({
   package: 'ts',
   meta: {
     type: 'layout',
-    docs: baseRule.meta.recommended,
+    docs: baseRule.meta.docs,
     fixable: 'code',
     hasSuggestions: baseRule.meta.hasSuggestions,
     schema: baseRule.meta.schema,

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
@@ -16,9 +16,7 @@ export default createRule<RuleOptions, MessageIds>({
   package: 'ts',
   meta: {
     type: 'layout',
-    docs: {
-      description: 'Disallow unnecessary parentheses',
-    },
+    docs: baseRule.meta.recommended,
     fixable: 'code',
     hasSuggestions: baseRule.meta.hasSuggestions,
     schema: baseRule.meta.schema,

--- a/packages/eslint-plugin/rules/no-floating-decimal/no-floating-decimal._js_.ts
+++ b/packages/eslint-plugin/rules/no-floating-decimal/no-floating-decimal._js_.ts
@@ -15,6 +15,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Disallow leading or trailing decimal points in numeric literals',
+      recommended: true,
     },
 
     schema: [],

--- a/packages/eslint-plugin/rules/no-mixed-operators/no-mixed-operators._js_.ts
+++ b/packages/eslint-plugin/rules/no-mixed-operators/no-mixed-operators._js_.ts
@@ -81,6 +81,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Disallow mixed binary operators',
+      recommended: true,
     },
 
     schema: [

--- a/packages/eslint-plugin/rules/no-mixed-spaces-and-tabs/no-mixed-spaces-and-tabs._js_.ts
+++ b/packages/eslint-plugin/rules/no-mixed-spaces-and-tabs/no-mixed-spaces-and-tabs._js_.ts
@@ -14,6 +14,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Disallow mixed spaces and tabs for indentation',
+      recommended: true,
     },
 
     schema: [

--- a/packages/eslint-plugin/rules/no-multi-spaces/no-multi-spaces._js_.ts
+++ b/packages/eslint-plugin/rules/no-multi-spaces/no-multi-spaces._js_.ts
@@ -16,6 +16,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Disallow multiple spaces',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/no-multiple-empty-lines/no-multiple-empty-lines._js_.ts
+++ b/packages/eslint-plugin/rules/no-multiple-empty-lines/no-multiple-empty-lines._js_.ts
@@ -15,6 +15,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Disallow multiple empty lines',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/no-tabs/no-tabs._js_.ts
+++ b/packages/eslint-plugin/rules/no-tabs/no-tabs._js_.ts
@@ -17,6 +17,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Disallow all tabs',
+      recommended: true,
     },
     schema: [{
       type: 'object',

--- a/packages/eslint-plugin/rules/no-trailing-spaces/no-trailing-spaces._js_.ts
+++ b/packages/eslint-plugin/rules/no-trailing-spaces/no-trailing-spaces._js_.ts
@@ -16,6 +16,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Disallow trailing whitespace at the end of lines',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/no-whitespace-before-property/no-whitespace-before-property._js_.ts
+++ b/packages/eslint-plugin/rules/no-whitespace-before-property/no-whitespace-before-property._js_.ts
@@ -16,6 +16,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Disallow whitespace before properties',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing._js_.ts
@@ -15,6 +15,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce consistent spacing inside braces',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing._ts_.ts
+++ b/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing._ts_.ts
@@ -16,9 +16,6 @@ export default createRule<RuleOptions, MessageIds>({
   package: 'ts',
   meta: {
     ...baseRule.meta,
-    docs: {
-      description: 'Enforce consistent spacing inside braces',
-    },
   },
   defaultOptions: ['never'],
   create(context) {

--- a/packages/eslint-plugin/rules/operator-linebreak/operator-linebreak._js_.ts
+++ b/packages/eslint-plugin/rules/operator-linebreak/operator-linebreak._js_.ts
@@ -16,6 +16,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce consistent linebreak style for operators',
+      recommended: true,
     },
 
     schema: [

--- a/packages/eslint-plugin/rules/padded-blocks/padded-blocks._js_.ts
+++ b/packages/eslint-plugin/rules/padded-blocks/padded-blocks._js_.ts
@@ -18,6 +18,7 @@ export default createRule<RuleOptions, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Require or disallow padding within blocks',
+      recommended: true,
     },
     fixable: 'whitespace',
     schema: [

--- a/packages/eslint-plugin/rules/quote-props/quote-props._js_.ts
+++ b/packages/eslint-plugin/rules/quote-props/quote-props._js_.ts
@@ -19,6 +19,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Require quotes around object literal property names',
+      recommended: true,
     },
 
     schema: {

--- a/packages/eslint-plugin/rules/quote-props/quote-props._ts_.ts
+++ b/packages/eslint-plugin/rules/quote-props/quote-props._ts_.ts
@@ -14,6 +14,7 @@ export default createRule<RuleOptions, MessageIds>({
     ...baseRule.meta,
     docs: {
       description: 'Require quotes around object literal, type literal, interfaces and enums property names',
+      recommended: true,
     },
   },
   defaultOptions: ['always'],

--- a/packages/eslint-plugin/rules/quotes/quotes._js_.ts
+++ b/packages/eslint-plugin/rules/quotes/quotes._js_.ts
@@ -72,6 +72,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce the consistent use of either backticks, double, or single quotes',
+      recommended: true,
     },
 
     fixable: 'code',

--- a/packages/eslint-plugin/rules/quotes/quotes._ts_.ts
+++ b/packages/eslint-plugin/rules/quotes/quotes._ts_.ts
@@ -11,10 +11,7 @@ export default createRule<RuleOptions, MessageIds>({
   package: 'ts',
   meta: {
     type: 'layout',
-    docs: {
-      description:
-        'Enforce the consistent use of either backticks, double, or single quotes',
-    },
+    docs: baseRule.meta.docs,
     fixable: 'code',
     hasSuggestions: baseRule.meta.hasSuggestions,
     messages: baseRule.meta.messages,

--- a/packages/eslint-plugin/rules/rest-spread-spacing/rest-spread-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/rest-spread-spacing/rest-spread-spacing._js_.ts
@@ -15,6 +15,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce spacing between rest and spread operators and their expressions',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/semi-spacing/semi-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/semi-spacing/semi-spacing._js_.ts
@@ -16,6 +16,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce consistent spacing before and after semicolons',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/semi-spacing/semi-spacing._ts_.ts
+++ b/packages/eslint-plugin/rules/semi-spacing/semi-spacing._ts_.ts
@@ -11,9 +11,7 @@ export default createRule<RuleOptions, MessageIds>({
   package: 'ts',
   meta: {
     type: 'layout',
-    docs: {
-      description: 'Enforce consistent spacing before and after semicolons',
-    },
+    docs: baseRule.meta.docs,
     fixable: 'whitespace',
     hasSuggestions: baseRule.meta.hasSuggestions,
     schema: baseRule.meta.schema,

--- a/packages/eslint-plugin/rules/semi/semi._js_.ts
+++ b/packages/eslint-plugin/rules/semi/semi._js_.ts
@@ -17,6 +17,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Require or disallow semicolons instead of ASI',
+      recommended: true,
     },
 
     fixable: 'code',

--- a/packages/eslint-plugin/rules/semi/semi._ts_.ts
+++ b/packages/eslint-plugin/rules/semi/semi._ts_.ts
@@ -12,10 +12,7 @@ export default createRule<RuleOptions, MessageIds>({
   package: 'ts',
   meta: {
     type: 'layout',
-    docs: {
-      description: 'Require or disallow semicolons instead of ASI',
-      // too opinionated to be recommended
-    },
+    docs: baseRule.meta.docs,
     fixable: 'code',
     hasSuggestions: baseRule.meta.hasSuggestions,
     schema: baseRule.meta.schema,

--- a/packages/eslint-plugin/rules/space-before-blocks/space-before-blocks._js_.ts
+++ b/packages/eslint-plugin/rules/space-before-blocks/space-before-blocks._js_.ts
@@ -31,6 +31,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce consistent spacing before blocks',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/space-before-blocks/space-before-blocks._ts_.ts
+++ b/packages/eslint-plugin/rules/space-before-blocks/space-before-blocks._ts_.ts
@@ -10,6 +10,7 @@ export default createRule<RuleOptions, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Enforce consistent spacing before blocks',
+      recommended: true,
     },
     fixable: 'whitespace',
     schema: [

--- a/packages/eslint-plugin/rules/space-before-function-paren/space-before-function-paren._js_.ts
+++ b/packages/eslint-plugin/rules/space-before-function-paren/space-before-function-paren._js_.ts
@@ -17,6 +17,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce consistent spacing before `function` definition opening parenthesis',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/space-before-function-paren/space-before-function-paren._ts_.ts
+++ b/packages/eslint-plugin/rules/space-before-function-paren/space-before-function-paren._ts_.ts
@@ -14,6 +14,7 @@ export default createRule<RuleOptions, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Enforce consistent spacing before function parenthesis',
+      recommended: true,
     },
     fixable: 'whitespace',
     schema: [

--- a/packages/eslint-plugin/rules/space-in-parens/space-in-parens._js_.ts
+++ b/packages/eslint-plugin/rules/space-in-parens/space-in-parens._js_.ts
@@ -16,6 +16,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce consistent spacing inside parentheses',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops._js_.ts
+++ b/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops._js_.ts
@@ -19,6 +19,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Require spacing around infix operators',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops._ts_.ts
+++ b/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops._ts_.ts
@@ -13,6 +13,7 @@ export default createRule<RuleOptions, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Require spacing around infix operators',
+      recommended: true,
     },
     fixable: 'whitespace',
     schema: [

--- a/packages/eslint-plugin/rules/space-unary-ops/space-unary-ops._js_.ts
+++ b/packages/eslint-plugin/rules/space-unary-ops/space-unary-ops._js_.ts
@@ -16,6 +16,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce consistent spacing before or after unary operators',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/spaced-comment/spaced-comment._js_.ts
+++ b/packages/eslint-plugin/rules/spaced-comment/spaced-comment._js_.ts
@@ -152,6 +152,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Enforce consistent spacing after the `//` or `/*` in a comment',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/template-curly-spacing/template-curly-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/template-curly-spacing/template-curly-spacing._js_.ts
@@ -16,6 +16,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Require or disallow spacing around embedded expressions of template strings',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/template-tag-spacing/template-tag-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/template-tag-spacing/template-tag-spacing._js_.ts
@@ -15,6 +15,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Require or disallow spacing between template tags and their literals',
+      recommended: true,
     },
 
     fixable: 'whitespace',

--- a/packages/eslint-plugin/rules/type-annotation-spacing/type-annotation-spacing._ts_.ts
+++ b/packages/eslint-plugin/rules/type-annotation-spacing/type-annotation-spacing._ts_.ts
@@ -105,6 +105,7 @@ export default createRule<Options, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Require consistent spacing around type annotations',
+      recommended: true,
     },
     fixable: 'whitespace',
     messages: {

--- a/packages/eslint-plugin/rules/type-generic-spacing/type-generic-spacing._plus_.ts
+++ b/packages/eslint-plugin/rules/type-generic-spacing/type-generic-spacing._plus_.ts
@@ -15,6 +15,7 @@ export default createRule<RuleOptions, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Enforces consistent spacing inside TypeScript type generics',
+      recommended: true,
     },
     fixable: 'whitespace',
     schema: [],

--- a/packages/eslint-plugin/rules/type-named-tuple-spacing/type-named-tuple-spacing._plus_.ts
+++ b/packages/eslint-plugin/rules/type-named-tuple-spacing/type-named-tuple-spacing._plus_.ts
@@ -11,6 +11,7 @@ export default createRule<RuleOptions, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Expect space before the type declaration in the named tuple',
+      recommended: true,
     },
     fixable: 'whitespace',
     schema: [],

--- a/packages/eslint-plugin/rules/wrap-iife/wrap-iife._js_.ts
+++ b/packages/eslint-plugin/rules/wrap-iife/wrap-iife._js_.ts
@@ -30,6 +30,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Require parentheses around immediate `function` invocations',
+      recommended: true,
     },
 
     schema: [

--- a/packages/eslint-plugin/rules/yield-star-spacing/yield-star-spacing._js_.ts
+++ b/packages/eslint-plugin/rules/yield-star-spacing/yield-star-spacing._js_.ts
@@ -15,6 +15,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     docs: {
       description: 'Require or disallow spacing around the `*` in `yield*` expressions',
+      recommended: true,
     },
 
     fixable: 'whitespace',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When running `eslint --inspect-config`, the tool provides the ability to filter rules based on a `recommended` property in the rule's metadata. This change adds matching `recommended: true` metadata to rules to match those included with the recommended shared config that eslint-stylistic provides.

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
- I'm happy to split the PR up into smaller chunks as this does touch a lot of files.

- After reading the eslint docs, I'm not sure if this change would be recommended by eslint. My opinion is that I think it would be nice to see what plugins define as recommended rules in the inspector. The eslint [docs](https://eslint.org/docs/latest/extend/custom-rules#rule-structure) might indicate this is only for those included with `@eslint/js` though:

> recommended: (boolean) For core rules, this specifies whether the rule is enabled by the recommended config from @eslint/js.

- To keep the TS rules consistent, I used the created `baseRule` object to derive their `meta.docs` property
- The indent rule had a comment about it being too opinionated to be recommended, but it is part of the recommended config so I set `recommended: true` to be consistent
