### PR TITLE
feat: Add granular configuration options to object-property-newline rule

### DIFF
--- a/packages/eslint-plugin/rules/object-property-newline/README._js_.md
+++ b/packages/eslint-plugin/rules/object-property-newline/README._js_.md
@@ -82,19 +82,71 @@ Another benefit of this rule is specificity of diffs when a property is changed:
 +var obj = { foo: "foo", bar: "bazz", baz: "baz" };
 ```
 
-### Optional Exception
+### Configuration Options
 
-The rule offers one object option, `allowAllPropertiesOnSameLine` (a deprecated synonym is `allowMultiplePropertiesPerLine`). If you set it to `true`, object literals such as the first two above, with all property specifications on the same line, will be permitted, but one like
+The rule offers several configuration options:
+
+#### Basic Configuration
+
+When using the basic configuration, all supported node types will use the same configuration:
+
+```js
+{
+  "object-property-newline": ["error", {
+    "allowAllPropertiesOnSameLine": true
+  }]
+}
+```
+
+With `allowAllPropertiesOnSameLine` set to `true`, object literals such as the first two above, with all property specifications on the same line, will be permitted, but one like
 
 ```js
 const newObject = {
     a: 'a.m.', b: 'p.m.',
     c: 'daylight saving time'
 };
-
 ```
 
 will be prohibited, because two properties, but not all properties, appear on the same line.
+
+A deprecated synonym is `allowMultiplePropertiesPerLine`, which has the same effect as `allowAllPropertiesOnSameLine`.
+
+#### Granular Configuration
+
+The rule also supports configuring each node type separately:
+
+```js
+{
+  "object-property-newline": ["error", {
+    "ObjectExpression": { "allowAllPropertiesOnSameLine": true },
+    "ObjectPattern": { "allowAllPropertiesOnSameLine": false },
+    "ImportDeclaration": { "allowAllPropertiesOnSameLine": true },
+    "ExportDeclaration": { "allowAllPropertiesOnSameLine": false }
+  }]
+}
+```
+
+This allows you to have different rules for different types of nodes:
+
+- `ObjectExpression`: Object literals
+- `ObjectPattern`: Object destructuring patterns
+- `ImportDeclaration`: Named imports
+- `ExportDeclaration`: Named exports
+- `TSTypeLiteral`: TypeScript type literals (TypeScript plugin only)
+- `TSInterfaceBody`: TypeScript interface bodies (TypeScript plugin only)
+
+You can also use a boolean shorthand where `true` means `{ allowAllPropertiesOnSameLine: true }` and `false` means `{ allowAllPropertiesOnSameLine: false }`:
+
+```js
+{
+  "object-property-newline": ["error", {
+    "ObjectExpression": true,  // Allow all properties on same line
+    "ImportDeclaration": false // Require each import on its own line
+  }]
+}
+```
+
+If a specific node type is not configured, it will fall back to the global options (if provided).
 
 ### Notations
 
@@ -118,6 +170,23 @@ const newObject = {
 ```
 
 (This behavior differs from that of the JSCS rule cited below, which does not treat the leading `[` of a computed property name as part of that property specification. The JSCS rule prohibits the second of these formats but permits the first.)
+
+### Import and Export Declarations
+
+This rule also applies to named imports and exports, requiring each to be on its own line. For example:
+
+```js
+// Invalid - multiple imports on same line
+import { foo, bar } from 'module';
+
+// Valid - each import on its own line
+import {
+    foo,
+    bar
+} from 'module';
+```
+
+The `allowAllPropertiesOnSameLine` option also applies to import and export declarations, allowing all specifiers to be on the same line when set to `true`.
 
 ### Multiline Properties
 
@@ -272,6 +341,29 @@ const user = process.argv[2];
 const obj3 = {
     user, [process.argv[3] ? "foo" : "bar"]: 0, baz: [1, 2, 4, 8]
 };
