### PR TITLE
refactor: merge `no-extra-parens`

### DIFF
--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.ts
@@ -22,6 +22,14 @@ import {
 } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
+type ReportsBuffer = {
+  upper: ReportsBuffer
+  inExpressionNodes: ASTNode[]
+  reports: { node: ASTNode, finishReport: () => void }[]
+} | undefined
+// eslint-disable-next-line import/no-mutable-exports
+export let reportsBuffer: ReportsBuffer
+
 export default createRule<RuleOptions, MessageIds>({
   name: 'no-extra-parens',
   package: 'js',
@@ -110,12 +118,12 @@ export default createRule<RuleOptions, MessageIds>({
     // @ts-expect-error other properties are not used
     const PRECEDENCE_OF_UPDATE_EXPR = precedence({ type: 'UpdateExpression' })
 
-    type ReportsBuffer = {
-      upper: ReportsBuffer
-      inExpressionNodes: ASTNode[]
-      reports: { node: ASTNode, finishReport: () => void }[]
-    } | undefined
-    let reportsBuffer: ReportsBuffer
+    // type ReportsBuffer = {
+    //   upper: ReportsBuffer
+    //   inExpressionNodes: ASTNode[]
+    //   reports: { node: ASTNode, finishReport: () => void }[]
+    // } | undefined
+    // let reportsBuffer: ReportsBuffer
 
     /**
      * Determines whether the given node is a `call` or `apply` method call, invoked directly on a `FunctionExpression` node.

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.ts
@@ -22,8 +22,6 @@ import {
 } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
-export const tokensToIgnore = new WeakSet()
-
 export default createRule<RuleOptions, MessageIds>({
   name: 'no-extra-parens',
   package: 'js',
@@ -88,7 +86,7 @@ export default createRule<RuleOptions, MessageIds>({
   create(context) {
     const sourceCode = context.sourceCode
 
-    // const tokensToIgnore = new WeakSet()
+    const tokensToIgnore = new WeakSet()
     const precedence = getPrecedence
     const ALL_NODES = context.options[0] !== 'functions'
     const EXCEPT_COND_ASSIGN = ALL_NODES && context.options[1] && context.options[1].conditionalAssign === false

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.ts
@@ -29,6 +29,7 @@ type ReportsBuffer = {
 } | undefined
 // eslint-disable-next-line import/no-mutable-exports
 export let reportsBuffer: ReportsBuffer
+export const tokensToIgnore = new WeakSet()
 
 export default createRule<RuleOptions, MessageIds>({
   name: 'no-extra-parens',
@@ -94,7 +95,7 @@ export default createRule<RuleOptions, MessageIds>({
   create(context) {
     const sourceCode = context.sourceCode
 
-    const tokensToIgnore = new WeakSet()
+    // const tokensToIgnore = new WeakSet()
     const precedence = getPrecedence
     const ALL_NODES = context.options[0] !== 'functions'
     const EXCEPT_COND_ASSIGN = ALL_NODES && context.options[1] && context.options[1].conditionalAssign === false

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.ts
@@ -22,13 +22,6 @@ import {
 } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
-type ReportsBuffer = {
-  upper: ReportsBuffer
-  inExpressionNodes: ASTNode[]
-  reports: { node: ASTNode, finishReport: () => void }[]
-} | undefined
-// eslint-disable-next-line import/no-mutable-exports
-export let reportsBuffer: ReportsBuffer
 export const tokensToIgnore = new WeakSet()
 
 export default createRule<RuleOptions, MessageIds>({
@@ -119,12 +112,12 @@ export default createRule<RuleOptions, MessageIds>({
     // @ts-expect-error other properties are not used
     const PRECEDENCE_OF_UPDATE_EXPR = precedence({ type: 'UpdateExpression' })
 
-    // type ReportsBuffer = {
-    //   upper: ReportsBuffer
-    //   inExpressionNodes: ASTNode[]
-    //   reports: { node: ASTNode, finishReport: () => void }[]
-    // } | undefined
-    // let reportsBuffer: ReportsBuffer
+    type ReportsBuffer = {
+      upper: ReportsBuffer
+      inExpressionNodes: ASTNode[]
+      reports: { node: ASTNode, finishReport: () => void }[]
+    } | undefined
+    let reportsBuffer: ReportsBuffer
 
     /**
      * Determines whether the given node is a `call` or `apply` method call, invoked directly on a `FunctionExpression` node.

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.ts
@@ -2,6 +2,10 @@
  * @fileoverview Disallow parenthesising higher precedence subexpressions.
  * @author Michael Ficarra
  */
+
+// MERGED: The JS version of this rule is merged to the TS version, this file will be removed
+// in the next major when we remove the `@stylistic/eslint-plugin-js` package.
+
 import type { ASTNode, Token, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
 import {

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
@@ -3,7 +3,14 @@
 import type { ASTNode, Tree } from '#types'
 import type { TSESLint } from '@typescript-eslint/utils'
 import type { MessageIds, RuleOptions } from './types'
-
+import {
+  canTokensBeAdjacent,
+  getPrecedence,
+  getStaticPropertyName,
+  isParenthesized as isParenthesizedRaw,
+  isTopLevelExpressionStatement,
+  skipChainExpression,
+} from '#utils/ast'
 import { castRuleModule, createRule } from '#utils/create-rule'
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import { isOpeningParenToken, isTypeAssertion } from '@typescript-eslint/utils/ast-utils'
@@ -28,6 +35,132 @@ export default createRule<RuleOptions, MessageIds>({
   create(context) {
     const sourceCode = context.sourceCode
     const rules = baseRule.create(context)
+
+    const tokensToIgnore = new WeakSet()
+    const precedence = getPrecedence
+    const ALL_NODES = context.options[0] !== 'functions'
+    const IGNORE_JSX = ALL_NODES && context.options[1]
+      && context.options[1].ignoreJSX
+    const IGNORE_SEQUENCE_EXPRESSIONS = ALL_NODES && context.options[1]
+      && context.options[1].enforceForSequenceExpressions === false
+    const IGNORE_FUNCTION_PROTOTYPE_METHODS = ALL_NODES && context.options[1]
+      && context.options[1].enforceForFunctionPrototypeMethods === false
+    const ALLOW_PARENS_AFTER_COMMENT_PATTERN = ALL_NODES && context.options[1]
+      && context.options[1].allowParensAfterCommentPattern
+
+    // @ts-expect-error other properties are not used
+    const PRECEDENCE_OF_ASSIGNMENT_EXPR = precedence({ type: 'AssignmentExpression' })
+
+    type ReportsBuffer = {
+      upper: ReportsBuffer
+      inExpressionNodes: ASTNode[]
+      reports: { node: ASTNode, finishReport: () => void }[]
+    } | undefined
+    let reportsBuffer: ReportsBuffer
+
+    /**
+     * Determines whether the given node is a `call` or `apply` method call, invoked directly on a `FunctionExpression` node.
+     * Example: function(){}.call()
+     * @param node The node to be checked.
+     * @returns True if the node is an immediate `call` or `apply` method call.
+     * @private
+     */
+    function isImmediateFunctionPrototypeMethodCall(node: ASTNode) {
+      const callNode = skipChainExpression(node)
+
+      if (callNode.type !== 'CallExpression')
+        return false
+
+      const callee = skipChainExpression(callNode.callee)
+
+      return (
+        callee.type === 'MemberExpression'
+        && callee.object.type === 'FunctionExpression'
+        && ['call', 'apply'].includes(getStaticPropertyName(callee)!)
+      )
+    }
+
+    /**
+     * Determines if this rule should be enforced for a node given the current configuration.
+     * @param node The node to be checked.
+     * @returns True if the rule should be enforced for this node.
+     * @private
+     */
+    function ruleApplies(node: ASTNode) {
+      if (node.type === 'JSXElement' || node.type === 'JSXFragment') {
+        const isSingleLine = node.loc.start.line === node.loc.end.line
+
+        switch (IGNORE_JSX) {
+          // Exclude this JSX element from linting
+          case 'all':
+            return false
+
+            // Exclude this JSX element if it is multi-line element
+          case 'multi-line':
+            return isSingleLine
+
+            // Exclude this JSX element if it is single-line element
+          case 'single-line':
+            return !isSingleLine
+
+            // Nothing special to be done for JSX elements
+          case 'none':
+            break
+
+                        // no default
+        }
+      }
+
+      if (node.type === 'SequenceExpression' && IGNORE_SEQUENCE_EXPRESSIONS)
+        return false
+
+      if (isImmediateFunctionPrototypeMethodCall(node) && IGNORE_FUNCTION_PROTOTYPE_METHODS)
+        return false
+
+      return ALL_NODES || node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression'
+    }
+
+    /**
+     * Determines if a node is surrounded by parentheses.
+     * @param node The node to be checked.
+     * @returns True if the node is parenthesised.
+     * @private
+     */
+    function isParenthesised(node: ASTNode) {
+      return isParenthesizedRaw(node, sourceCode, 1)
+    }
+
+    /**
+     * Determines if a node is surrounded by parentheses twice.
+     * @param node The node to be checked.
+     * @returns True if the node is doubly parenthesised.
+     * @private
+     */
+    function isParenthesisedTwice(node: ASTNode) {
+      return isParenthesizedRaw(node, sourceCode, 2)
+    }
+
+    /**
+     * Determines if a node that is expected to be parenthesised is surrounded by
+     * (potentially) invalid extra parentheses with considering precedence level of the node.
+     * If the preference level of the node is not higher or equal to precedence lower limit, it also checks
+     * whether the node is surrounded by parentheses twice or not.
+     * @param node The node to be checked.
+     * @param precedenceLowerLimit The lower limit of precedence.
+     * @returns True if the node is has an unexpected extra pair of parentheses.
+     * @private
+     */
+    function hasExcessParensWithPrecedence(node: ASTNode, precedenceLowerLimit: number) {
+      if (ruleApplies(node) && isParenthesised(node)) {
+        if (
+          precedence(node) >= precedenceLowerLimit
+          || isParenthesisedTwice(node)
+        ) {
+          return true
+        }
+      }
+      return false
+    }
 
     function binaryExp(
       node: Tree.BinaryExpression | Tree.LogicalExpression,
@@ -116,16 +249,144 @@ export default createRule<RuleOptions, MessageIds>({
       return rule(node)
     }
 
+    /**
+     * Determines whether a node should be preceded by an additional space when removing parens
+     * @param node node to evaluate; must be surrounded by parentheses
+     * @returns `true` if a space should be inserted before the node
+     * @private
+     */
+    function requiresLeadingSpace(node: ASTNode) {
+      const leftParenToken = sourceCode.getTokenBefore(node)!
+      const tokenBeforeLeftParen = sourceCode.getTokenBefore(leftParenToken, { includeComments: true })!
+      const tokenAfterLeftParen = sourceCode.getTokenAfter(leftParenToken, { includeComments: true })!
+
+      return tokenBeforeLeftParen
+        && tokenBeforeLeftParen.range[1] === leftParenToken.range[0]
+        && leftParenToken.range[1] === tokenAfterLeftParen.range[0]
+        && !canTokensBeAdjacent(tokenBeforeLeftParen, tokenAfterLeftParen)
+    }
+
+    /**
+     * Determines whether a node should be followed by an additional space when removing parens
+     * @param node node to evaluate; must be surrounded by parentheses
+     * @returns `true` if a space should be inserted after the node
+     * @private
+     */
+    function requiresTrailingSpace(node: ASTNode) {
+      const nextTwoTokens = sourceCode.getTokensAfter(node, { count: 2 })
+      const rightParenToken = nextTwoTokens[0]
+      const tokenAfterRightParen = nextTwoTokens[1]
+      const tokenBeforeRightParen = sourceCode.getLastToken(node)!
+
+      return rightParenToken && tokenAfterRightParen
+        && !sourceCode.isSpaceBetween(rightParenToken, tokenAfterRightParen)
+        && !canTokensBeAdjacent(tokenBeforeRightParen, tokenAfterRightParen)
+    }
+
+    /**
+     * Determines if a given expression node is an IIFE
+     * @param node The node to check
+     * @returns `true` if the given node is an IIFE
+     */
+    function isIIFE(node: ASTNode) {
+      const maybeCallNode = skipChainExpression(node)
+
+      return maybeCallNode.type === 'CallExpression' && maybeCallNode.callee.type === 'FunctionExpression'
+    }
+
+    /**
+     * Checks if a node is fixable.
+     * A node is fixable if removing a single pair of surrounding parentheses does not turn it
+     * into a directive after fixing other nodes.
+     * Almost all nodes are fixable, except if all of the following conditions are met:
+     * The node is a string Literal
+     * It has a single pair of parentheses
+     * It is the only child of an ExpressionStatement
+     * @param node The node to evaluate.
+     * @returns Whether or not the node is fixable.
+     * @private
+     */
+    function isFixable(node: ASTNode) {
+      // if it's not a string literal it can be autofixed
+      if (node.type !== 'Literal' || typeof node.value !== 'string')
+        return true
+
+      if (isParenthesisedTwice(node))
+        return true
+
+      return !isTopLevelExpressionStatement(node.parent)
+    }
+
+    /**
+     * Report the node
+     * @param node node to evaluate
+     * @private
+     */
+    function report(node: ASTNode) {
+      const leftParenToken = sourceCode.getTokenBefore(node)!
+      const rightParenToken = sourceCode.getTokenAfter(node)!
+
+      if (!isParenthesisedTwice(node)) {
+        if (tokensToIgnore.has(sourceCode.getFirstToken(node)!))
+          return
+
+        if (isIIFE(node) && !('callee' in node && isParenthesised(node.callee)))
+          return
+
+        if (ALLOW_PARENS_AFTER_COMMENT_PATTERN) {
+          const commentsBeforeLeftParenToken = sourceCode.getCommentsBefore(leftParenToken)
+          const totalCommentsBeforeLeftParenTokenCount = commentsBeforeLeftParenToken.length
+          const ignorePattern = new RegExp(ALLOW_PARENS_AFTER_COMMENT_PATTERN, 'u')
+
+          if (
+            totalCommentsBeforeLeftParenTokenCount > 0
+            && ignorePattern.test(commentsBeforeLeftParenToken[totalCommentsBeforeLeftParenTokenCount - 1].value)
+          ) {
+            return
+          }
+        }
+      }
+
+      /**
+       * Finishes reporting
+       * @private
+       */
+      function finishReport() {
+        context.report({
+          node,
+          loc: leftParenToken.loc,
+          messageId: 'unexpected',
+          fix: isFixable(node)
+            ? (fixer) => {
+                const parenthesizedSource = sourceCode.text.slice(leftParenToken.range[1], rightParenToken.range[0])
+
+                return fixer.replaceTextRange([
+                  leftParenToken.range[0],
+                  rightParenToken.range[1],
+                ], (requiresLeadingSpace(node) ? ' ' : '') + parenthesizedSource + (requiresTrailingSpace(node) ? ' ' : ''))
+              }
+            : null,
+        })
+      }
+
+      if (reportsBuffer) {
+        reportsBuffer.reports.push({ node, finishReport })
+        return
+      }
+
+      finishReport()
+    }
+
     const overrides: TSESLint.RuleListener = {
       ArrayExpression(node) {
-        return rules.ArrayExpression!({
-          ...node,
-          elements: node.elements.map(element =>
+        node.elements
+          .map(element =>
             isTypeAssertion(element)
               ? { ...element, type: AST_NODE_TYPES.FunctionExpression as any }
               : element,
-          ),
-        })
+          )
+          .filter((e): e is NonNullable<typeof e> => !!e && hasExcessParensWithPrecedence(e, PRECEDENCE_OF_ASSIGNMENT_EXPR))
+          .forEach(report)
       },
       ArrowFunctionExpression(node) {
         if (!isTypeAssertion(node.body))

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
@@ -345,11 +345,9 @@ export default createRule<RuleOptions, MessageIds>({
     function unaryUpdateExpression(
       node: Tree.UnaryExpression | Tree.UpdateExpression,
     ): void {
-      const rule = rules.UnaryExpression as (n: typeof node) => void
-
       if (isTypeAssertion(node.argument)) {
         // reduces the precedence of the node so the rule thinks it needs to be wrapped
-        return rule({
+        return checkArgumentWithPrecedence({
           ...node,
           argument: {
             ...node.argument,
@@ -358,7 +356,7 @@ export default createRule<RuleOptions, MessageIds>({
         })
       }
 
-      return rule(node)
+      return checkArgumentWithPrecedence(node)
     }
 
     /**

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
@@ -377,6 +377,16 @@ export default createRule<RuleOptions, MessageIds>({
       finishReport()
     }
 
+    /**
+     * Evaluate a argument of the node.
+     * @param node node to evaluate
+     * @private
+     */
+    function checkArgumentWithPrecedence(node: ASTNode) {
+      if ('argument' in node && node.argument && hasExcessParensWithPrecedence(node.argument, precedence(node)))
+        report(node.argument)
+    }
+
     const overrides: TSESLint.RuleListener = {
       ArrayExpression(node) {
         node.elements
@@ -396,7 +406,7 @@ export default createRule<RuleOptions, MessageIds>({
       AwaitExpression(node) {
         if (isTypeAssertion(node.argument)) {
           // reduces the precedence of the node so the rule thinks it needs to be wrapped
-          return rules.AwaitExpression!({
+          return checkArgumentWithPrecedence({
             ...node,
             argument: {
               ...node.argument,
@@ -404,7 +414,7 @@ export default createRule<RuleOptions, MessageIds>({
             },
           })
         }
-        return rules.AwaitExpression!(node)
+        return checkArgumentWithPrecedence(node)
       },
       'BinaryExpression': binaryExp,
       'CallExpression': callExp,

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
@@ -577,8 +577,13 @@ export default createRule<RuleOptions, MessageIds>({
       // ReturnStatement
       // SequenceExpression
       SpreadElement(node) {
-        if (!isTypeAssertion(node.argument))
-          return rules.SpreadElement!(node)
+        if (isTypeAssertion(node.argument))
+          return
+
+        if (!hasExcessParensWithPrecedence(node.argument, PRECEDENCE_OF_ASSIGNMENT_EXPR))
+          return
+
+        report(node.argument)
       },
       SwitchCase(node) {
         if (node.test && !isTypeAssertion(node.test))

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
@@ -725,8 +725,9 @@ export default createRule<RuleOptions, MessageIds>({
 
         return rules.MemberExpression!(node)
       },
-      // TODO: use MethodDefinition directly
-      'MethodDefinition[computed=true]': function (node: Tree.MethodDefinition) {
+      MethodDefinition(node) {
+        if (!node.computed)
+          return
         if (hasExcessParensWithPrecedence(node.key, PRECEDENCE_OF_ASSIGNMENT_EXPR))
           report(node.key)
       },

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
@@ -20,7 +20,7 @@ import {
 import { castRuleModule, createRule } from '#utils/create-rule'
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import { isOpeningParenToken, isTypeAssertion } from '@typescript-eslint/utils/ast-utils'
-import _baseRule, { tokensToIgnore } from './no-extra-parens._js_'
+import _baseRule from './no-extra-parens._js_'
 
 const baseRule = /* @__PURE__ */ castRuleModule(_baseRule)
 
@@ -41,7 +41,7 @@ export default createRule<RuleOptions, MessageIds>({
   create(context) {
     const sourceCode = context.sourceCode
 
-    // const tokensToIgnore = new WeakSet()
+    const tokensToIgnore = new WeakSet()
     const precedence = getPrecedence
     const ALL_NODES = context.options[0] !== 'functions'
     const EXCEPT_COND_ASSIGN = ALL_NODES && context.options[1]

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
@@ -828,7 +828,22 @@ export default createRule<RuleOptions, MessageIds>({
         if (isTypeAssertion(node.argument)) {
           return unaryUpdateExpression(node)
         }
-        return rules.UpdateExpression!(node)
+
+        if (node.prefix) {
+          checkArgumentWithPrecedence(node)
+        }
+        else {
+          const { argument } = node
+          const operatorToken = sourceCode.getLastToken(node)!
+
+          if (argument.loc.end.line === operatorToken.loc.start.line) {
+            checkArgumentWithPrecedence(node)
+          }
+          else {
+            if (hasDoubleExcessParens(argument))
+              report(argument)
+          }
+        }
       },
       VariableDeclarator(node) {
         if (isTypeAssertion(node.init)) {

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
@@ -673,10 +673,12 @@ export default createRule<RuleOptions, MessageIds>({
         return rules.ForOfStatement!(node)
       },
       TSStringKeyword(node) {
-        return rules.TSStringKeyword!({
-          ...node,
-          type: AST_NODE_TYPES.FunctionExpression as any,
-        })
+        if (hasExcessParens(node)) {
+          report({
+            ...node,
+            type: AST_NODE_TYPES.FunctionExpression as any,
+          })
+        }
       },
     }
     return Object.assign({}, rules, overrides)

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
@@ -1257,8 +1257,7 @@ export default createRule<RuleOptions, MessageIds>({
               node.computed
               || !(
                 isDecimalInteger(node.object)
-
-                // RegExp literal is allowed to have parens (#1589)
+                // RegExp literal is allowed to have parens (https://github.com/eslint/eslint/issues/1589)
                 || (node.object.type === 'Literal' && 'regex' in node.object && node.object.regex)
               )
             )
@@ -1360,12 +1359,13 @@ export default createRule<RuleOptions, MessageIds>({
         if (isReturnAssignException(node))
           return
 
-        if (node.argument
+        if (
+          node.argument
           && returnToken
           && hasExcessParensNoLineTerminator(returnToken, node.argument)
-
-        // RegExp literal is allowed to have parens (#1589)
-          && !(node.argument.type === 'Literal' && 'regex' in node.argument && node.argument.regex)) {
+          // RegExp literal is allowed to have parens (https://github.com/eslint/eslint/issues/1589)
+          && !(node.argument.type === 'Literal' && 'regex' in node.argument && node.argument.regex)
+        ) {
           report(node.argument)
         }
       },
@@ -1435,8 +1435,7 @@ export default createRule<RuleOptions, MessageIds>({
         const rule = (node: Tree.VariableDeclarator) => {
           if (
             node.init && hasExcessParensWithPrecedence(node.init, PRECEDENCE_OF_ASSIGNMENT_EXPR)
-
-            // RegExp literal is allowed to have parens (#1589)
+            // RegExp literal is allowed to have parens (https://github.com/eslint/eslint/issues/1589)
             && !(node.init.type === 'Literal' && 'regex' in node.init && node.init.regex)
           ) {
             report(node.init)

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
@@ -15,7 +15,7 @@ import {
 import { castRuleModule, createRule } from '#utils/create-rule'
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import { isOpeningParenToken, isTypeAssertion } from '@typescript-eslint/utils/ast-utils'
-import _baseRule, { reportsBuffer } from './no-extra-parens._js_'
+import _baseRule, { reportsBuffer, tokensToIgnore } from './no-extra-parens._js_'
 
 const baseRule = /* @__PURE__ */ castRuleModule(_baseRule)
 
@@ -37,7 +37,7 @@ export default createRule<RuleOptions, MessageIds>({
     const sourceCode = context.sourceCode
     const rules = baseRule.create(context)
 
-    const tokensToIgnore = new WeakSet()
+    // const tokensToIgnore = new WeakSet()
     const precedence = getPrecedence
     const ALL_NODES = context.options[0] !== 'functions'
     const EXCEPT_COND_ASSIGN = ALL_NODES && context.options[1]

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
@@ -14,7 +14,7 @@ import {
 import { castRuleModule, createRule } from '#utils/create-rule'
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import { isOpeningParenToken, isTypeAssertion } from '@typescript-eslint/utils/ast-utils'
-import _baseRule from './no-extra-parens._js_'
+import _baseRule, { reportsBuffer } from './no-extra-parens._js_'
 
 const baseRule = /* @__PURE__ */ castRuleModule(_baseRule)
 
@@ -57,12 +57,12 @@ export default createRule<RuleOptions, MessageIds>({
     // @ts-expect-error other properties are not used
     const PRECEDENCE_OF_UPDATE_EXPR = precedence({ type: 'UpdateExpression' })
 
-    type ReportsBuffer = {
-      upper: ReportsBuffer
-      inExpressionNodes: ASTNode[]
-      reports: { node: ASTNode, finishReport: () => void }[]
-    } | undefined
-    let reportsBuffer: ReportsBuffer
+    // type ReportsBuffer = {
+    //   upper: ReportsBuffer
+    //   inExpressionNodes: ASTNode[]
+    //   reports: { node: ASTNode, finishReport: () => void }[]
+    // } | undefined
+    // let reportsBuffer: ReportsBuffer
 
     /**
      * Determines whether the given node is a `call` or `apply` method call, invoked directly on a `FunctionExpression` node.

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
@@ -586,10 +586,13 @@ export default createRule<RuleOptions, MessageIds>({
         report(node.argument)
       },
       SwitchCase(node) {
-        if (node.test && !isTypeAssertion(node.test))
-          return rules.SwitchCase!(node)
+        if (node.test && !isTypeAssertion(node.test) && hasExcessParens(node.test))
+          report(node.test)
       },
-      // SwitchStatement
+      SwitchStatement(node) {
+        if (hasExcessParens(node.discriminant))
+          report(node.discriminant)
+      },
       ThrowStatement(node) {
         if (node.argument && !isTypeAssertion(node.argument))
           return rules.ThrowStatement!(node)

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
@@ -1,7 +1,6 @@
 // any is required to work around manipulating the AST in weird ways
 
 import type { ASTNode, Token, Tree } from '#types'
-import type { TSESLint } from '@typescript-eslint/utils'
 import type { MessageIds, RuleOptions } from './types'
 import {
   canTokensBeAdjacent,
@@ -531,7 +530,7 @@ export default createRule<RuleOptions, MessageIds>({
         report(node.superClass)
     }
 
-    const overrides: TSESLint.RuleListener = {
+    return {
       ArrayExpression(node) {
         node.elements
           .map(element =>
@@ -551,7 +550,7 @@ export default createRule<RuleOptions, MessageIds>({
         if (!isTypeAssertion(node.body))
           return rules.ArrowFunctionExpression!(node)
       },
-      // AssignmentExpression
+      'AssignmentExpression': rules.AssignmentExpression,
       AssignmentPattern(node) {
         const { left, right } = node
 
@@ -636,8 +635,8 @@ export default createRule<RuleOptions, MessageIds>({
         if (hasExcessParens(node.test) && !isCondAssignException(node))
           report(node.test)
       },
-      // ExportDefaultDeclaration
-      // ExpressionStatement
+      'ExportDefaultDeclaration': rules.ExportDefaultDeclaration,
+      'ExpressionStatement': rules.ExpressionStatement,
       ForInStatement(node) {
         if (isTypeAssertion(node.right)) {
           // as of 7.20.0 there's no way to skip checking the right of the ForIn
@@ -875,6 +874,5 @@ export default createRule<RuleOptions, MessageIds>({
         }
       },
     }
-    return Object.assign({}, rules, overrides)
   },
 })

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
@@ -809,8 +809,15 @@ export default createRule<RuleOptions, MessageIds>({
           .forEach(report)
       },
       ThrowStatement(node) {
-        if (node.argument && !isTypeAssertion(node.argument))
-          return rules.ThrowStatement!(node)
+        if (!node.argument || isTypeAssertion(node.argument))
+          return
+
+        const throwToken = sourceCode.getFirstToken(node)
+        if (!throwToken)
+          return
+
+        if (hasExcessParensNoLineTerminator(throwToken, node.argument))
+          report(node.argument)
       },
       'UnaryExpression': unaryUpdateExpression,
       UpdateExpression(node) {

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
@@ -542,6 +542,11 @@ export default createRule<RuleOptions, MessageIds>({
           .filter((e): e is NonNullable<typeof e> => !!e && hasExcessParensWithPrecedence(e, PRECEDENCE_OF_ASSIGNMENT_EXPR))
           .forEach(report)
       },
+      ArrayPattern(node) {
+        node.elements
+          .filter((e): e is NonNullable<typeof e> => !!e && canBeAssignmentTarget(e) && hasExcessParens(e))
+          .forEach(report)
+      },
       ArrowFunctionExpression(node) {
         if (!isTypeAssertion(node.body))
           return rules.ArrowFunctionExpression!(node)

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
@@ -1099,35 +1099,20 @@ export default createRule<RuleOptions, MessageIds>({
           report(node.right)
       },
       ForOfStatement(node) {
-        const rule = (node: Tree.ForOfStatement) => {
-          if (node.left.type !== 'VariableDeclaration') {
-            const firstLeftToken = sourceCode.getFirstToken(node.left, isNotOpeningParenToken)!
+        if (node.left.type !== 'VariableDeclaration') {
+          const firstLeftToken = sourceCode.getFirstToken(node.left, isNotOpeningParenToken)!
 
-            if (firstLeftToken.value === 'let') {
+          if (firstLeftToken.value === 'let') {
             // ForOfStatement#left expression cannot start with `let`.
-              tokensToIgnore.add(firstLeftToken)
-            }
+            tokensToIgnore.add(firstLeftToken)
           }
-
-          if (hasExcessParens(node.left))
-            report(node.left)
-
-          if (hasExcessParensWithPrecedence(node.right, PRECEDENCE_OF_ASSIGNMENT_EXPR))
-            report(node.right)
-        }
-        if (isTypeAssertion(node.right)) {
-          // makes the rule skip checking of the right
-          return rule({
-            ...node,
-            type: AST_NODE_TYPES.ForOfStatement,
-            right: {
-              ...node.right,
-              type: AST_NODE_TYPES.SequenceExpression as any,
-            },
-          })
         }
 
-        return rule(node)
+        if (hasExcessParens(node.left))
+          report(node.left)
+
+        if (!isTypeAssertion(node.right) && hasExcessParensWithPrecedence(node.right, PRECEDENCE_OF_ASSIGNMENT_EXPR))
+          report(node.right)
       },
       ForStatement(node) {
         if (node.test && hasExcessParens(node.test) && !isCondAssignException(node) && !isTypeAssertion(node.test))

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
@@ -17,12 +17,9 @@ import {
   isTopLevelExpressionStatement,
   skipChainExpression,
 } from '#utils/ast'
-import { castRuleModule, createRule } from '#utils/create-rule'
+import { createRule } from '#utils/create-rule'
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import { isOpeningParenToken, isTypeAssertion } from '@typescript-eslint/utils/ast-utils'
-import _baseRule from './no-extra-parens._js_'
-
-const baseRule = /* @__PURE__ */ castRuleModule(_baseRule)
 
 export default createRule<RuleOptions, MessageIds>({
   name: 'no-extra-parens',
@@ -33,9 +30,52 @@ export default createRule<RuleOptions, MessageIds>({
       description: 'Disallow unnecessary parentheses',
     },
     fixable: 'code',
-    hasSuggestions: baseRule.meta.hasSuggestions,
-    schema: baseRule.meta.schema,
-    messages: baseRule.meta.messages,
+    schema: {
+      anyOf: [
+        {
+          type: 'array',
+          items: [
+            {
+              type: 'string',
+              enum: ['functions'],
+            },
+          ],
+          minItems: 0,
+          maxItems: 1,
+        },
+        {
+          type: 'array',
+          items: [
+            {
+              type: 'string',
+              enum: ['all'],
+            },
+            {
+              type: 'object',
+              properties: {
+                conditionalAssign: { type: 'boolean' },
+                ternaryOperandBinaryExpressions: { type: 'boolean' },
+                nestedBinaryExpressions: { type: 'boolean' },
+                returnAssign: { type: 'boolean' },
+                ignoreJSX: { type: 'string', enum: ['none', 'all', 'single-line', 'multi-line'] },
+                enforceForArrowConditionals: { type: 'boolean' },
+                enforceForSequenceExpressions: { type: 'boolean' },
+                enforceForNewInMemberExpressions: { type: 'boolean' },
+                enforceForFunctionPrototypeMethods: { type: 'boolean' },
+                allowParensAfterCommentPattern: { type: 'string' },
+                nestedConditionalExpressions: { type: 'boolean' },
+              },
+              additionalProperties: false,
+            },
+          ],
+          minItems: 0,
+          maxItems: 2,
+        },
+      ],
+    },
+    messages: {
+      unexpected: 'Unnecessary parentheses around expression.',
+    },
   },
   defaultOptions: ['all'],
   create(context) {

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
@@ -846,8 +846,18 @@ export default createRule<RuleOptions, MessageIds>({
         }
       },
       VariableDeclarator(node) {
+        const rule = (node: Tree.VariableDeclarator) => {
+          if (
+            node.init && hasExcessParensWithPrecedence(node.init, PRECEDENCE_OF_ASSIGNMENT_EXPR)
+
+            // RegExp literal is allowed to have parens (#1589)
+            && !(node.init.type === 'Literal' && 'regex' in node.init && node.init.regex)
+          ) {
+            report(node.init)
+          }
+        }
         if (isTypeAssertion(node.init)) {
-          return rules.VariableDeclarator!({
+          return rule({
             ...node,
             type: AST_NODE_TYPES.VariableDeclarator,
             init: {
@@ -857,7 +867,7 @@ export default createRule<RuleOptions, MessageIds>({
           } as any)
         }
 
-        return rules.VariableDeclarator!(node)
+        return rule(node)
       },
       WhileStatement(node) {
         if (hasExcessParens(node.test) && !isCondAssignException(node))


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Part of #482 

### Additional context

Some nodes force the child nodes(typically type assertion) to be converted to `SequenceExpression` or `FunctionExpression` to implement functionality quickly.
I will create a new PR to refactor them in the future.

<!-- e.g. is there anything you'd like reviewers to focus on? -->
