### PR TITLE
feat(jsx-quotes): add rule to `eslint-plugin-jsx`

### DIFF
--- a/packages/eslint-plugin-jsx/package.json
+++ b/packages/eslint-plugin-jsx/package.json
@@ -41,6 +41,7 @@
     "./rules/jsx-one-expression-per-line": "./dist/rules/jsx-one-expression-per-line.js",
     "./rules/jsx-pascal-case": "./dist/rules/jsx-pascal-case.js",
     "./rules/jsx-props-no-multi-spaces": "./dist/rules/jsx-props-no-multi-spaces.js",
+    "./rules/jsx-quotes": "./dist/rules/jsx-quotes.js",
     "./rules/jsx-self-closing-comp": "./dist/rules/jsx-self-closing-comp.js",
     "./rules/jsx-sort-props": "./dist/rules/jsx-sort-props.js",
     "./rules/jsx-tag-spacing": "./dist/rules/jsx-tag-spacing.js",

--- a/packages/eslint-plugin-jsx/rules/jsx-quotes/jsx-quotes.ts
+++ b/packages/eslint-plugin-jsx/rules/jsx-quotes/jsx-quotes.ts
@@ -1,0 +1,1 @@
+export { default } from '../../../eslint-plugin/rules/jsx-quotes/jsx-quotes._js_'


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Added legacy eslint `jsx-quotes` rule into `eslint-plugin-jsx` plugin.

### Linked Issues

#303 

### Additional context

In the context of importing `@stylistic/eslint-plugin-jsx` only into flat config, rule `jsx-quotes` is not available yet. 