+```
+
+:::
+
+Examples of **correct** code for this rule with granular configuration:
+
+::: correct
+
+```js
+/*eslint object-property-newline: ["error", {
+  "ObjectExpression": { "allowAllPropertiesOnSameLine": true },
+  "ImportDeclaration": { "allowAllPropertiesOnSameLine": false }
+}]*/
+
+// Object literal properties can be on the same line
+const obj = { foo: "foo", bar: "bar", baz: "baz" };
+
+// But import specifiers must be on separate lines
+import {
+    foo,
+    bar,
+    baz
+} from 'module';
 ```
 
 :::

--- a/packages/eslint-plugin/rules/object-property-newline/README._ts_.md
+++ b/packages/eslint-plugin/rules/object-property-newline/README._ts_.md
@@ -6,4 +6,4 @@ description: Enforce placing object properties on separate lines.
 
 This rule extends the base [`object-property-newline`](/rules/js/object-property-newline) rule.
 
-It adds support for TypeScript's object types.
+It adds support for TypeScript's object types and interfaces, in addition to the import and export declaration handling from the base rule.

--- a/packages/eslint-plugin/rules/object-property-newline/object-property-newline._js_.test.ts
+++ b/packages/eslint-plugin/rules/object-property-newline/object-property-newline._js_.test.ts
@@ -55,6 +55,84 @@ run({
 
     // allowMultiplePropertiesPerLine: true (deprecated)
     { code: 'var obj = { k1: \'val1\', k2: \'val2\', k3: \'val3\' };', options: [{ allowMultiplePropertiesPerLine: true }] },
+
+    // Import declaration tests
+    'import {a} from \'module\';',
+    'import {\na\n} from \'module\';',
+    'import {} from \'module\';',
+    'import DefaultExport from \'module\';',
+    'import * as All from \'module\';',
+
+    'import {\na,\nb\n} from \'module\';',
+    'import {\na,\nb,\nc\n} from \'module\';',
+
+    // allowAllPropertiesOnSameLine: true for import declarations
+    { code: 'import {a, b, c} from \'module\';', options: [{ allowAllPropertiesOnSameLine: true }] },
+    { code: 'import {\na, b, c\n} from \'module\';', options: [{ allowAllPropertiesOnSameLine: true }] },
+    { code: 'var obj = { a: 1, b: 2 }; import { c, d } from "module";', options: [{
+      ObjectExpression: { allowAllPropertiesOnSameLine: true },
+      ImportDeclaration: { allowAllPropertiesOnSameLine: true },
+    }] },
+
+    // Granular configuration for different node types
+    {
+      code: 'var obj = { a: 1, b: 2 }; import { c, d } from \'module\';',
+      options: [{
+        ObjectExpression: true,
+        ImportDeclaration: true,
+      }],
+    },
+    {
+      code: 'var obj = { a: 1, b: 2 }; const { c, d } = obj;',
+      options: [{
+        ObjectExpression: true,
+        ObjectPattern: true,
+      }],
+    },
+    {
+      code: 'var obj = {\na: 1,\nb: 2\n}; import { c, d } from \'module\';',
+      options: [{
+        ObjectExpression: false,
+        ImportDeclaration: true,
+      }],
+    },
+    {
+      code: 'var obj = { a: 1, b: 2 }; import {\nc,\nd\n} from \'module\';',
+      options: [{
+        ObjectExpression: true,
+        ImportDeclaration: false,
+      }],
+    },
+    {
+      code: 'var obj = { a: 1, b: 2 }; export { c, d } from \'module\';',
+      options: [{
+        ObjectExpression: true,
+        ExportDeclaration: true,
+      }],
+    },
+    {
+      code: 'var obj = { a: 1, b: 2 }; import {\nc,\nd\n} from \'module\'; export { e, f } from \'module\';',
+      options: [{
+        ObjectExpression: true,
+        ImportDeclaration: false,
+        ExportDeclaration: true,
+      }],
+    },
+    // Boolean shorthand syntax tests
+    {
+      code: 'var obj = { a: 1, b: 2 }; import { c, d } from \'module\';',
+      options: [{
+        ObjectExpression: true,
+        ImportDeclaration: true,
+      }],
+    },
+    {
+      code: 'var obj = {\na: 1,\nb: 2\n}; import {\nc,\nd\n} from \'module\';',
+      options: [{
+        ObjectExpression: false,
+        ImportDeclaration: false,
+      }],
+    },
   ],
 
   invalid: [
@@ -656,6 +734,192 @@ run({
           column: 13,
           endLine: 3,
           endColumn: 15,
+        },
+      ],
+    },
+
+    // Import declaration tests
+    {
+      code: 'import {a, b} from \'module\';',
+      output: 'import {a,\nb} from \'module\';',
+      errors: [
+        {
+          messageId: 'propertiesOnNewline',
+          type: 'ImportDeclaration',
+          line: 1,
+          column: 12,
+        },
+      ],
+    },
+    {
+      code: 'import {a, b, c} from \'module\';',
+      output: 'import {a,\nb,\nc} from \'module\';',
+      errors: [
+        {
+          messageId: 'propertiesOnNewline',
+          type: 'ImportDeclaration',
+          line: 1,
+          column: 12,
+        },
+        {
+          messageId: 'propertiesOnNewline',
+          type: 'ImportDeclaration',
+          line: 1,
+          column: 15,
+        },
+      ],
+    },
+    {
+      code: 'import {\na, b\n} from \'module\';',
+      output: 'import {\na,\nb\n} from \'module\';',
+      errors: [
+        {
+          messageId: 'propertiesOnNewline',
+          type: 'ImportDeclaration',
+          line: 2,
+          column: 4,
+        },
+      ],
+    },
+    {
+      code: 'import DefaultExport, {a, b} from \'module\';',
+      output: 'import DefaultExport, {a,\nb} from \'module\';',
+      errors: [
+        {
+          messageId: 'propertiesOnNewline',
+          type: 'ImportDeclaration',
+          line: 1,
+          column: 27,
+        },
+      ],
+    },
+
+    // With allowAllPropertiesOnSameLine: true
+    {
+      code: 'import {a, b} from \'module\';',
+      output: 'import {a,\nb} from \'module\';',
+      errors: [
+        {
+          messageId: 'propertiesOnNewline',
+          type: 'ImportDeclaration',
+          line: 1,
+          column: 12,
+        },
+      ],
+    },
+    {
+      code: 'import {a, b, c} from \'module\';',
+      output: 'import {a,\nb,\nc} from \'module\';',
+      errors: [
+        {
+          messageId: 'propertiesOnNewline',
+          type: 'ImportDeclaration',
+          line: 1,
+          column: 12,
+        },
+        {
+          messageId: 'propertiesOnNewline',
+          type: 'ImportDeclaration',
+          line: 1,
+          column: 15,
+        },
+      ],
+    },
+
+    // With granular configuration
+    {
+      code: 'var obj = { a: 1, b: 2 }; import { c, d } from "module";',
+      output: 'var obj = { a: 1,\nb: 2 }; import { c, d } from "module";',
+      options: [{
+        ObjectExpression: { allowAllPropertiesOnSameLine: false },
+        ImportDeclaration: { allowAllPropertiesOnSameLine: true },
+      }],
+      errors: [
+        {
+          messageId: 'propertiesOnNewline',
+          type: 'ObjectExpression',
+          line: 1,
+          column: 19,
+          endLine: 1,
+          endColumn: 20,
+        },
+      ],
+    },
+    {
+      code: 'var obj = { a: 1, b: 2 }; import { c, d } from "module";',
+      output: 'var obj = { a: 1, b: 2 }; import { c,\nd } from "module";',
+      options: [{
+        ObjectExpression: { allowAllPropertiesOnSameLine: true },
+        ImportDeclaration: { allowAllPropertiesOnSameLine: false },
+      }],
+      errors: [
+        {
+          messageId: 'propertiesOnNewline',
+          type: 'ImportDeclaration',
+          line: 1,
+          column: 39,
+          endLine: 1,
+          endColumn: 40,
+        },
+      ],
+    },
+    {
+      code: 'var obj = { a: 1, b: 2 }; import { c, d } from "module";',
+      output: 'var obj = { a: 1,\nb: 2 }; import { c,\nd } from "module";',
+      options: [{
+        ObjectExpression: false,
+        ImportDeclaration: false,
+      }],
+      errors: [
+        {
+          messageId: 'propertiesOnNewline',
+          type: 'ObjectExpression',
+          line: 1,
+          column: 19,
+          endLine: 1,
+          endColumn: 20,
+        },
+        {
+          messageId: 'propertiesOnNewline',
+          type: 'ImportDeclaration',
+          line: 1,
+          column: 39,
+          endLine: 1,
+          endColumn: 40,
+        },
+      ],
+    },
+    {
+      code: 'const { a, b } = obj;',
+      output: 'const { a,\nb } = obj;',
+      options: [{
+        ObjectPattern: { allowAllPropertiesOnSameLine: false },
+      }],
+      errors: [
+        {
+          messageId: 'propertiesOnNewline',
+          type: 'ObjectPattern',
+          line: 1,
+          column: 12,
+          endLine: 1,
+          endColumn: 13,
+        },
+      ],
+    },
+    {
+      code: 'export { a, b } from "module";',
+      output: 'export { a,\nb } from "module";',
+      options: [{
+        ExportDeclaration: { allowAllPropertiesOnSameLine: false },
+      }],
+      errors: [
+        {
+          messageId: 'propertiesOnNewline',
+          type: 'ExportNamedDeclaration',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 14,
         },
       ],
     },

--- a/packages/eslint-plugin/rules/object-property-newline/object-property-newline._js_.ts
+++ b/packages/eslint-plugin/rules/object-property-newline/object-property-newline._js_.ts
@@ -28,6 +28,120 @@ export default createRule<RuleOptions, MessageIds>({
             type: 'boolean',
             default: false,
           },
+          ObjectExpression: {
+            oneOf: [
+              {
+                type: 'boolean',
+              },
+              {
+                type: 'object',
+                properties: {
+                  allowAllPropertiesOnSameLine: {
+                    type: 'boolean',
+                  },
+                  allowMultiplePropertiesPerLine: { // Deprecated
+                    type: 'boolean',
+                  },
+                },
+                additionalProperties: false,
+              },
+            ],
+          },
+          ObjectPattern: {
+            oneOf: [
+              {
+                type: 'boolean',
+              },
+              {
+                type: 'object',
+                properties: {
+                  allowAllPropertiesOnSameLine: {
+                    type: 'boolean',
+                  },
+                  allowMultiplePropertiesPerLine: { // Deprecated
+                    type: 'boolean',
+                  },
+                },
+                additionalProperties: false,
+              },
+            ],
+          },
+          ImportDeclaration: {
+            oneOf: [
+              {
+                type: 'boolean',
+              },
+              {
+                type: 'object',
+                properties: {
+                  allowAllPropertiesOnSameLine: {
+                    type: 'boolean',
+                  },
+                  allowMultiplePropertiesPerLine: { // Deprecated
+                    type: 'boolean',
+                  },
+                },
+                additionalProperties: false,
+              },
+            ],
+          },
+          ExportDeclaration: {
+            oneOf: [
+              {
+                type: 'boolean',
+              },
+              {
+                type: 'object',
+                properties: {
+                  allowAllPropertiesOnSameLine: {
+                    type: 'boolean',
+                  },
+                  allowMultiplePropertiesPerLine: { // Deprecated
+                    type: 'boolean',
+                  },
+                },
+                additionalProperties: false,
+              },
+            ],
+          },
+          TSTypeLiteral: {
+            oneOf: [
+              {
+                type: 'boolean',
+              },
+              {
+                type: 'object',
+                properties: {
+                  allowAllPropertiesOnSameLine: {
+                    type: 'boolean',
+                  },
+                  allowMultiplePropertiesPerLine: { // Deprecated
+                    type: 'boolean',
+                  },
+                },
+                additionalProperties: false,
+              },
+            ],
+          },
+          TSInterfaceBody: {
+            oneOf: [
+              {
+                type: 'boolean',
+              },
+              {
+                type: 'object',
+                properties: {
+                  allowAllPropertiesOnSameLine: {
+                    type: 'boolean',
+                  },
+                  allowMultiplePropertiesPerLine: { // Deprecated
+                    type: 'boolean',
+                  },
+                },
+                additionalProperties: false,
+              },
+            ],
+          },
         },
         additionalProperties: false,
       },
@@ -42,50 +156,111 @@ export default createRule<RuleOptions, MessageIds>({
   },
 
   create(context) {
-    const allowSameLine = context.options[0] && (
-      (context.options[0].allowAllPropertiesOnSameLine || context.options[0].allowMultiplePropertiesPerLine /* Deprecated */)
-    )
-    const messageId = allowSameLine
-      ? 'propertiesOnNewlineAll'
-      : 'propertiesOnNewline'
-
+    const options = context.options[0] || {}
     const sourceCode = context.sourceCode
+
+    /**
+     * Gets configuration for a specific node type
+     * @param nodeType The type of node to get configuration for
+     * @returns Configuration for the specified node type
+     */
+    function getOptionsForNodeType(nodeType: string): { allowSameLine: boolean } {
+      // First check for specific node type configuration
+      const nodeTypeOptions = typeof nodeType === 'string'
+        && nodeType in options ? (options as Record<string, any>)[nodeType] : undefined
+
+      if (nodeTypeOptions !== undefined) {
+        if (typeof nodeTypeOptions === 'boolean') {
+          // If it's a boolean, true means allow properties on same line, false means enforce newlines
+          return { allowSameLine: nodeTypeOptions }
+        }
+
+        // It's an object with configuration
+        return {
+          allowSameLine: !!(
+            nodeTypeOptions.allowAllPropertiesOnSameLine
+            || nodeTypeOptions.allowMultiplePropertiesPerLine
+          ),
+        }
+      }
+
+      // Fall back to global options
+      return {
+        allowSameLine: !!(
+          options.allowAllPropertiesOnSameLine
+          || options.allowMultiplePropertiesPerLine
+        ),
+      }
+    }
+
+    /**
+     * Checks properties of an object to enforce the rule
+     * @param properties Array of properties to check
+     * @param node Node representing the object
+     * @param nodeType Type of node being checked
+     */
+    function checkProperties(properties: any[], node: any, nodeType?: string) {
+      const { allowSameLine } = getOptionsForNodeType(nodeType || 'ObjectExpression')
+      const messageId = allowSameLine
+        ? 'propertiesOnNewlineAll'
+        : 'propertiesOnNewline'
+
+      if (allowSameLine) {
+        if (properties.length > 1) {
+          const firstTokenOfFirstProperty = sourceCode.getFirstToken(properties[0])!
+          const lastTokenOfLastProperty = sourceCode.getLastToken(properties[properties.length - 1])!
+
+          if (firstTokenOfFirstProperty.loc.end.line === lastTokenOfLastProperty.loc.start.line) {
+            // All keys and values are on the same line
+            return
+          }
+        }
+      }
+
+      for (let i = 1; i < properties.length; i++) {
+        const lastTokenOfPreviousProperty = sourceCode.getLastToken(properties[i - 1])!
+        const firstTokenOfCurrentProperty = sourceCode.getFirstToken(properties[i])!
+
+        if (lastTokenOfPreviousProperty.loc.end.line === firstTokenOfCurrentProperty.loc.start.line) {
+          context.report({
+            node,
+            loc: firstTokenOfCurrentProperty.loc,
+            messageId,
+            fix(fixer) {
+              const comma = sourceCode.getTokenBefore(firstTokenOfCurrentProperty)!
+              const rangeAfterComma = [comma.range[1], firstTokenOfCurrentProperty.range[0]] as const
+
+              // Don't perform a fix if there are any comments between the comma and the next property.
+              if (sourceCode.text.slice(rangeAfterComma[0], rangeAfterComma[1]).trim())
+                return null
+
+              return fixer.replaceTextRange(rangeAfterComma, '\n')
+            },
+          })
+        }
+      }
+    }
 
     return {
       ObjectExpression(node) {
-        if (allowSameLine) {
-          if (node.properties.length > 1) {
-            const firstTokenOfFirstProperty = sourceCode.getFirstToken(node.properties[0])!
-            const lastTokenOfLastProperty = sourceCode.getLastToken(node.properties[node.properties.length - 1])!
-
-            if (firstTokenOfFirstProperty.loc.end.line === lastTokenOfLastProperty.loc.start.line) {
-              // All keys and values are on the same line
-              return
-            }
-          }
+        checkProperties(node.properties, node, 'ObjectExpression')
+      },
+      ObjectPattern(node) {
+        checkProperties(node.properties, node, 'ObjectPattern')
+      },
+      // Add support for import declarations
+      ImportDeclaration(node) {
+        // Only check import declarations with named imports
+        if (node.specifiers.some(specifier => specifier.type === 'ImportSpecifier')) {
+          const importSpecifiers = node.specifiers.filter(specifier => specifier.type === 'ImportSpecifier')
+          checkProperties(importSpecifiers, node, 'ImportDeclaration')
         }
-
-        for (let i = 1; i < node.properties.length; i++) {
-          const lastTokenOfPreviousProperty = sourceCode.getLastToken(node.properties[i - 1])!
-          const firstTokenOfCurrentProperty = sourceCode.getFirstToken(node.properties[i])!
-
-          if (lastTokenOfPreviousProperty.loc.end.line === firstTokenOfCurrentProperty.loc.start.line) {
-            context.report({
-              node,
-              loc: firstTokenOfCurrentProperty.loc,
-              messageId,
-              fix(fixer) {
-                const comma = sourceCode.getTokenBefore(firstTokenOfCurrentProperty)!
-                const rangeAfterComma = [comma.range[1], firstTokenOfCurrentProperty.range[0]] as const
-
-                // Don't perform a fix if there are any comments between the comma and the next property.
-                if (sourceCode.text.slice(rangeAfterComma[0], rangeAfterComma[1]).trim())
-                  return null
-
-                return fixer.replaceTextRange(rangeAfterComma, '\n')
-              },
-            })
-          }
+      },
+      // Add support for export declarations
+      ExportNamedDeclaration(node) {
+        if (node.specifiers.some(specifier => specifier.type === 'ExportSpecifier')) {
+          const exportSpecifiers = node.specifiers.filter(specifier => specifier.type === 'ExportSpecifier')
+          checkProperties(exportSpecifiers, node, 'ExportDeclaration')
         }
       },
     }

--- a/packages/eslint-plugin/rules/object-property-newline/object-property-newline._ts_.test.ts
+++ b/packages/eslint-plugin/rules/object-property-newline/object-property-newline._ts_.test.ts
@@ -76,6 +76,24 @@ run({
         '{ id: number; name: string; age: number; }',
       ],
     ].flatMap(code => createValidRule(code, true)),
+    {
+      code: 'type T = { a: string, b: number };',
+      options: [{
+        allowAllPropertiesOnSameLine: true,
+      }],
+    },
+    {
+      code: 'interface Foo { a: string, b: number }',
+      options: [{
+        allowAllPropertiesOnSameLine: true,
+      }],
+    },
+    {
+      code: 'type T = { a: string, b: number }; interface Bar { c: boolean, d: string }',
+      options: [{
+        allowAllPropertiesOnSameLine: true,
+      }],
+    },
   ],
   invalid: [
     ...[
@@ -156,5 +174,39 @@ run({
         ],
       },
     ].flatMap(c => createInvalidRule(c.code, c.output, c.errors, true)),
+
+    // Invalid tests for granular configuration
+    {
+      code: 'type T = { a: string, b: number };',
+      output: 'type T = { a: string,\nb: number };',
+      options: [{
+        TSTypeLiteral: { allowAllPropertiesOnSameLine: false },
+      }],
+      errors: [
+        { messageId: 'propertiesOnNewline', line: 1, column: 23 },
+      ],
+    },
+    {
+      code: 'interface Foo { a: string, b: number }',
+      output: 'interface Foo { a: string,\nb: number }',
+      options: [{
+        TSInterfaceBody: { allowAllPropertiesOnSameLine: false },
+      }],
+      errors: [
+        { messageId: 'propertiesOnNewline', line: 1, column: 28 },
+      ],
+    },
+    {
+      code: 'type T = { a: string, b: number }; interface Bar { c: boolean, d: string }',
+      output: 'type T = { a: string,\nb: number }; interface Bar { c: boolean,\nd: string }',
+      options: [{
+        TSTypeLiteral: { allowAllPropertiesOnSameLine: false },
+        TSInterfaceBody: { allowAllPropertiesOnSameLine: false },
+      }],
+      errors: [
+        { messageId: 'propertiesOnNewline', line: 1, column: 23 },
+        { messageId: 'propertiesOnNewline', line: 1, column: 64 },
+      ],
+    },
   ],
 })

--- a/packages/eslint-plugin/rules/object-property-newline/object-property-newline._ts_.ts
+++ b/packages/eslint-plugin/rules/object-property-newline/object-property-newline._ts_.ts
@@ -27,6 +27,7 @@ export default createRule<RuleOptions, MessageIds>({
     return {
       ...rules,
       TSTypeLiteral(node: Tree.TSTypeLiteral) {
+        // Use the ObjectExpression handler but with the TSTypeLiteral node
         return rules.ObjectExpression!({
           ...node,
           // @ts-expect-error only used to get token and loc
@@ -34,6 +35,7 @@ export default createRule<RuleOptions, MessageIds>({
         })
       },
       TSInterfaceBody(node: Tree.TSInterfaceBody) {
+        // Use the ObjectExpression handler but with the TSInterfaceBody node
         return rules.ObjectExpression!({
           ...node,
           // @ts-expect-error only used to get token and loc


### PR DESCRIPTION
Add support for granular configuration options to the object-property-newline rule