### PR TITLE
In member-delimiter-style README remove /ts/ suffix

### DIFF
--- a/packages/eslint-plugin/rules/member-delimiter-style/README._ts_.md
+++ b/packages/eslint-plugin/rules/member-delimiter-style/README._ts_.md
@@ -110,7 +110,7 @@ Examples of code for this rule with the default config:
 
 <!-- prettier-ignore -->
 ```ts
-/*eslint @stylistic/ts/member-delimiter-style: "error"*/
+/*eslint @stylistic/member-delimiter-style: "error"*/
 
 // missing semicolon delimiter
 interface Foo {
@@ -141,7 +141,7 @@ type FooBar = { name: string; greet(): string; }
 
 <!-- prettier-ignore -->
 ```ts
-/*eslint @stylistic/ts/member-delimiter-style: "error"*/
+/*eslint @stylistic/member-delimiter-style: "error"*/
 
 interface Foo {
     name: string;


### PR DESCRIPTION
### Description

With `/ts/` suffix there is error:
```
TypeError: Key "rules": Key "@stylistic/ts/member-delimiter-style": Could not find plugin "@stylistic/ts".
```