### PR TITLE
test: use `RuleOptions` and `MessageIds` generic type

### DIFF
--- a/packages/eslint-plugin/rules/array-bracket-newline/array-bracket-newline._js_.test.ts
+++ b/packages/eslint-plugin/rules/array-bracket-newline/array-bracket-newline._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Jan Peer Stöcklmair <https://github.com/JPeer264>
  */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'array-bracket-newline',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/array-bracket-newline/array-bracket-newline._js_.test.ts
+++ b/packages/eslint-plugin/rules/array-bracket-newline/array-bracket-newline._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Jan Peer Stöcklmair <https://github.com/JPeer264>
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'array-bracket-newline',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/array-bracket-spacing/array-bracket-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/array-bracket-spacing/array-bracket-spacing._js_.test.ts
@@ -3,11 +3,12 @@
  * @author Ian Christian Myers
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { languageOptionsForBabelFlow } from '#test/parsers-flow'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'array-bracket-spacing',
   rule,
 

--- a/packages/eslint-plugin/rules/array-bracket-spacing/array-bracket-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/array-bracket-spacing/array-bracket-spacing._js_.test.ts
@@ -3,12 +3,12 @@
  * @author Ian Christian Myers
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { languageOptionsForBabelFlow } from '#test/parsers-flow'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'array-bracket-spacing',
   rule,
 

--- a/packages/eslint-plugin/rules/array-element-newline/array-element-newline._js_.test.ts
+++ b/packages/eslint-plugin/rules/array-element-newline/array-element-newline._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Jan Peer Stöcklmair <https://github.com/JPeer264>
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'array-element-newline',
   rule,
 

--- a/packages/eslint-plugin/rules/array-element-newline/array-element-newline._js_.test.ts
+++ b/packages/eslint-plugin/rules/array-element-newline/array-element-newline._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Jan Peer Stöcklmair <https://github.com/JPeer264>
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'array-element-newline',
   rule,
 

--- a/packages/eslint-plugin/rules/arrow-parens/arrow-parens._js_.test.ts
+++ b/packages/eslint-plugin/rules/arrow-parens/arrow-parens._js_.test.ts
@@ -3,529 +3,524 @@
  * @author Jxck
  */
 
-import type { InvalidTestCase, ValidTestCase } from '#test'
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import { languageOptionsForBabelFlow } from '#test/parsers-flow'
 import rule from '.'
 
-const valid: ValidTestCase[] = [
-  // "always" (by default)
-  '() => {}',
-  '(a) => {}',
-  '(a) => a',
-  '(a) => {\n}',
-  'a.then((foo) => {});',
-  'a.then((foo) => { if (true) {}; });',
-  'const f = (/* */a) => a + a;',
-  'const f = (a/** */) => a + a;',
-  'const f = (a//\n) => a + a;',
-  'const f = (//\na) => a + a;',
-  'const f = (/*\n */a//\n) => a + a;',
-  'const f = (/** @type {number} */a/**hello*/) => a + a;',
-  { code: 'a.then(async (foo) => { if (true) {}; });', parserOptions: { ecmaVersion: 8 } },
-
-  // "always" (explicit)
-  { code: '() => {}', options: ['always'] },
-  { code: '(a) => {}', options: ['always'] },
-  { code: '(a) => a', options: ['always'] },
-  { code: '(a) => {\n}', options: ['always'] },
-  { code: 'a.then((foo) => {});', options: ['always'] },
-  { code: 'a.then((foo) => { if (true) {}; });', options: ['always'] },
-  { code: 'a.then(async (foo) => { if (true) {}; });', options: ['always'], parserOptions: { ecmaVersion: 8 } },
-  { code: '(a: T) => a', options: ['always'], languageOptions: languageOptionsForBabelFlow },
-  { code: '(a): T => a', options: ['always'], languageOptions: languageOptionsForBabelFlow },
-
-  // "as-needed"
-  { code: '() => {}', options: ['as-needed'] },
-  { code: 'a => {}', options: ['as-needed'] },
-  { code: 'a => a', options: ['as-needed'] },
-  { code: 'a => (a)', options: ['as-needed'] },
-  { code: '(a => a)', options: ['as-needed'] },
-  { code: '((a => a))', options: ['as-needed'] },
-  { code: '([a, b]) => {}', options: ['as-needed'] },
-  { code: '({ a, b }) => {}', options: ['as-needed'] },
-  { code: '(a = 10) => {}', options: ['as-needed'] },
-  { code: '(...a) => a[0]', options: ['as-needed'] },
-  { code: '(a, b) => {}', options: ['as-needed'] },
-  { code: 'async a => a', options: ['as-needed'], parserOptions: { ecmaVersion: 8 } },
-  { code: 'async ([a, b]) => {}', options: ['as-needed'], parserOptions: { ecmaVersion: 8 } },
-  { code: 'async (a, b) => {}', options: ['as-needed'], parserOptions: { ecmaVersion: 8 } },
-  { code: '(a: T) => a', options: ['as-needed'], languageOptions: languageOptionsForBabelFlow },
-  { code: '(a?) => a', options: ['as-needed'], languageOptions: languageOptionsForBabelFlow },
-  { code: '(a): T => a', options: ['as-needed'], languageOptions: languageOptionsForBabelFlow },
-
-  // "as-needed", { "requireForBlockBody": true }
-  { code: '() => {}', options: ['as-needed', { requireForBlockBody: true }] },
-  { code: 'a => a', options: ['as-needed', { requireForBlockBody: true }] },
-  { code: 'a => (a)', options: ['as-needed', { requireForBlockBody: true }] },
-  { code: '(a => a)', options: ['as-needed', { requireForBlockBody: true }] },
-  { code: '((a => a))', options: ['as-needed', { requireForBlockBody: true }] },
-  { code: '([a, b]) => {}', options: ['as-needed', { requireForBlockBody: true }] },
-  { code: '([a, b]) => a', options: ['as-needed', { requireForBlockBody: true }] },
-  { code: '({ a, b }) => {}', options: ['as-needed', { requireForBlockBody: true }] },
-  { code: '({ a, b }) => a + b', options: ['as-needed', { requireForBlockBody: true }] },
-  { code: '(a = 10) => {}', options: ['as-needed', { requireForBlockBody: true }] },
-  { code: '(...a) => a[0]', options: ['as-needed', { requireForBlockBody: true }] },
-  { code: '(a, b) => {}', options: ['as-needed', { requireForBlockBody: true }] },
-  { code: 'a => ({})', options: ['as-needed', { requireForBlockBody: true }] },
-  { code: 'async a => ({})', options: ['as-needed', { requireForBlockBody: true }], parserOptions: { ecmaVersion: 8 } },
-  { code: 'async a => a', options: ['as-needed', { requireForBlockBody: true }], parserOptions: { ecmaVersion: 8 } },
-  { code: '(a: T) => a', options: ['as-needed', { requireForBlockBody: true }], languageOptions: languageOptionsForBabelFlow },
-  { code: '(a): T => a', options: ['as-needed', { requireForBlockBody: true }], languageOptions: languageOptionsForBabelFlow },
-  {
-    code: 'const f = (/** @type {number} */a/**hello*/) => a + a;',
-    options: ['as-needed'],
-  },
-  {
-    code: 'const f = (/* */a) => a + a;',
-    options: ['as-needed'],
-  },
-  {
-    code: 'const f = (a/** */) => a + a;',
-    options: ['as-needed'],
-  },
-  {
-    code: 'const f = (a//\n) => a + a;',
-    options: ['as-needed'],
-  },
-  {
-    code: 'const f = (//\na) => a + a;',
-    options: ['as-needed'],
-  },
-  {
-    code: 'const f = (/*\n */a//\n) => a + a;',
-    options: ['as-needed'],
-  },
-  {
-    code: 'var foo = (a,/**/) => b;',
-    parserOptions: { ecmaVersion: 2017 },
-    options: ['as-needed'],
-  },
-  {
-    code: 'var foo = (a , /**/) => b;',
-    parserOptions: { ecmaVersion: 2017 },
-    options: ['as-needed'],
-  },
-  {
-    code: 'var foo = (a\n,\n/**/) => b;',
-    parserOptions: { ecmaVersion: 2017 },
-    options: ['as-needed'],
-  },
-  {
-    code: 'var foo = (a,//\n) => b;',
-    parserOptions: { ecmaVersion: 2017 },
-    options: ['as-needed'],
-  },
-  {
-    code: 'const i = (a/**/,) => a + a;',
-    parserOptions: { ecmaVersion: 2017 },
-    options: ['as-needed'],
-  },
-  {
-    code: 'const i = (a \n /**/,) => a + a;',
-    parserOptions: { ecmaVersion: 2017 },
-    options: ['as-needed'],
-  },
-  {
-    code: 'var bar = ({/*comment here*/a}) => a',
-    options: ['as-needed'],
-  },
-  {
-    code: 'var bar = (/*comment here*/{a}) => a',
-    options: ['as-needed'],
-  },
-
-  // generics
-  {
-    code: '<T>(a) => b',
-    options: ['always'],
-  },
-  {
-    code: '<T>(a) => b',
-    options: ['as-needed'],
-  },
-  {
-    code: '<T>(a) => b',
-    options: ['as-needed', { requireForBlockBody: true }],
-  },
-  {
-    code: 'async <T>(a) => b',
-    options: ['always'],
-  },
-  {
-    code: 'async <T>(a) => b',
-    options: ['as-needed'],
-  },
-  {
-    code: 'async <T>(a) => b',
-    options: ['as-needed', { requireForBlockBody: true }],
-  },
-  {
-    code: '<T>() => b',
-    options: ['always'],
-  },
-  {
-    code: '<T>() => b',
-    options: ['as-needed'],
-  },
-  {
-    code: '<T>() => b',
-    options: ['as-needed', { requireForBlockBody: true }],
-  },
-  {
-    code: '<T extends A>(a) => b',
-    options: ['always'],
-  },
-  {
-    code: '<T extends A>(a) => b',
-    options: ['as-needed'],
-  },
-  {
-    code: '<T extends A>(a) => b',
-    options: ['as-needed', { requireForBlockBody: true }],
-  },
-  {
-    code: '<T extends (A | B) & C>(a) => b',
-    options: ['always'],
-  },
-  {
-    code: '<T extends (A | B) & C>(a) => b',
-    options: ['as-needed'],
-  },
-  {
-    code: '<T extends (A | B) & C>(a) => b',
-    options: ['as-needed', { requireForBlockBody: true }],
-  },
-]
-
 const type = 'ArrowFunctionExpression'
 
-const invalid: InvalidTestCase[] = [
-  // "always" (by default)
-  {
-    code: 'a => {}',
-    output: '(a) => {}',
-    errors: [{
-      line: 1,
-      column: 1,
-      endColumn: 2,
-      messageId: 'expectedParens',
-      type,
-    }],
-  },
-  {
-    code: 'a => a',
-    output: '(a) => a',
-    errors: [{
-      line: 1,
-      column: 1,
-      endColumn: 2,
-      messageId: 'expectedParens',
-      type,
-    }],
-  },
-  {
-    code: 'a => {\n}',
-    output: '(a) => {\n}',
-    errors: [{
-      line: 1,
-      column: 1,
-      endColumn: 2,
-      messageId: 'expectedParens',
-      type,
-    }],
-  },
-  {
-    code: 'a.then(foo => {});',
-    output: 'a.then((foo) => {});',
-    errors: [{
-      line: 1,
-      column: 8,
-      endColumn: 11,
-      messageId: 'expectedParens',
-      type,
-    }],
-  },
-  {
-    code: 'a.then(foo => a);',
-    output: 'a.then((foo) => a);',
-    errors: [{
-      line: 1,
-      column: 8,
-      endColumn: 11,
-      messageId: 'expectedParens',
-      type,
-    }],
-  },
-  {
-    code: 'a(foo => { if (true) {}; });',
-    output: 'a((foo) => { if (true) {}; });',
-    errors: [{
-      line: 1,
-      column: 3,
-      endColumn: 6,
-      messageId: 'expectedParens',
-      type,
-    }],
-  },
-  {
-    code: 'a(async foo => { if (true) {}; });',
-    output: 'a(async (foo) => { if (true) {}; });',
-    parserOptions: { ecmaVersion: 8 },
-    errors: [{
-      line: 1,
-      column: 9,
-      endColumn: 12,
-      messageId: 'expectedParens',
-      type,
-    }],
-  },
-
-  // "as-needed"
-  {
-    code: '(a) => a',
-    output: 'a => a',
-    options: ['as-needed'],
-    errors: [{
-      line: 1,
-      column: 2,
-      endColumn: 3,
-      messageId: 'unexpectedParens',
-      type,
-    }],
-  },
-  {
-    code: '(  a  ) => b',
-    output: 'a => b',
-    options: ['as-needed'],
-    errors: [{
-      line: 1,
-      column: 4,
-      endColumn: 5,
-      messageId: 'unexpectedParens',
-      type,
-    }],
-  },
-  {
-    code: '(\na\n) => b',
-    output: 'a => b',
-    options: ['as-needed'],
-    errors: [{
-      line: 2,
-      column: 1,
-      endColumn: 2,
-      messageId: 'unexpectedParens',
-      type,
-    }],
-  },
-  {
-    code: '(a,) => a',
-    output: 'a => a',
-    options: ['as-needed'],
-    parserOptions: { ecmaVersion: 8 },
-    errors: [{
-      line: 1,
-      column: 2,
-      endColumn: 3,
-      messageId: 'unexpectedParens',
-      type,
-    }],
-  },
-  {
-    code: 'async (a) => a',
-    output: 'async a => a',
-    options: ['as-needed'],
-    parserOptions: { ecmaVersion: 8 },
-    errors: [{
-      line: 1,
-      column: 8,
-      endColumn: 9,
-      messageId: 'unexpectedParens',
-      type,
-    }],
-  },
-  {
-    code: 'async(a) => a',
-    output: 'async a => a',
-    options: ['as-needed'],
-    parserOptions: { ecmaVersion: 8 },
-    errors: [{
-      line: 1,
-      column: 7,
-      endColumn: 8,
-      messageId: 'unexpectedParens',
-      type,
-    }],
-  },
-  {
-    code: 'typeof((a) => {})',
-    output: 'typeof(a => {})',
-    options: ['as-needed'],
-    errors: [{
-      line: 1,
-      column: 9,
-      endColumn: 10,
-      messageId: 'unexpectedParens',
-      type,
-    }],
-  },
-  {
-    code: 'function *f() { yield(a) => a; }',
-    output: 'function *f() { yield a => a; }',
-    options: ['as-needed'],
-    errors: [{
-      line: 1,
-      column: 23,
-      endColumn: 24,
-      messageId: 'unexpectedParens',
-      type,
-    }],
-  },
-
-  // "as-needed", { "requireForBlockBody": true }
-  {
-    code: 'a => {}',
-    output: '(a) => {}',
-    options: ['as-needed', { requireForBlockBody: true }],
-    errors: [{
-      line: 1,
-      column: 1,
-      endColumn: 2,
-      messageId: 'expectedParensBlock',
-      type,
-    }],
-  },
-  {
-    code: '(a) => a',
-    output: 'a => a',
-    options: ['as-needed', { requireForBlockBody: true }],
-    errors: [{
-      line: 1,
-      column: 2,
-      endColumn: 3,
-      messageId: 'unexpectedParensInline',
-      type,
-    }],
-  },
-  {
-    code: 'async a => {}',
-    output: 'async (a) => {}',
-    options: ['as-needed', { requireForBlockBody: true }],
-    parserOptions: { ecmaVersion: 8 },
-    errors: [{
-      line: 1,
-      column: 7,
-      endColumn: 8,
-      messageId: 'expectedParensBlock',
-      type,
-    }],
-  },
-  {
-    code: 'async (a) => a',
-    output: 'async a => a',
-    options: ['as-needed', { requireForBlockBody: true }],
-    parserOptions: { ecmaVersion: 8 },
-    errors: [{
-      line: 1,
-      column: 8,
-      endColumn: 9,
-      messageId: 'unexpectedParensInline',
-      type,
-    }],
-  },
-  {
-    code: 'async(a) => a',
-    output: 'async a => a',
-    options: ['as-needed', { requireForBlockBody: true }],
-    parserOptions: { ecmaVersion: 8 },
-    errors: [{
-      line: 1,
-      column: 7,
-      endColumn: 8,
-      messageId: 'unexpectedParensInline',
-      type,
-    }],
-  },
-  {
-    code: 'const f = /** @type {number} */(a)/**hello*/ => a + a;',
-    options: ['as-needed'],
-    output: 'const f = /** @type {number} */a/**hello*/ => a + a;',
-    errors: [{
-      line: 1,
-      column: 33,
-      type,
-      messageId: 'unexpectedParens',
-      endLine: 1,
-      endColumn: 34,
-    }],
-  },
-  {
-    code: 'const f = //\n(a) => a + a;',
-    output: 'const f = //\na => a + a;',
-    options: ['as-needed'],
-    errors: [{
-      line: 2,
-      column: 2,
-      type,
-      messageId: 'unexpectedParens',
-      endLine: 2,
-      endColumn: 3,
-    }],
-  },
-  {
-    code: 'var foo = /**/ a => b;',
-    output: 'var foo = /**/ (a) => b;',
-    errors: [{
-      line: 1,
-      column: 16,
-      type: 'ArrowFunctionExpression',
-      messageId: 'expectedParens',
-      endLine: 1,
-      endColumn: 17,
-    }],
-  },
-  {
-    code: 'var bar = a /**/ =>  b;',
-    output: 'var bar = (a) /**/ =>  b;',
-    errors: [{
-      line: 1,
-      column: 11,
-      type: 'ArrowFunctionExpression',
-      messageId: 'expectedParens',
-      endLine: 1,
-      endColumn: 12,
-    }],
-  },
-  {
-    code: $`
-      const foo = a => {};
-      
-      // comment between 'a' and an unrelated closing paren
-      
-      bar();
-    `,
-    output: $`
-      const foo = (a) => {};
-      
-      // comment between 'a' and an unrelated closing paren
-      
-      bar();
-    `,
-    errors: [{
-      line: 1,
-      column: 13,
-      type: 'ArrowFunctionExpression',
-      messageId: 'expectedParens',
-      endLine: 1,
-      endColumn: 14,
-    }],
-  },
-
-]
-
-run({
+run<RuleOptions>({
   name: 'arrow-parens',
   rule,
-  valid,
-  invalid,
+  valid: [
+    // "always" (by default)
+    '() => {}',
+    '(a) => {}',
+    '(a) => a',
+    '(a) => {\n}',
+    'a.then((foo) => {});',
+    'a.then((foo) => { if (true) {}; });',
+    'const f = (/* */a) => a + a;',
+    'const f = (a/** */) => a + a;',
+    'const f = (a//\n) => a + a;',
+    'const f = (//\na) => a + a;',
+    'const f = (/*\n */a//\n) => a + a;',
+    'const f = (/** @type {number} */a/**hello*/) => a + a;',
+    { code: 'a.then(async (foo) => { if (true) {}; });', parserOptions: { ecmaVersion: 8 } },
+
+    // "always" (explicit)
+    { code: '() => {}', options: ['always'] },
+    { code: '(a) => {}', options: ['always'] },
+    { code: '(a) => a', options: ['always'] },
+    { code: '(a) => {\n}', options: ['always'] },
+    { code: 'a.then((foo) => {});', options: ['always'] },
+    { code: 'a.then((foo) => { if (true) {}; });', options: ['always'] },
+    { code: 'a.then(async (foo) => { if (true) {}; });', options: ['always'], parserOptions: { ecmaVersion: 8 } },
+    { code: '(a: T) => a', options: ['always'], languageOptions: languageOptionsForBabelFlow },
+    { code: '(a): T => a', options: ['always'], languageOptions: languageOptionsForBabelFlow },
+
+    // "as-needed"
+    { code: '() => {}', options: ['as-needed'] },
+    { code: 'a => {}', options: ['as-needed'] },
+    { code: 'a => a', options: ['as-needed'] },
+    { code: 'a => (a)', options: ['as-needed'] },
+    { code: '(a => a)', options: ['as-needed'] },
+    { code: '((a => a))', options: ['as-needed'] },
+    { code: '([a, b]) => {}', options: ['as-needed'] },
+    { code: '({ a, b }) => {}', options: ['as-needed'] },
+    { code: '(a = 10) => {}', options: ['as-needed'] },
+    { code: '(...a) => a[0]', options: ['as-needed'] },
+    { code: '(a, b) => {}', options: ['as-needed'] },
+    { code: 'async a => a', options: ['as-needed'], parserOptions: { ecmaVersion: 8 } },
+    { code: 'async ([a, b]) => {}', options: ['as-needed'], parserOptions: { ecmaVersion: 8 } },
+    { code: 'async (a, b) => {}', options: ['as-needed'], parserOptions: { ecmaVersion: 8 } },
+    { code: '(a: T) => a', options: ['as-needed'], languageOptions: languageOptionsForBabelFlow },
+    { code: '(a?) => a', options: ['as-needed'], languageOptions: languageOptionsForBabelFlow },
+    { code: '(a): T => a', options: ['as-needed'], languageOptions: languageOptionsForBabelFlow },
+
+    // "as-needed", { "requireForBlockBody": true }
+    { code: '() => {}', options: ['as-needed', { requireForBlockBody: true }] },
+    { code: 'a => a', options: ['as-needed', { requireForBlockBody: true }] },
+    { code: 'a => (a)', options: ['as-needed', { requireForBlockBody: true }] },
+    { code: '(a => a)', options: ['as-needed', { requireForBlockBody: true }] },
+    { code: '((a => a))', options: ['as-needed', { requireForBlockBody: true }] },
+    { code: '([a, b]) => {}', options: ['as-needed', { requireForBlockBody: true }] },
+    { code: '([a, b]) => a', options: ['as-needed', { requireForBlockBody: true }] },
+    { code: '({ a, b }) => {}', options: ['as-needed', { requireForBlockBody: true }] },
+    { code: '({ a, b }) => a + b', options: ['as-needed', { requireForBlockBody: true }] },
+    { code: '(a = 10) => {}', options: ['as-needed', { requireForBlockBody: true }] },
+    { code: '(...a) => a[0]', options: ['as-needed', { requireForBlockBody: true }] },
+    { code: '(a, b) => {}', options: ['as-needed', { requireForBlockBody: true }] },
+    { code: 'a => ({})', options: ['as-needed', { requireForBlockBody: true }] },
+    { code: 'async a => ({})', options: ['as-needed', { requireForBlockBody: true }], parserOptions: { ecmaVersion: 8 } },
+    { code: 'async a => a', options: ['as-needed', { requireForBlockBody: true }], parserOptions: { ecmaVersion: 8 } },
+    { code: '(a: T) => a', options: ['as-needed', { requireForBlockBody: true }], languageOptions: languageOptionsForBabelFlow },
+    { code: '(a): T => a', options: ['as-needed', { requireForBlockBody: true }], languageOptions: languageOptionsForBabelFlow },
+    {
+      code: 'const f = (/** @type {number} */a/**hello*/) => a + a;',
+      options: ['as-needed'],
+    },
+    {
+      code: 'const f = (/* */a) => a + a;',
+      options: ['as-needed'],
+    },
+    {
+      code: 'const f = (a/** */) => a + a;',
+      options: ['as-needed'],
+    },
+    {
+      code: 'const f = (a//\n) => a + a;',
+      options: ['as-needed'],
+    },
+    {
+      code: 'const f = (//\na) => a + a;',
+      options: ['as-needed'],
+    },
+    {
+      code: 'const f = (/*\n */a//\n) => a + a;',
+      options: ['as-needed'],
+    },
+    {
+      code: 'var foo = (a,/**/) => b;',
+      parserOptions: { ecmaVersion: 2017 },
+      options: ['as-needed'],
+    },
+    {
+      code: 'var foo = (a , /**/) => b;',
+      parserOptions: { ecmaVersion: 2017 },
+      options: ['as-needed'],
+    },
+    {
+      code: 'var foo = (a\n,\n/**/) => b;',
+      parserOptions: { ecmaVersion: 2017 },
+      options: ['as-needed'],
+    },
+    {
+      code: 'var foo = (a,//\n) => b;',
+      parserOptions: { ecmaVersion: 2017 },
+      options: ['as-needed'],
+    },
+    {
+      code: 'const i = (a/**/,) => a + a;',
+      parserOptions: { ecmaVersion: 2017 },
+      options: ['as-needed'],
+    },
+    {
+      code: 'const i = (a \n /**/,) => a + a;',
+      parserOptions: { ecmaVersion: 2017 },
+      options: ['as-needed'],
+    },
+    {
+      code: 'var bar = ({/*comment here*/a}) => a',
+      options: ['as-needed'],
+    },
+    {
+      code: 'var bar = (/*comment here*/{a}) => a',
+      options: ['as-needed'],
+    },
+
+    // generics
+    {
+      code: '<T>(a) => b',
+      options: ['always'],
+    },
+    {
+      code: '<T>(a) => b',
+      options: ['as-needed'],
+    },
+    {
+      code: '<T>(a) => b',
+      options: ['as-needed', { requireForBlockBody: true }],
+    },
+    {
+      code: 'async <T>(a) => b',
+      options: ['always'],
+    },
+    {
+      code: 'async <T>(a) => b',
+      options: ['as-needed'],
+    },
+    {
+      code: 'async <T>(a) => b',
+      options: ['as-needed', { requireForBlockBody: true }],
+    },
+    {
+      code: '<T>() => b',
+      options: ['always'],
+    },
+    {
+      code: '<T>() => b',
+      options: ['as-needed'],
+    },
+    {
+      code: '<T>() => b',
+      options: ['as-needed', { requireForBlockBody: true }],
+    },
+    {
+      code: '<T extends A>(a) => b',
+      options: ['always'],
+    },
+    {
+      code: '<T extends A>(a) => b',
+      options: ['as-needed'],
+    },
+    {
+      code: '<T extends A>(a) => b',
+      options: ['as-needed', { requireForBlockBody: true }],
+    },
+    {
+      code: '<T extends (A | B) & C>(a) => b',
+      options: ['always'],
+    },
+    {
+      code: '<T extends (A | B) & C>(a) => b',
+      options: ['as-needed'],
+    },
+    {
+      code: '<T extends (A | B) & C>(a) => b',
+      options: ['as-needed', { requireForBlockBody: true }],
+    },
+  ],
+  invalid: [
+    // "always" (by default)
+    {
+      code: 'a => {}',
+      output: '(a) => {}',
+      errors: [{
+        line: 1,
+        column: 1,
+        endColumn: 2,
+        messageId: 'expectedParens',
+        type,
+      }],
+    },
+    {
+      code: 'a => a',
+      output: '(a) => a',
+      errors: [{
+        line: 1,
+        column: 1,
+        endColumn: 2,
+        messageId: 'expectedParens',
+        type,
+      }],
+    },
+    {
+      code: 'a => {\n}',
+      output: '(a) => {\n}',
+      errors: [{
+        line: 1,
+        column: 1,
+        endColumn: 2,
+        messageId: 'expectedParens',
+        type,
+      }],
+    },
+    {
+      code: 'a.then(foo => {});',
+      output: 'a.then((foo) => {});',
+      errors: [{
+        line: 1,
+        column: 8,
+        endColumn: 11,
+        messageId: 'expectedParens',
+        type,
+      }],
+    },
+    {
+      code: 'a.then(foo => a);',
+      output: 'a.then((foo) => a);',
+      errors: [{
+        line: 1,
+        column: 8,
+        endColumn: 11,
+        messageId: 'expectedParens',
+        type,
+      }],
+    },
+    {
+      code: 'a(foo => { if (true) {}; });',
+      output: 'a((foo) => { if (true) {}; });',
+      errors: [{
+        line: 1,
+        column: 3,
+        endColumn: 6,
+        messageId: 'expectedParens',
+        type,
+      }],
+    },
+    {
+      code: 'a(async foo => { if (true) {}; });',
+      output: 'a(async (foo) => { if (true) {}; });',
+      parserOptions: { ecmaVersion: 8 },
+      errors: [{
+        line: 1,
+        column: 9,
+        endColumn: 12,
+        messageId: 'expectedParens',
+        type,
+      }],
+    },
+
+    // "as-needed"
+    {
+      code: '(a) => a',
+      output: 'a => a',
+      options: ['as-needed'],
+      errors: [{
+        line: 1,
+        column: 2,
+        endColumn: 3,
+        messageId: 'unexpectedParens',
+        type,
+      }],
+    },
+    {
+      code: '(  a  ) => b',
+      output: 'a => b',
+      options: ['as-needed'],
+      errors: [{
+        line: 1,
+        column: 4,
+        endColumn: 5,
+        messageId: 'unexpectedParens',
+        type,
+      }],
+    },
+    {
+      code: '(\na\n) => b',
+      output: 'a => b',
+      options: ['as-needed'],
+      errors: [{
+        line: 2,
+        column: 1,
+        endColumn: 2,
+        messageId: 'unexpectedParens',
+        type,
+      }],
+    },
+    {
+      code: '(a,) => a',
+      output: 'a => a',
+      options: ['as-needed'],
+      parserOptions: { ecmaVersion: 8 },
+      errors: [{
+        line: 1,
+        column: 2,
+        endColumn: 3,
+        messageId: 'unexpectedParens',
+        type,
+      }],
+    },
+    {
+      code: 'async (a) => a',
+      output: 'async a => a',
+      options: ['as-needed'],
+      parserOptions: { ecmaVersion: 8 },
+      errors: [{
+        line: 1,
+        column: 8,
+        endColumn: 9,
+        messageId: 'unexpectedParens',
+        type,
+      }],
+    },
+    {
+      code: 'async(a) => a',
+      output: 'async a => a',
+      options: ['as-needed'],
+      parserOptions: { ecmaVersion: 8 },
+      errors: [{
+        line: 1,
+        column: 7,
+        endColumn: 8,
+        messageId: 'unexpectedParens',
+        type,
+      }],
+    },
+    {
+      code: 'typeof((a) => {})',
+      output: 'typeof(a => {})',
+      options: ['as-needed'],
+      errors: [{
+        line: 1,
+        column: 9,
+        endColumn: 10,
+        messageId: 'unexpectedParens',
+        type,
+      }],
+    },
+    {
+      code: 'function *f() { yield(a) => a; }',
+      output: 'function *f() { yield a => a; }',
+      options: ['as-needed'],
+      errors: [{
+        line: 1,
+        column: 23,
+        endColumn: 24,
+        messageId: 'unexpectedParens',
+        type,
+      }],
+    },
+
+    // "as-needed", { "requireForBlockBody": true }
+    {
+      code: 'a => {}',
+      output: '(a) => {}',
+      options: ['as-needed', { requireForBlockBody: true }],
+      errors: [{
+        line: 1,
+        column: 1,
+        endColumn: 2,
+        messageId: 'expectedParensBlock',
+        type,
+      }],
+    },
+    {
+      code: '(a) => a',
+      output: 'a => a',
+      options: ['as-needed', { requireForBlockBody: true }],
+      errors: [{
+        line: 1,
+        column: 2,
+        endColumn: 3,
+        messageId: 'unexpectedParensInline',
+        type,
+      }],
+    },
+    {
+      code: 'async a => {}',
+      output: 'async (a) => {}',
+      options: ['as-needed', { requireForBlockBody: true }],
+      parserOptions: { ecmaVersion: 8 },
+      errors: [{
+        line: 1,
+        column: 7,
+        endColumn: 8,
+        messageId: 'expectedParensBlock',
+        type,
+      }],
+    },
+    {
+      code: 'async (a) => a',
+      output: 'async a => a',
+      options: ['as-needed', { requireForBlockBody: true }],
+      parserOptions: { ecmaVersion: 8 },
+      errors: [{
+        line: 1,
+        column: 8,
+        endColumn: 9,
+        messageId: 'unexpectedParensInline',
+        type,
+      }],
+    },
+    {
+      code: 'async(a) => a',
+      output: 'async a => a',
+      options: ['as-needed', { requireForBlockBody: true }],
+      parserOptions: { ecmaVersion: 8 },
+      errors: [{
+        line: 1,
+        column: 7,
+        endColumn: 8,
+        messageId: 'unexpectedParensInline',
+        type,
+      }],
+    },
+    {
+      code: 'const f = /** @type {number} */(a)/**hello*/ => a + a;',
+      options: ['as-needed'],
+      output: 'const f = /** @type {number} */a/**hello*/ => a + a;',
+      errors: [{
+        line: 1,
+        column: 33,
+        type,
+        messageId: 'unexpectedParens',
+        endLine: 1,
+        endColumn: 34,
+      }],
+    },
+    {
+      code: 'const f = //\n(a) => a + a;',
+      output: 'const f = //\na => a + a;',
+      options: ['as-needed'],
+      errors: [{
+        line: 2,
+        column: 2,
+        type,
+        messageId: 'unexpectedParens',
+        endLine: 2,
+        endColumn: 3,
+      }],
+    },
+    {
+      code: 'var foo = /**/ a => b;',
+      output: 'var foo = /**/ (a) => b;',
+      errors: [{
+        line: 1,
+        column: 16,
+        type: 'ArrowFunctionExpression',
+        messageId: 'expectedParens',
+        endLine: 1,
+        endColumn: 17,
+      }],
+    },
+    {
+      code: 'var bar = a /**/ =>  b;',
+      output: 'var bar = (a) /**/ =>  b;',
+      errors: [{
+        line: 1,
+        column: 11,
+        type: 'ArrowFunctionExpression',
+        messageId: 'expectedParens',
+        endLine: 1,
+        endColumn: 12,
+      }],
+    },
+    {
+      code: $`
+        const foo = a => {};
+        
+        // comment between 'a' and an unrelated closing paren
+        
+        bar();
+      `,
+      output: $`
+        const foo = (a) => {};
+        
+        // comment between 'a' and an unrelated closing paren
+        
+        bar();
+      `,
+      errors: [{
+        line: 1,
+        column: 13,
+        type: 'ArrowFunctionExpression',
+        messageId: 'expectedParens',
+        endLine: 1,
+        endColumn: 14,
+      }],
+    },
+  ],
 })

--- a/packages/eslint-plugin/rules/arrow-parens/arrow-parens._js_.test.ts
+++ b/packages/eslint-plugin/rules/arrow-parens/arrow-parens._js_.test.ts
@@ -3,14 +3,14 @@
  * @author Jxck
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import { languageOptionsForBabelFlow } from '#test/parsers-flow'
 import rule from '.'
 
 const type = 'ArrowFunctionExpression'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'arrow-parens',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/arrow-spacing/arrow-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/arrow-spacing/arrow-spacing._js_.test.ts
@@ -4,11 +4,11 @@
  */
 //
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'arrow-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/arrow-spacing/arrow-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/arrow-spacing/arrow-spacing._js_.test.ts
@@ -4,300 +4,297 @@
  */
 //
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-const valid = [
-  {
-    code: 'a => a',
-    options: [{ after: true, before: true }],
-  },
-  {
-    code: '() => {}',
-    options: [{ after: true, before: true }],
-  },
-  {
-    code: '(a) => {}',
-    options: [{ after: true, before: true }],
-  },
-  {
-    code: 'a=> a',
-    options: [{ after: true, before: false }],
-  },
-  {
-    code: '()=> {}',
-    options: [{ after: true, before: false }],
-  },
-  {
-    code: '(a)=> {}',
-    options: [{ after: true, before: false }],
-  },
-  {
-    code: 'a =>a',
-    options: [{ after: false, before: true }],
-  },
-  {
-    code: '() =>{}',
-    options: [{ after: false, before: true }],
-  },
-  {
-    code: '(a) =>{}',
-    options: [{ after: false, before: true }],
-  },
-  {
-    code: 'a=>a',
-    options: [{ after: false, before: false }],
-  },
-  {
-    code: '()=>{}',
-    options: [{ after: false, before: false }],
-  },
-  {
-    code: '(a)=>{}',
-    options: [{ after: false, before: false }],
-  },
-  {
-    code: 'a => a',
-    options: [{}],
-  },
-  {
-    code: '() => {}',
-    options: [{}],
-  },
-  {
-    code: '(a) => {}',
-    options: [{}],
-  },
-  '(a) =>\n{}',
-  '(a) =>\r\n{}',
-  '(a) =>\n    0',
-]
-
-const invalid = [
-  {
-    code: 'a=>a',
-    output: 'a => a',
-    options: [{ after: true, before: true }],
-    errors: [
-      { column: 1, line: 1, type: 'Identifier', messageId: 'expectedBefore' },
-      { column: 4, line: 1, type: 'Identifier', messageId: 'expectedAfter' },
-    ],
-  },
-  {
-    code: '()=>{}',
-    output: '() => {}',
-    options: [{ after: true, before: true }],
-    errors: [
-      { column: 2, line: 1, type: 'Punctuator', messageId: 'expectedBefore' },
-      { column: 5, line: 1, type: 'Punctuator', messageId: 'expectedAfter' },
-    ],
-  },
-  {
-    code: '(a)=>{}',
-    output: '(a) => {}',
-    options: [{ after: true, before: true }],
-    errors: [
-      { column: 3, line: 1, type: 'Punctuator', messageId: 'expectedBefore' },
-      { column: 6, line: 1, type: 'Punctuator', messageId: 'expectedAfter' },
-    ],
-  },
-  {
-    code: 'a=> a',
-    output: 'a =>a',
-    options: [{ after: false, before: true }],
-    errors: [
-      { column: 1, line: 1, type: 'Identifier', messageId: 'expectedBefore' },
-      { column: 5, line: 1, type: 'Identifier', messageId: 'unexpectedAfter' },
-    ],
-  },
-  {
-    code: '()=> {}',
-    output: '() =>{}',
-    options: [{ after: false, before: true }],
-    errors: [
-      { column: 2, line: 1, type: 'Punctuator', messageId: 'expectedBefore' },
-      { column: 6, line: 1, type: 'Punctuator', messageId: 'unexpectedAfter' },
-    ],
-  },
-  {
-    code: '(a)=> {}',
-    output: '(a) =>{}',
-    options: [{ after: false, before: true }],
-    errors: [
-      { column: 3, line: 1, type: 'Punctuator', messageId: 'expectedBefore' },
-      { column: 7, line: 1, type: 'Punctuator', messageId: 'unexpectedAfter' },
-    ],
-  },
-  {
-    code: 'a=>  a',
-    output: 'a =>a',
-    options: [{ after: false, before: true }],
-    errors: [
-      { column: 1, line: 1, type: 'Identifier', messageId: 'expectedBefore' },
-      { column: 6, line: 1, type: 'Identifier', messageId: 'unexpectedAfter' },
-    ],
-  },
-  {
-    code: '()=>  {}',
-    output: '() =>{}',
-    options: [{ after: false, before: true }],
-    errors: [
-      { column: 2, line: 1, type: 'Punctuator', messageId: 'expectedBefore' },
-      { column: 7, line: 1, type: 'Punctuator', messageId: 'unexpectedAfter' },
-    ],
-  },
-  {
-    code: '(a)=>  {}',
-    output: '(a) =>{}',
-    options: [{ after: false, before: true }],
-    errors: [
-      { column: 3, line: 1, type: 'Punctuator', messageId: 'expectedBefore' },
-      { column: 8, line: 1, type: 'Punctuator', messageId: 'unexpectedAfter' },
-    ],
-  },
-  {
-    code: 'a =>a',
-    output: 'a=> a',
-    options: [{ after: true, before: false }],
-    errors: [
-      { column: 1, line: 1, type: 'Identifier', messageId: 'unexpectedBefore' },
-      { column: 5, line: 1, type: 'Identifier', messageId: 'expectedAfter' },
-    ],
-  },
-  {
-    code: '() =>{}',
-    output: '()=> {}',
-    options: [{ after: true, before: false }],
-    errors: [
-      { column: 2, line: 1, type: 'Punctuator', messageId: 'unexpectedBefore' },
-      { column: 6, line: 1, type: 'Punctuator', messageId: 'expectedAfter' },
-    ],
-  },
-  {
-    code: '(a) =>{}',
-    output: '(a)=> {}',
-    options: [{ after: true, before: false }],
-    errors: [
-      { column: 3, line: 1, type: 'Punctuator', messageId: 'unexpectedBefore' },
-      { column: 7, line: 1, type: 'Punctuator', messageId: 'expectedAfter' },
-    ],
-  },
-  {
-    code: 'a  =>a',
-    output: 'a=> a',
-    options: [{ after: true, before: false }],
-    errors: [
-      { column: 1, line: 1, type: 'Identifier', messageId: 'unexpectedBefore' },
-      { column: 6, line: 1, type: 'Identifier', messageId: 'expectedAfter' },
-    ],
-  },
-  {
-    code: '()  =>{}',
-    output: '()=> {}',
-    options: [{ after: true, before: false }],
-    errors: [
-      { column: 2, line: 1, type: 'Punctuator', messageId: 'unexpectedBefore' },
-      { column: 7, line: 1, type: 'Punctuator', messageId: 'expectedAfter' },
-    ],
-  },
-  {
-    code: '(a)  =>{}',
-    output: '(a)=> {}',
-    options: [{ after: true, before: false }],
-    errors: [
-      { column: 3, line: 1, type: 'Punctuator', messageId: 'unexpectedBefore' },
-      { column: 8, line: 1, type: 'Punctuator', messageId: 'expectedAfter' },
-    ],
-  },
-  {
-    code: 'a => a',
-    output: 'a=>a',
-    options: [{ after: false, before: false }],
-    errors: [
-      { column: 1, line: 1, type: 'Identifier', messageId: 'unexpectedBefore' },
-      { column: 6, line: 1, type: 'Identifier', messageId: 'unexpectedAfter' },
-    ],
-  },
-  {
-    code: '() => {}',
-    output: '()=>{}',
-    options: [{ after: false, before: false }],
-    errors: [
-      { column: 2, line: 1, type: 'Punctuator', messageId: 'unexpectedBefore' },
-      { column: 7, line: 1, type: 'Punctuator', messageId: 'unexpectedAfter' },
-    ],
-  },
-  {
-    code: '(a) => {}',
-    output: '(a)=>{}',
-    options: [{ after: false, before: false }],
-    errors: [
-      { column: 3, line: 1, type: 'Punctuator', messageId: 'unexpectedBefore' },
-      { column: 8, line: 1, type: 'Punctuator', messageId: 'unexpectedAfter' },
-    ],
-  },
-  {
-    code: 'a  =>  a',
-    output: 'a=>a',
-    options: [{ after: false, before: false }],
-    errors: [
-      { column: 1, line: 1, type: 'Identifier', messageId: 'unexpectedBefore' },
-      { column: 8, line: 1, type: 'Identifier', messageId: 'unexpectedAfter' },
-    ],
-  },
-  {
-    code: '()  =>  {}',
-    output: '()=>{}',
-    options: [{ after: false, before: false }],
-    errors: [
-      { column: 2, line: 1, type: 'Punctuator', messageId: 'unexpectedBefore' },
-      { column: 9, line: 1, type: 'Punctuator', messageId: 'unexpectedAfter' },
-    ],
-  },
-  {
-    code: '(a)  =>  {}',
-    output: '(a)=>{}',
-    options: [{ after: false, before: false }],
-    errors: [
-      { column: 3, line: 1, type: 'Punctuator', messageId: 'unexpectedBefore' },
-      { column: 10, line: 1, type: 'Punctuator', messageId: 'unexpectedAfter' },
-    ],
-  },
-  {
-    code: '(a)  =>\n{}',
-    output: '(a)  =>{}',
-    options: [{ after: false }],
-    errors: [
-      { column: 1, line: 2, type: 'Punctuator', messageId: 'unexpectedAfter' },
-    ],
-  },
-
-  // https://github.com/eslint/eslint/issues/7079
-  {
-    code: '(a = ()=>0)=>1',
-    output: '(a = () => 0) => 1',
-    errors: [
-      { column: 7, line: 1, messageId: 'expectedBefore' },
-      { column: 10, line: 1, messageId: 'expectedAfter' },
-      { column: 11, line: 1, messageId: 'expectedBefore' },
-      { column: 14, line: 1, messageId: 'expectedAfter' },
-    ],
-  },
-  {
-    code: '(a = ()=>0)=>(1)',
-    output: '(a = () => 0) => (1)',
-    errors: [
-      { column: 7, line: 1, messageId: 'expectedBefore' },
-      { column: 10, line: 1, messageId: 'expectedAfter' },
-      { column: 11, line: 1, messageId: 'expectedBefore' },
-      { column: 14, line: 1, messageId: 'expectedAfter' },
-    ],
-  },
-]
-
-run({
+run<RuleOptions>({
   name: 'arrow-spacing',
   rule,
-  valid,
-  invalid,
+  valid: [
+    {
+      code: 'a => a',
+      options: [{ after: true, before: true }],
+    },
+    {
+      code: '() => {}',
+      options: [{ after: true, before: true }],
+    },
+    {
+      code: '(a) => {}',
+      options: [{ after: true, before: true }],
+    },
+    {
+      code: 'a=> a',
+      options: [{ after: true, before: false }],
+    },
+    {
+      code: '()=> {}',
+      options: [{ after: true, before: false }],
+    },
+    {
+      code: '(a)=> {}',
+      options: [{ after: true, before: false }],
+    },
+    {
+      code: 'a =>a',
+      options: [{ after: false, before: true }],
+    },
+    {
+      code: '() =>{}',
+      options: [{ after: false, before: true }],
+    },
+    {
+      code: '(a) =>{}',
+      options: [{ after: false, before: true }],
+    },
+    {
+      code: 'a=>a',
+      options: [{ after: false, before: false }],
+    },
+    {
+      code: '()=>{}',
+      options: [{ after: false, before: false }],
+    },
+    {
+      code: '(a)=>{}',
+      options: [{ after: false, before: false }],
+    },
+    {
+      code: 'a => a',
+      options: [{}],
+    },
+    {
+      code: '() => {}',
+      options: [{}],
+    },
+    {
+      code: '(a) => {}',
+      options: [{}],
+    },
+    '(a) =>\n{}',
+    '(a) =>\r\n{}',
+    '(a) =>\n    0',
+  ],
+  invalid: [
+    {
+      code: 'a=>a',
+      output: 'a => a',
+      options: [{ after: true, before: true }],
+      errors: [
+        { column: 1, line: 1, type: 'Identifier', messageId: 'expectedBefore' },
+        { column: 4, line: 1, type: 'Identifier', messageId: 'expectedAfter' },
+      ],
+    },
+    {
+      code: '()=>{}',
+      output: '() => {}',
+      options: [{ after: true, before: true }],
+      errors: [
+        { column: 2, line: 1, type: 'Punctuator', messageId: 'expectedBefore' },
+        { column: 5, line: 1, type: 'Punctuator', messageId: 'expectedAfter' },
+      ],
+    },
+    {
+      code: '(a)=>{}',
+      output: '(a) => {}',
+      options: [{ after: true, before: true }],
+      errors: [
+        { column: 3, line: 1, type: 'Punctuator', messageId: 'expectedBefore' },
+        { column: 6, line: 1, type: 'Punctuator', messageId: 'expectedAfter' },
+      ],
+    },
+    {
+      code: 'a=> a',
+      output: 'a =>a',
+      options: [{ after: false, before: true }],
+      errors: [
+        { column: 1, line: 1, type: 'Identifier', messageId: 'expectedBefore' },
+        { column: 5, line: 1, type: 'Identifier', messageId: 'unexpectedAfter' },
+      ],
+    },
+    {
+      code: '()=> {}',
+      output: '() =>{}',
+      options: [{ after: false, before: true }],
+      errors: [
+        { column: 2, line: 1, type: 'Punctuator', messageId: 'expectedBefore' },
+        { column: 6, line: 1, type: 'Punctuator', messageId: 'unexpectedAfter' },
+      ],
+    },
+    {
+      code: '(a)=> {}',
+      output: '(a) =>{}',
+      options: [{ after: false, before: true }],
+      errors: [
+        { column: 3, line: 1, type: 'Punctuator', messageId: 'expectedBefore' },
+        { column: 7, line: 1, type: 'Punctuator', messageId: 'unexpectedAfter' },
+      ],
+    },
+    {
+      code: 'a=>  a',
+      output: 'a =>a',
+      options: [{ after: false, before: true }],
+      errors: [
+        { column: 1, line: 1, type: 'Identifier', messageId: 'expectedBefore' },
+        { column: 6, line: 1, type: 'Identifier', messageId: 'unexpectedAfter' },
+      ],
+    },
+    {
+      code: '()=>  {}',
+      output: '() =>{}',
+      options: [{ after: false, before: true }],
+      errors: [
+        { column: 2, line: 1, type: 'Punctuator', messageId: 'expectedBefore' },
+        { column: 7, line: 1, type: 'Punctuator', messageId: 'unexpectedAfter' },
+      ],
+    },
+    {
+      code: '(a)=>  {}',
+      output: '(a) =>{}',
+      options: [{ after: false, before: true }],
+      errors: [
+        { column: 3, line: 1, type: 'Punctuator', messageId: 'expectedBefore' },
+        { column: 8, line: 1, type: 'Punctuator', messageId: 'unexpectedAfter' },
+      ],
+    },
+    {
+      code: 'a =>a',
+      output: 'a=> a',
+      options: [{ after: true, before: false }],
+      errors: [
+        { column: 1, line: 1, type: 'Identifier', messageId: 'unexpectedBefore' },
+        { column: 5, line: 1, type: 'Identifier', messageId: 'expectedAfter' },
+      ],
+    },
+    {
+      code: '() =>{}',
+      output: '()=> {}',
+      options: [{ after: true, before: false }],
+      errors: [
+        { column: 2, line: 1, type: 'Punctuator', messageId: 'unexpectedBefore' },
+        { column: 6, line: 1, type: 'Punctuator', messageId: 'expectedAfter' },
+      ],
+    },
+    {
+      code: '(a) =>{}',
+      output: '(a)=> {}',
+      options: [{ after: true, before: false }],
+      errors: [
+        { column: 3, line: 1, type: 'Punctuator', messageId: 'unexpectedBefore' },
+        { column: 7, line: 1, type: 'Punctuator', messageId: 'expectedAfter' },
+      ],
+    },
+    {
+      code: 'a  =>a',
+      output: 'a=> a',
+      options: [{ after: true, before: false }],
+      errors: [
+        { column: 1, line: 1, type: 'Identifier', messageId: 'unexpectedBefore' },
+        { column: 6, line: 1, type: 'Identifier', messageId: 'expectedAfter' },
+      ],
+    },
+    {
+      code: '()  =>{}',
+      output: '()=> {}',
+      options: [{ after: true, before: false }],
+      errors: [
+        { column: 2, line: 1, type: 'Punctuator', messageId: 'unexpectedBefore' },
+        { column: 7, line: 1, type: 'Punctuator', messageId: 'expectedAfter' },
+      ],
+    },
+    {
+      code: '(a)  =>{}',
+      output: '(a)=> {}',
+      options: [{ after: true, before: false }],
+      errors: [
+        { column: 3, line: 1, type: 'Punctuator', messageId: 'unexpectedBefore' },
+        { column: 8, line: 1, type: 'Punctuator', messageId: 'expectedAfter' },
+      ],
+    },
+    {
+      code: 'a => a',
+      output: 'a=>a',
+      options: [{ after: false, before: false }],
+      errors: [
+        { column: 1, line: 1, type: 'Identifier', messageId: 'unexpectedBefore' },
+        { column: 6, line: 1, type: 'Identifier', messageId: 'unexpectedAfter' },
+      ],
+    },
+    {
+      code: '() => {}',
+      output: '()=>{}',
+      options: [{ after: false, before: false }],
+      errors: [
+        { column: 2, line: 1, type: 'Punctuator', messageId: 'unexpectedBefore' },
+        { column: 7, line: 1, type: 'Punctuator', messageId: 'unexpectedAfter' },
+      ],
+    },
+    {
+      code: '(a) => {}',
+      output: '(a)=>{}',
+      options: [{ after: false, before: false }],
+      errors: [
+        { column: 3, line: 1, type: 'Punctuator', messageId: 'unexpectedBefore' },
+        { column: 8, line: 1, type: 'Punctuator', messageId: 'unexpectedAfter' },
+      ],
+    },
+    {
+      code: 'a  =>  a',
+      output: 'a=>a',
+      options: [{ after: false, before: false }],
+      errors: [
+        { column: 1, line: 1, type: 'Identifier', messageId: 'unexpectedBefore' },
+        { column: 8, line: 1, type: 'Identifier', messageId: 'unexpectedAfter' },
+      ],
+    },
+    {
+      code: '()  =>  {}',
+      output: '()=>{}',
+      options: [{ after: false, before: false }],
+      errors: [
+        { column: 2, line: 1, type: 'Punctuator', messageId: 'unexpectedBefore' },
+        { column: 9, line: 1, type: 'Punctuator', messageId: 'unexpectedAfter' },
+      ],
+    },
+    {
+      code: '(a)  =>  {}',
+      output: '(a)=>{}',
+      options: [{ after: false, before: false }],
+      errors: [
+        { column: 3, line: 1, type: 'Punctuator', messageId: 'unexpectedBefore' },
+        { column: 10, line: 1, type: 'Punctuator', messageId: 'unexpectedAfter' },
+      ],
+    },
+    {
+      code: '(a)  =>\n{}',
+      output: '(a)  =>{}',
+      options: [{ after: false }],
+      errors: [
+        { column: 1, line: 2, type: 'Punctuator', messageId: 'unexpectedAfter' },
+      ],
+    },
+
+    // https://github.com/eslint/eslint/issues/7079
+    {
+      code: '(a = ()=>0)=>1',
+      output: '(a = () => 0) => 1',
+      errors: [
+        { column: 7, line: 1, messageId: 'expectedBefore' },
+        { column: 10, line: 1, messageId: 'expectedAfter' },
+        { column: 11, line: 1, messageId: 'expectedBefore' },
+        { column: 14, line: 1, messageId: 'expectedAfter' },
+      ],
+    },
+    {
+      code: '(a = ()=>0)=>(1)',
+      output: '(a = () => 0) => (1)',
+      errors: [
+        { column: 7, line: 1, messageId: 'expectedBefore' },
+        { column: 10, line: 1, messageId: 'expectedAfter' },
+        { column: 11, line: 1, messageId: 'expectedBefore' },
+        { column: 14, line: 1, messageId: 'expectedAfter' },
+      ],
+    },
+  ],
 })

--- a/packages/eslint-plugin/rules/block-spacing/block-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/block-spacing/block-spacing._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Toru Nagashima
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'block-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/block-spacing/block-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/block-spacing/block-spacing._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Toru Nagashima
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'block-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/block-spacing/block-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/block-spacing/block-spacing._ts_.test.ts
@@ -1,5 +1,5 @@
 import type { InvalidTestCase, ValidTestCase } from '#test'
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import rule from '.'
@@ -27,7 +27,7 @@ const emptyBlocks = ['{}', '{ }']
 const singlePropertyBlocks = ['{bar: true}', '{ bar: true }']
 const blockComment = '/* comment */'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'block-spacing',
   rule,
   valid: [
@@ -66,7 +66,7 @@ run<RuleOptions>({
   invalid: [
     ...options.flatMap(option =>
       typeDeclarations.flatMap((typeDec) => {
-        return singlePropertyBlocks.flatMap<InvalidTestCase<RuleOptions>>(
+        return singlePropertyBlocks.flatMap<InvalidTestCase<RuleOptions, MessageIds>>(
           (blockType, blockIndex) => {
             // These are actually valid, so filter them out
             if (
@@ -107,7 +107,7 @@ run<RuleOptions>({
     ),
     // With block comments
     ...options.flatMap(option =>
-      typeDeclarations.flatMap <InvalidTestCase<RuleOptions>>((typeDec) => {
+      typeDeclarations.flatMap <InvalidTestCase<RuleOptions, MessageIds>>((typeDec) => {
         const property
           = typeDec.nodeType === AST_NODE_TYPES.TSEnumDeclaration
             ? 'bar = 1'

--- a/packages/eslint-plugin/rules/block-spacing/block-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/block-spacing/block-spacing._ts_.test.ts
@@ -1,4 +1,5 @@
 import type { InvalidTestCase, ValidTestCase } from '#test'
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import rule from '.'
@@ -26,20 +27,20 @@ const emptyBlocks = ['{}', '{ }']
 const singlePropertyBlocks = ['{bar: true}', '{ bar: true }']
 const blockComment = '/* comment */'
 
-run({
+run<RuleOptions>({
   name: 'block-spacing',
   rule,
   valid: [
     // Empty blocks don't apply
     ...options.flatMap(option =>
-      typeDeclarations.flatMap(typeDec =>
+      typeDeclarations.flatMap<ValidTestCase<RuleOptions>>(typeDec =>
         emptyBlocks.map<ValidTestCase>(blockType => ({
           code: typeDec.stringPrefix + blockType,
           options: [option],
         })),
       ),
     ),
-    ...typeDeclarations.flatMap<ValidTestCase>(
+    ...typeDeclarations.flatMap<ValidTestCase<RuleOptions>>(
       (typeDec) => {
         const property
           = typeDec.nodeType === AST_NODE_TYPES.TSEnumDeclaration
@@ -65,7 +66,7 @@ run({
   invalid: [
     ...options.flatMap(option =>
       typeDeclarations.flatMap((typeDec) => {
-        return singlePropertyBlocks.flatMap<InvalidTestCase>(
+        return singlePropertyBlocks.flatMap<InvalidTestCase<RuleOptions>>(
           (blockType, blockIndex) => {
             // These are actually valid, so filter them out
             if (
@@ -106,7 +107,7 @@ run({
     ),
     // With block comments
     ...options.flatMap(option =>
-      typeDeclarations.flatMap<InvalidTestCase>((typeDec) => {
+      typeDeclarations.flatMap <InvalidTestCase<RuleOptions>>((typeDec) => {
         const property
           = typeDec.nodeType === AST_NODE_TYPES.TSEnumDeclaration
             ? 'bar = 1'

--- a/packages/eslint-plugin/rules/block-spacing/block-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/block-spacing/block-spacing._ts_.test.ts
@@ -34,7 +34,7 @@ run<RuleOptions>({
     // Empty blocks don't apply
     ...options.flatMap(option =>
       typeDeclarations.flatMap<ValidTestCase<RuleOptions>>(typeDec =>
-        emptyBlocks.map<ValidTestCase>(blockType => ({
+        emptyBlocks.map<ValidTestCase<RuleOptions>>(blockType => ({
           code: typeDec.stringPrefix + blockType,
           options: [option],
         })),

--- a/packages/eslint-plugin/rules/brace-style/brace-style._js_.test.ts
+++ b/packages/eslint-plugin/rules/brace-style/brace-style._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Ian Christian Myers
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'brace-style',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/brace-style/brace-style._js_.test.ts
+++ b/packages/eslint-plugin/rules/brace-style/brace-style._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Ian Christian Myers
  */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'brace-style',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/brace-style/brace-style._ts_.test.ts
+++ b/packages/eslint-plugin/rules/brace-style/brace-style._ts_.test.ts
@@ -1,11 +1,11 @@
 // this rule tests the position of braces, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'brace-style',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/brace-style/brace-style._ts_.test.ts
+++ b/packages/eslint-plugin/rules/brace-style/brace-style._ts_.test.ts
@@ -1,10 +1,11 @@
 // this rule tests the position of braces, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'brace-style',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/comma-dangle/comma-dangle._js_.test.ts
+++ b/packages/eslint-plugin/rules/comma-dangle/comma-dangle._js_.test.ts
@@ -620,12 +620,12 @@ run<RuleOptions>({
     },
     {
       code: 'import(source)',
-      options: { functions: 'always' },
+      options: [{ functions: 'always' }],
       parserOptions: { ecmaVersion: 'latest' },
     },
     {
       code: 'import(source,)',
-      options: { functions: 'never', dynamicImports: 'always' },
+      options: [{ functions: 'never', dynamicImports: 'always' }],
       parserOptions: { ecmaVersion: 'latest' },
     },
 
@@ -665,7 +665,7 @@ run<RuleOptions>({
     },
     {
       code: 'import foo from "foo" with {type: "json",}',
-      options: { functions: 'never', importAttributes: 'always' },
+      options: [{ functions: 'never', importAttributes: 'always' }],
       parserOptions: { ecmaVersion: 'latest' },
     },
     {
@@ -703,7 +703,7 @@ run<RuleOptions>({
     },
     {
       code: 'export {foo} from "foo" with {type: "json",}',
-      options: { functions: 'never', importAttributes: 'always' },
+      options: [{ functions: 'never', importAttributes: 'always' }],
       parserOptions: { ecmaVersion: 'latest' },
     },
     {
@@ -741,7 +741,7 @@ run<RuleOptions>({
     },
     {
       code: 'export * from "foo" with {type: "json",}',
-      options: { functions: 'never', importAttributes: 'always' },
+      options: [{ functions: 'never', importAttributes: 'always' }],
       parserOptions: { ecmaVersion: 'latest' },
     },
   ],
@@ -2178,7 +2178,7 @@ run<RuleOptions>({
     {
       code: 'import(source)',
       output: 'import(source,)',
-      options: { functions: 'never', dynamicImports: 'always' },
+      options: [{ functions: 'never', dynamicImports: 'always' }],
       parserOptions: { ecmaVersion: 'latest' },
     },
 
@@ -2229,7 +2229,7 @@ run<RuleOptions>({
     {
       code: 'import foo from "foo" with {type: "json"}',
       output: 'import foo from "foo" with {type: "json",}',
-      options: { functions: 'never', importAttributes: 'always' },
+      options: [{ functions: 'never', importAttributes: 'always' }],
       parserOptions: { ecmaVersion: 'latest' },
     },
     {
@@ -2278,7 +2278,7 @@ run<RuleOptions>({
     {
       code: 'export {foo} from "foo" with {type: "json"}',
       output: 'export {foo} from "foo" with {type: "json",}',
-      options: { functions: 'never', importAttributes: 'always' },
+      options: [{ functions: 'never', importAttributes: 'always' }],
       parserOptions: { ecmaVersion: 'latest' },
     },
     {
@@ -2327,7 +2327,7 @@ run<RuleOptions>({
     {
       code: 'export * from "foo" with {type: "json"}',
       output: 'export * from "foo" with {type: "json",}',
-      options: { functions: 'never', importAttributes: 'always' },
+      options: [{ functions: 'never', importAttributes: 'always' }],
       parserOptions: { ecmaVersion: 'latest' },
     },
   ],

--- a/packages/eslint-plugin/rules/comma-dangle/comma-dangle._js_.test.ts
+++ b/packages/eslint-plugin/rules/comma-dangle/comma-dangle._js_.test.ts
@@ -3,11 +3,12 @@
  * @author Ian Christian Myers
  */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import { languageOptionsForBabelFlow } from '#test/parsers-flow'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'comma-dangle',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/comma-dangle/comma-dangle._js_.test.ts
+++ b/packages/eslint-plugin/rules/comma-dangle/comma-dangle._js_.test.ts
@@ -3,12 +3,12 @@
  * @author Ian Christian Myers
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import { languageOptionsForBabelFlow } from '#test/parsers-flow'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'comma-dangle',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/comma-dangle/comma-dangle._ts_.test.ts
+++ b/packages/eslint-plugin/rules/comma-dangle/comma-dangle._ts_.test.ts
@@ -1,11 +1,11 @@
 // this rule tests the new lines, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'comma-dangle',
   rule,
 

--- a/packages/eslint-plugin/rules/comma-dangle/comma-dangle._ts_.test.ts
+++ b/packages/eslint-plugin/rules/comma-dangle/comma-dangle._ts_.test.ts
@@ -1,10 +1,11 @@
 // this rule tests the new lines, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'comma-dangle',
   rule,
 

--- a/packages/eslint-plugin/rules/comma-spacing/comma-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/comma-spacing/comma-spacing._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Vignesh Anand.
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'comma-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/comma-spacing/comma-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/comma-spacing/comma-spacing._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Vignesh Anand.
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'comma-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/comma-spacing/comma-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/comma-spacing/comma-spacing._ts_.test.ts
@@ -1,11 +1,11 @@
 // this rule tests the spacing, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'comma-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/comma-spacing/comma-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/comma-spacing/comma-spacing._ts_.test.ts
@@ -1,10 +1,11 @@
 // this rule tests the spacing, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'comma-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/comma-style/comma-style._js_.test.ts
+++ b/packages/eslint-plugin/rules/comma-style/comma-style._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Vignesh Anand aka vegetableman
  */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'comma-style',
   rule,
 

--- a/packages/eslint-plugin/rules/comma-style/comma-style._js_.test.ts
+++ b/packages/eslint-plugin/rules/comma-style/comma-style._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Vignesh Anand aka vegetableman
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'comma-style',
   rule,
 

--- a/packages/eslint-plugin/rules/computed-property-spacing/computed-property-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/computed-property-spacing/computed-property-spacing._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Jamund Ferguson
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'computed-property-spacing',
   rule,
 

--- a/packages/eslint-plugin/rules/computed-property-spacing/computed-property-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/computed-property-spacing/computed-property-spacing._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Jamund Ferguson
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'computed-property-spacing',
   rule,
 

--- a/packages/eslint-plugin/rules/curly-newline/curly-newline._plus_.test.ts
+++ b/packages/eslint-plugin/rules/curly-newline/curly-newline._plus_.test.ts
@@ -163,7 +163,8 @@ function specializationTest(specialization: SpecializationOption, code: string, 
   })
 }
 
-test({ BlockStatement: 'always' }, 'for(;;){{}}', 'for(;;){{\n}}', 9, 10)
+test({ BlockStatement: 'always' }, 'for(;;){{}}', 'for(;;){{\n}}', { line: 1, column: 9, messageId: 'expectedLinebreakAfterOpeningBrace' }, { line: 1, column: 10, messageId: 'expectedLinebreakBeforeClosingBrace' },
+)
 specializationTest('IfStatementConsequent', `if(true){}`, `if(true){\n}`, 9, 10)
 specializationTest('IfStatementAlternative', `if(true){}else{}`, `if(true){}else{\n}`, 15, 16)
 specializationTest('DoWhileStatement', `do{}while(true)`, `do{\n}while(true)`, 3, 4)

--- a/packages/eslint-plugin/rules/curly-newline/curly-newline._plus_.test.ts
+++ b/packages/eslint-plugin/rules/curly-newline/curly-newline._plus_.test.ts
@@ -3,13 +3,15 @@
  * @author Toru Nagashima
  */
 
+import type { InvalidTestCase, ValidTestCase } from '#test'
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-const valid: any[] = []
-const invalid: any[] = []
+const valid: ValidTestCase<RuleOptions>[] = []
+const invalid: InvalidTestCase<RuleOptions>[] = []
 
-function test(options: any, code: string, output?: null | string, ...errors: any[]) {
+function test(options: RuleOptions[0], code: string, output?: null | string, ...errors: any[]) {
   if (output === undefined) {
     valid.push({ code, options: options !== undefined ? [options] : [] })
   }
@@ -139,9 +141,11 @@ test({ multiline: true, consistent: true, minElements: 2 }, `{\nvoid 0;void 0\n}
 
 // specializations
 
-function specializationTest(specialization: string, code: string): void
-function specializationTest(specialization: string, code: string, output: string, openingBraceColumn: number, closingBraceColumn: number): void
-function specializationTest(specialization: string, code: string, output?: string, openingBraceColumn?: number, closingBraceColumn?: number) {
+type SpecializationOption = keyof Extract<RuleOptions[0], object>
+
+function specializationTest(specialization: SpecializationOption, code: string): void
+function specializationTest(specialization: SpecializationOption, code: string, output: string, openingBraceColumn: number, closingBraceColumn: number): void
+function specializationTest(specialization: SpecializationOption, code: string, output?: string, openingBraceColumn?: number, closingBraceColumn?: number) {
   invalid.push({
     code: `{\n${code}\n}`,
     output: `{${output ?? code}}`,
@@ -187,7 +191,7 @@ specializationTest('TSEnumBody', `enum _{}`, `enum _{\n}`, 7, 8)
 specializationTest('TSInterfaceBody', `interface _{}`, `interface _{\n}`, 12, 13)
 specializationTest('TSModuleBlock', `module _{}`, `module _{\n}`, 9, 10)
 
-run({
+run<RuleOptions>({
   name: 'curly-newline',
   rule,
   valid,

--- a/packages/eslint-plugin/rules/curly-newline/curly-newline._plus_.test.ts
+++ b/packages/eslint-plugin/rules/curly-newline/curly-newline._plus_.test.ts
@@ -3,15 +3,15 @@
  * @author Toru Nagashima
  */
 
-import type { InvalidTestCase, ValidTestCase } from '#test'
-import type { RuleOptions } from './types'
+import type { InvalidTestCase, TestCaseError, ValidTestCase } from '#test'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
 const valid: ValidTestCase<RuleOptions>[] = []
-const invalid: InvalidTestCase<RuleOptions>[] = []
+const invalid: InvalidTestCase<RuleOptions, MessageIds>[] = []
 
-function test(options: RuleOptions[0], code: string, output?: null | string, ...errors: any[]) {
+function test(options: RuleOptions[0], code: string, output?: null | string, ...errors: TestCaseError<MessageIds>[]) {
   if (output === undefined) {
     valid.push({ code, options: options !== undefined ? [options] : [] })
   }
@@ -159,7 +159,7 @@ function specializationTest(specialization: SpecializationOption, code: string, 
           ]
         : [],
       { line: 3, column: 1, messageId: 'unexpectedLinebreakBeforeClosingBrace' },
-    ],
+    ] as TestCaseError<MessageIds>[],
   })
 }
 
@@ -191,7 +191,7 @@ specializationTest('TSEnumBody', `enum _{}`, `enum _{\n}`, 7, 8)
 specializationTest('TSInterfaceBody', `interface _{}`, `interface _{\n}`, 12, 13)
 specializationTest('TSModuleBlock', `module _{}`, `module _{\n}`, 9, 10)
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'curly-newline',
   rule,
   valid,

--- a/packages/eslint-plugin/rules/dot-location/dot-location._js_.test.ts
+++ b/packages/eslint-plugin/rules/dot-location/dot-location._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Greg Cochard
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'dot-location',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/dot-location/dot-location._js_.test.ts
+++ b/packages/eslint-plugin/rules/dot-location/dot-location._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Greg Cochard
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'dot-location',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/eol-last/eol-last._js_.test.ts
+++ b/packages/eslint-plugin/rules/eol-last/eol-last._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Nodeca Team <https://github.com/nodeca>
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'eol-last',
   rule,
 

--- a/packages/eslint-plugin/rules/eol-last/eol-last._js_.test.ts
+++ b/packages/eslint-plugin/rules/eol-last/eol-last._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Nodeca Team <https://github.com/nodeca>
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'eol-last',
   rule,
 

--- a/packages/eslint-plugin/rules/function-call-argument-newline/function-call-argument-newline._js_.test.ts
+++ b/packages/eslint-plugin/rules/function-call-argument-newline/function-call-argument-newline._js_.test.ts
@@ -1,7 +1,8 @@
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'function-call-argument-newline',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/function-call-argument-newline/function-call-argument-newline._js_.test.ts
+++ b/packages/eslint-plugin/rules/function-call-argument-newline/function-call-argument-newline._js_.test.ts
@@ -1,8 +1,8 @@
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'function-call-argument-newline',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/function-call-spacing/function-call-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/function-call-spacing/function-call-spacing._js_.test.ts
@@ -2,10 +2,12 @@
  * @fileoverview Tests for func-call-spacing rule.
  * @author Matt DuVall <http://www.mattduvall.com>
  */
+
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'function-call-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/function-call-spacing/function-call-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/function-call-spacing/function-call-spacing._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Matt DuVall <http://www.mattduvall.com>
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'function-call-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/function-call-spacing/function-call-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/function-call-spacing/function-call-spacing._ts_.test.ts
@@ -2,10 +2,11 @@
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
 import type { InvalidTestCase, ValidTestCase } from '#test'
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'function-call-spacing',
   rule,
   valid: [
@@ -68,7 +69,7 @@ run({
       '( f )?.<a>( 0 )',
       '( (f) )?.<a>( (0) )',
       '( f()() )?.<a>(0)',
-    ].map<ValidTestCase>(code => ({
+    ].map<ValidTestCase<RuleOptions>>(code => ({
       code,
       options: ['never'],
     })),
@@ -102,7 +103,7 @@ run({
       'f?.b ()?.c ();',
       'f?.b<a> (b, b)',
       'f ?. ();',
-    ].map<ValidTestCase>(code => ({
+    ].map<ValidTestCase<RuleOptions>>(code => ({
       code,
       options: ['always'],
     })),
@@ -125,7 +126,7 @@ run({
       'f\n() ()?.b \n()\n ()',
       'f ?. ();',
       'f\n?.\n();',
-    ].map<ValidTestCase>(code => ({
+    ].map<ValidTestCase<RuleOptions>>(code => ({
       code,
       options: ['always', { allowNewlines: true }],
     })),
@@ -256,7 +257,7 @@ run({
         code: 'import\n//comment\n(source)',
         output: null,
       },
-    ].map<InvalidTestCase>(code => ({
+    ].map<InvalidTestCase<RuleOptions>>(code => ({
       options: ['never'],
       errors: [
         {
@@ -296,7 +297,7 @@ run({
         code: 'import(source)',
         output: 'import (source)',
       },
-    ].map<InvalidTestCase>(code => ({
+    ].map<InvalidTestCase<RuleOptions>>(code => ({
       options: ['always'],
       errors: [
         {
@@ -409,7 +410,7 @@ run({
         code: 'f\r\n();',
         output: 'f ();',
       },
-    ].map<InvalidTestCase>(code => ({
+    ].map<InvalidTestCase<RuleOptions>>(code => ({
       options: ['always'],
       errors: [
         {
@@ -478,7 +479,7 @@ run({
           },
         ],
       },
-    ].map<InvalidTestCase>(code => ({
+    ].map<InvalidTestCase<RuleOptions>>(code => ({
       options: ['always', { allowNewlines: true }],
       errors: [
         {
@@ -499,7 +500,7 @@ run({
       'f\n?.\n();',
       'f ?.\n();',
       'f\n?. ();',
-    ].map<InvalidTestCase>(code => ({
+    ].map<InvalidTestCase<RuleOptions>>(code => ({
       options: ['never'],
       output: 'f?.();',
       errors: [
@@ -519,7 +520,7 @@ run({
       'f\n?.\n();',
       'f ?.\n();',
       'f\n?. ();',
-    ].map<InvalidTestCase>(code => ({
+    ].map<InvalidTestCase<RuleOptions>>(code => ({
       options: ['always'],
       output: 'f ?. ();',
       errors: [
@@ -539,7 +540,7 @@ run({
         code: 'f?.\n();',
         output: 'f ?.\n();',
       },
-    ].map<InvalidTestCase>(code => ({
+    ].map<InvalidTestCase<RuleOptions>>(code => ({
       options: ['always', { allowNewlines: true }],
       errors: [
         {
@@ -556,7 +557,7 @@ run({
       'f\n?.\n();',
       'f ?.\n();',
       'f\n?. ();',
-    ].flatMap<InvalidTestCase>((code) => {
+    ].flatMap<InvalidTestCase<RuleOptions>>((code) => {
       const messageId = code.includes('f ') || code.includes('f\n') ? 'unexpectedWhitespace' : 'missing'
       return [
         {
@@ -589,7 +590,7 @@ run({
       'f\n?.\n();',
       'f ?.\n();',
       'f\n?. ();',
-    ].flatMap<InvalidTestCase>((code) => {
+    ].flatMap<InvalidTestCase<RuleOptions>>((code) => {
       const messageId = code.includes(' ();') || code.includes('\n();') ? 'unexpectedWhitespace' : 'missing'
       return [
         {

--- a/packages/eslint-plugin/rules/function-call-spacing/function-call-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/function-call-spacing/function-call-spacing._ts_.test.ts
@@ -2,11 +2,11 @@
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
 import type { InvalidTestCase, ValidTestCase } from '#test'
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'function-call-spacing',
   rule,
   valid: [
@@ -257,7 +257,7 @@ run<RuleOptions>({
         code: 'import\n//comment\n(source)',
         output: null,
       },
-    ].map<InvalidTestCase<RuleOptions>>(code => ({
+    ].map<InvalidTestCase<RuleOptions, MessageIds>>(code => ({
       options: ['never'],
       errors: [
         {
@@ -297,7 +297,7 @@ run<RuleOptions>({
         code: 'import(source)',
         output: 'import (source)',
       },
-    ].map<InvalidTestCase<RuleOptions>>(code => ({
+    ].map<InvalidTestCase<RuleOptions, MessageIds>>(code => ({
       options: ['always'],
       errors: [
         {
@@ -410,7 +410,7 @@ run<RuleOptions>({
         code: 'f\r\n();',
         output: 'f ();',
       },
-    ].map<InvalidTestCase<RuleOptions>>(code => ({
+    ].map<InvalidTestCase<RuleOptions, MessageIds>>(code => ({
       options: ['always'],
       errors: [
         {
@@ -479,7 +479,7 @@ run<RuleOptions>({
           },
         ],
       },
-    ].map<InvalidTestCase<RuleOptions>>(code => ({
+    ].map<InvalidTestCase<RuleOptions, MessageIds>>(code => ({
       options: ['always', { allowNewlines: true }],
       errors: [
         {
@@ -500,7 +500,7 @@ run<RuleOptions>({
       'f\n?.\n();',
       'f ?.\n();',
       'f\n?. ();',
-    ].map<InvalidTestCase<RuleOptions>>(code => ({
+    ].map<InvalidTestCase<RuleOptions, MessageIds>>(code => ({
       options: ['never'],
       output: 'f?.();',
       errors: [
@@ -520,7 +520,7 @@ run<RuleOptions>({
       'f\n?.\n();',
       'f ?.\n();',
       'f\n?. ();',
-    ].map<InvalidTestCase<RuleOptions>>(code => ({
+    ].map<InvalidTestCase<RuleOptions, MessageIds>>(code => ({
       options: ['always'],
       output: 'f ?. ();',
       errors: [
@@ -540,7 +540,7 @@ run<RuleOptions>({
         code: 'f?.\n();',
         output: 'f ?.\n();',
       },
-    ].map<InvalidTestCase<RuleOptions>>(code => ({
+    ].map<InvalidTestCase<RuleOptions, MessageIds>>(code => ({
       options: ['always', { allowNewlines: true }],
       errors: [
         {
@@ -557,7 +557,7 @@ run<RuleOptions>({
       'f\n?.\n();',
       'f ?.\n();',
       'f\n?. ();',
-    ].flatMap<InvalidTestCase<RuleOptions>>((code) => {
+    ].flatMap<InvalidTestCase<RuleOptions, MessageIds>>((code) => {
       const messageId = code.includes('f ') || code.includes('f\n') ? 'unexpectedWhitespace' : 'missing'
       return [
         {
@@ -590,7 +590,7 @@ run<RuleOptions>({
       'f\n?.\n();',
       'f ?.\n();',
       'f\n?. ();',
-    ].flatMap<InvalidTestCase<RuleOptions>>((code) => {
+    ].flatMap<InvalidTestCase<RuleOptions, MessageIds>>((code) => {
       const messageId = code.includes(' ();') || code.includes('\n();') ? 'unexpectedWhitespace' : 'missing'
       return [
         {

--- a/packages/eslint-plugin/rules/function-paren-newline/function-paren-newline._js_.test.ts
+++ b/packages/eslint-plugin/rules/function-paren-newline/function-paren-newline._js_.test.ts
@@ -3,18 +3,19 @@
  * @author Teddy Katz
  */
 
-import type { RuleOptions } from './types'
+import type { TestCaseError } from '#test'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import tsParser from '@typescript-eslint/parser'
 import rule from '.'
 
-const LEFT_MISSING_ERROR = { messageId: 'expectedAfter', type: 'Punctuator' }
-const LEFT_UNEXPECTED_ERROR = { messageId: 'unexpectedAfter', type: 'Punctuator' }
-const RIGHT_MISSING_ERROR = { messageId: 'expectedBefore', type: 'Punctuator' }
-const RIGHT_UNEXPECTED_ERROR = { messageId: 'unexpectedBefore', type: 'Punctuator' }
-const EXPECTED_BETWEEN = { messageId: 'expectedBetween', type: 'Identifier' }
+const LEFT_MISSING_ERROR: TestCaseError<MessageIds> = { messageId: 'expectedAfter', type: 'Punctuator' }
+const LEFT_UNEXPECTED_ERROR: TestCaseError<MessageIds> = { messageId: 'unexpectedAfter', type: 'Punctuator' }
+const RIGHT_MISSING_ERROR: TestCaseError<MessageIds> = { messageId: 'expectedBefore', type: 'Punctuator' }
+const RIGHT_UNEXPECTED_ERROR: TestCaseError<MessageIds> = { messageId: 'unexpectedBefore', type: 'Punctuator' }
+const EXPECTED_BETWEEN: TestCaseError<MessageIds> = { messageId: 'expectedBetween', type: 'Identifier' }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'function-paren-newline',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/function-paren-newline/function-paren-newline._js_.test.ts
+++ b/packages/eslint-plugin/rules/function-paren-newline/function-paren-newline._js_.test.ts
@@ -3,6 +3,7 @@
  * @author Teddy Katz
  */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import tsParser from '@typescript-eslint/parser'
 import rule from '.'
@@ -13,7 +14,7 @@ const RIGHT_MISSING_ERROR = { messageId: 'expectedBefore', type: 'Punctuator' }
 const RIGHT_UNEXPECTED_ERROR = { messageId: 'unexpectedBefore', type: 'Punctuator' }
 const EXPECTED_BETWEEN = { messageId: 'expectedBetween', type: 'Identifier' }
 
-run({
+run<RuleOptions>({
   name: 'function-paren-newline',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/generator-star-spacing/generator-star-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/generator-star-spacing/generator-star-spacing._js_.test.ts
@@ -3,6 +3,7 @@
  * @author Jamund Ferguson
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
@@ -11,7 +12,7 @@ const missingAfterError = { messageId: 'missingAfter', type: 'Punctuator' }
 const unexpectedBeforeError = { messageId: 'unexpectedBefore', type: 'Punctuator' }
 const unexpectedAfterError = { messageId: 'unexpectedAfter', type: 'Punctuator' }
 
-run({
+run<RuleOptions>({
   name: 'generator-star-spacing',
   rule,
 

--- a/packages/eslint-plugin/rules/generator-star-spacing/generator-star-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/generator-star-spacing/generator-star-spacing._js_.test.ts
@@ -3,16 +3,17 @@
  * @author Jamund Ferguson
  */
 
-import type { RuleOptions } from './types'
+import type { TestCaseError } from '#test'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-const missingBeforeError = { messageId: 'missingBefore', type: 'Punctuator' }
-const missingAfterError = { messageId: 'missingAfter', type: 'Punctuator' }
-const unexpectedBeforeError = { messageId: 'unexpectedBefore', type: 'Punctuator' }
-const unexpectedAfterError = { messageId: 'unexpectedAfter', type: 'Punctuator' }
+const missingBeforeError: TestCaseError<MessageIds> = { messageId: 'missingBefore', type: 'Punctuator' }
+const missingAfterError: TestCaseError<MessageIds> = { messageId: 'missingAfter', type: 'Punctuator' }
+const unexpectedBeforeError: TestCaseError<MessageIds> = { messageId: 'unexpectedBefore', type: 'Punctuator' }
+const unexpectedAfterError: TestCaseError<MessageIds> = { messageId: 'unexpectedAfter', type: 'Punctuator' }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'generator-star-spacing',
   rule,
 

--- a/packages/eslint-plugin/rules/implicit-arrow-linebreak/implicit-arrow-linebreak._js_.test.ts
+++ b/packages/eslint-plugin/rules/implicit-arrow-linebreak/implicit-arrow-linebreak._js_.test.ts
@@ -3,14 +3,15 @@
  * @author Sharmila Jesupaul
  */
 
-import type { RuleOptions } from './types'
+import type { TestCaseError } from '#test'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-const EXPECTED_LINEBREAK = { messageId: 'expected' }
-const UNEXPECTED_LINEBREAK = { messageId: 'unexpected' }
+const EXPECTED_LINEBREAK: TestCaseError<MessageIds> = { messageId: 'expected' }
+const UNEXPECTED_LINEBREAK: TestCaseError<MessageIds> = { messageId: 'unexpected' }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'implicit-arrow-linebreak',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/implicit-arrow-linebreak/implicit-arrow-linebreak._js_.test.ts
+++ b/packages/eslint-plugin/rules/implicit-arrow-linebreak/implicit-arrow-linebreak._js_.test.ts
@@ -3,13 +3,14 @@
  * @author Sharmila Jesupaul
  */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
 const EXPECTED_LINEBREAK = { messageId: 'expected' }
 const UNEXPECTED_LINEBREAK = { messageId: 'unexpected' }
 
-run({
+run<RuleOptions>({
   name: 'implicit-arrow-linebreak',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/indent-binary-ops/indent-binary-ops._plus_.test.ts
+++ b/packages/eslint-plugin/rules/indent-binary-ops/indent-binary-ops._plus_.test.ts
@@ -1,9 +1,9 @@
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, createLinter, run } from '#test'
 import { expect, it } from 'vitest'
 import rule from './indent-binary-ops._plus_'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'indent-binary-ops',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/indent-binary-ops/indent-binary-ops._plus_.test.ts
+++ b/packages/eslint-plugin/rules/indent-binary-ops/indent-binary-ops._plus_.test.ts
@@ -1,8 +1,9 @@
+import type { RuleOptions } from './types'
 import { $, createLinter, run } from '#test'
 import { expect, it } from 'vitest'
 import rule from './indent-binary-ops._plus_'
 
-run({
+run<RuleOptions>({
   name: 'indent-binary-ops',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/indent/indent._js_.test.ts
+++ b/packages/eslint-plugin/rules/indent/indent._js_.test.ts
@@ -1,4 +1,4 @@
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 /**
  * @fileoverview This option sets a specific tab width for your code
  * @author Dmitriy Shekhovtsov
@@ -16,7 +16,7 @@ const fixedFixture = readFileSync(join(__dirname, './fixtures/indent-valid-fixtu
 
 type ErrorInput = [number, number | string, number | string, string]
 interface ErrorOutput {
-  messageId: string
+  messageId: MessageIds
   data: {
     expected: string
     actual: string | number
@@ -56,7 +56,7 @@ export function expectedErrors(providedIndentType: any, providedErrors?: any): E
   }))
 }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'indent',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/indent/indent._js_.test.ts
+++ b/packages/eslint-plugin/rules/indent/indent._js_.test.ts
@@ -1,3 +1,4 @@
+import type { RuleOptions } from './types'
 /**
  * @fileoverview This option sets a specific tab width for your code
  * @author Dmitriy Shekhovtsov
@@ -55,7 +56,7 @@ export function expectedErrors(providedIndentType: any, providedErrors?: any): E
   }))
 }
 
-run({
+run<RuleOptions>({
   name: 'indent',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/indent/indent._ts_.test.ts
+++ b/packages/eslint-plugin/rules/indent/indent._ts_.test.ts
@@ -1,7 +1,7 @@
 // this rule tests the spacing, which prettier will want to fix and break the tests
 
 import type { InvalidTestCase, TestCaseError, TestCasesOptions, ValidTestCase } from '#test'
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import rule from '.'
@@ -591,12 +591,12 @@ type Foo = string | {
             `,
     ],
   },
-].reduce<TestCasesOptions<RuleOptions>>(
+].reduce<TestCasesOptions<RuleOptions, MessageIds>>(
   (acc, testCase) => {
     const indent = '    '
 
     const validCases: ValidTestCase<RuleOptions>[] = [...acc.valid!]
-    const invalidCases: InvalidTestCase<RuleOptions>[] = [...acc.invalid!]
+    const invalidCases: InvalidTestCase<RuleOptions, MessageIds>[] = [...acc.invalid!]
 
     const codeCases = testCase.code.map(code => [
       '', // newline to make test error messages nicer
@@ -614,7 +614,7 @@ type Foo = string | {
         output: code,
         errors: code
           .split('\n')
-          .map<TestCaseError | null>((line, lineNum) => {
+          .map<TestCaseError<MessageIds> | null>((line, lineNum) => {
             const indentCount = line.split(indent).length - 1
             const spaceCount = indentCount * indent.length
 
@@ -632,7 +632,7 @@ type Foo = string | {
             }
           })
           .filter(
-            (error): error is TestCaseError =>
+            (error): error is TestCaseError<MessageIds> =>
               error != null,
           ),
       }
@@ -646,7 +646,7 @@ type Foo = string | {
 )
 // #endregion
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'indent',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/indent/indent._ts_.test.ts
+++ b/packages/eslint-plugin/rules/indent/indent._ts_.test.ts
@@ -1,6 +1,7 @@
 // this rule tests the spacing, which prettier will want to fix and break the tests
-import type { InvalidTestCase, TestCaseError, TestCasesOptions, ValidTestCase } from '#test'
 
+import type { InvalidTestCase, TestCaseError, TestCasesOptions, ValidTestCase } from '#test'
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import rule from '.'
@@ -590,12 +591,12 @@ type Foo = string | {
             `,
     ],
   },
-].reduce<TestCasesOptions>(
+].reduce<TestCasesOptions<RuleOptions>>(
   (acc, testCase) => {
     const indent = '    '
 
-    const validCases: ValidTestCase[] = [...acc.valid!]
-    const invalidCases: InvalidTestCase[] = [...acc.invalid!]
+    const validCases: ValidTestCase<RuleOptions>[] = [...acc.valid!]
+    const invalidCases: InvalidTestCase<RuleOptions>[] = [...acc.invalid!]
 
     const codeCases = testCase.code.map(code => [
       '', // newline to make test error messages nicer
@@ -645,7 +646,7 @@ type Foo = string | {
 )
 // #endregion
 
-run({
+run<RuleOptions>({
   name: 'indent',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/indent/jsx-indent._js_.test.ts
+++ b/packages/eslint-plugin/rules/indent/jsx-indent._js_.test.ts
@@ -3,13 +3,13 @@
  * @author Yannick Croissant
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import { invalids as _invalids, valids as _valids } from '#test/parsers-jsx'
 import rule from '.'
 import { expectedErrors } from './indent._js_.test'
 
-function valids<RuleOptions>(...tests: Parameters<typeof _valids<RuleOptions>>) {
+function valids(...tests: Parameters<typeof _valids<RuleOptions>>) {
   tests.forEach((test) => {
     if (test !== false && !Array.isArray(test) && test?.code)
       test.code = $(test.code)
@@ -17,7 +17,7 @@ function valids<RuleOptions>(...tests: Parameters<typeof _valids<RuleOptions>>) 
   return _valids(...tests)
 }
 
-function invalids<RuleOptions>(...tests: Parameters<typeof _invalids<RuleOptions>>) {
+function invalids(...tests: Parameters<typeof _invalids<RuleOptions, MessageIds>>) {
   tests.forEach((test) => {
     if (test !== false && !Array.isArray(test)) {
       if (test?.code)
@@ -30,7 +30,7 @@ function invalids<RuleOptions>(...tests: Parameters<typeof _invalids<RuleOptions
   return _invalids(...tests)
 }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'jsx-indent',
   rule,
   parserOptions: {

--- a/packages/eslint-plugin/rules/indent/jsx-indent._js_.test.ts
+++ b/packages/eslint-plugin/rules/indent/jsx-indent._js_.test.ts
@@ -3,12 +3,13 @@
  * @author Yannick Croissant
  */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import { invalids as _invalids, valids as _valids } from '#test/parsers-jsx'
 import rule from '.'
 import { expectedErrors } from './indent._js_.test'
 
-function valids(...tests: Parameters<typeof _valids>) {
+function valids<RuleOptions>(...tests: Parameters<typeof _valids<RuleOptions>>) {
   tests.forEach((test) => {
     if (test !== false && !Array.isArray(test) && test?.code)
       test.code = $(test.code)
@@ -16,7 +17,7 @@ function valids(...tests: Parameters<typeof _valids>) {
   return _valids(...tests)
 }
 
-function invalids(...tests: Parameters<typeof _invalids>) {
+function invalids<RuleOptions>(...tests: Parameters<typeof _invalids<RuleOptions>>) {
   tests.forEach((test) => {
     if (test !== false && !Array.isArray(test)) {
       if (test?.code)
@@ -29,7 +30,7 @@ function invalids(...tests: Parameters<typeof _invalids>) {
   return _invalids(...tests)
 }
 
-run({
+run<RuleOptions>({
   name: 'jsx-indent',
   rule,
   parserOptions: {

--- a/packages/eslint-plugin/rules/jsx-child-element-spacing/jsx-child-element-spacing._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-child-element-spacing/jsx-child-element-spacing._jsx_.test.ts
@@ -1,9 +1,9 @@
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-child-element-spacing._jsx_'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'jsx-child-element-spacing',
   rule,
   parserOptions: {
@@ -185,7 +185,7 @@ run<RuleOptions>({
     },
   ),
 
-  invalid: invalids<RuleOptions>(
+  invalid: invalids<RuleOptions, MessageIds>(
     {
       code: `
         <App>

--- a/packages/eslint-plugin/rules/jsx-child-element-spacing/jsx-child-element-spacing._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-child-element-spacing/jsx-child-element-spacing._jsx_.test.ts
@@ -1,8 +1,9 @@
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-child-element-spacing._jsx_'
 
-run({
+run<RuleOptions>({
   name: 'jsx-child-element-spacing',
   rule,
   parserOptions: {
@@ -11,7 +12,7 @@ run({
     },
   },
 
-  valid: valids(
+  valid: valids<RuleOptions>(
     {
       code: `
         <App>
@@ -184,7 +185,7 @@ run({
     },
   ),
 
-  invalid: invalids(
+  invalid: invalids<RuleOptions>(
     {
       code: `
         <App>

--- a/packages/eslint-plugin/rules/jsx-closing-bracket-location/jsx-closing-bracket-location._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-closing-bracket-location/jsx-closing-bracket-location._jsx_.test.ts
@@ -3,6 +3,7 @@
  * @author Yannick Croissant
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-closing-bracket-location._jsx_'
@@ -18,7 +19,7 @@ function details(expectedColumn: number, expectedNextLine: boolean) {
   return ` (expected column ${expectedColumn}${expectedNextLine ? ' on the next line)' : ')'}`
 }
 
-run({
+run<RuleOptions>({
   name: 'jsx-closing-bracket-location',
   rule,
   parserOptions: {

--- a/packages/eslint-plugin/rules/jsx-closing-bracket-location/jsx-closing-bracket-location._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-closing-bracket-location/jsx-closing-bracket-location._jsx_.test.ts
@@ -3,7 +3,7 @@
  * @author Yannick Croissant
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-closing-bracket-location._jsx_'
@@ -19,7 +19,7 @@ function details(expectedColumn: number, expectedNextLine: boolean) {
   return ` (expected column ${expectedColumn}${expectedNextLine ? ' on the next line)' : ')'}`
 }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'jsx-closing-bracket-location',
   rule,
   parserOptions: {
@@ -28,7 +28,7 @@ run<RuleOptions>({
     },
   },
 
-  valid: valids(
+  valid: valids<RuleOptions>(
     {
       code: `
         <App />
@@ -431,7 +431,7 @@ run<RuleOptions>({
     },
   ),
 
-  invalid: invalids(
+  invalid: invalids<RuleOptions, MessageIds>(
     {
       code: `
         <App

--- a/packages/eslint-plugin/rules/jsx-closing-tag-location/jsx-closing-tag-location._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-closing-tag-location/jsx-closing-tag-location._jsx_.test.ts
@@ -3,11 +3,12 @@
  * @author Ross Solomon
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-closing-tag-location._jsx_'
 
-run({
+run<RuleOptions>({
   name: 'jsx-closing-tag-location',
   rule,
   parserOptions: {

--- a/packages/eslint-plugin/rules/jsx-closing-tag-location/jsx-closing-tag-location._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-closing-tag-location/jsx-closing-tag-location._jsx_.test.ts
@@ -3,12 +3,12 @@
  * @author Ross Solomon
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-closing-tag-location._jsx_'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'jsx-closing-tag-location',
   rule,
   parserOptions: {
@@ -18,7 +18,7 @@ run<RuleOptions>({
     },
   },
 
-  valid: valids(
+  valid: valids<RuleOptions>(
     {
       code: `
         <App>
@@ -98,7 +98,7 @@ run<RuleOptions>({
     },
   ),
 
-  invalid: invalids(
+  invalid: invalids<RuleOptions, MessageIds>(
     {
       code: `
         <App>

--- a/packages/eslint-plugin/rules/jsx-curly-brace-presence/jsx-curly-brace-presence._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-curly-brace-presence/jsx-curly-brace-presence._jsx_.test.ts
@@ -5,12 +5,12 @@
 
 // For better readability on tests involving quotes
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { BABEL_ESLINT, babelParserOptions, invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-curly-brace-presence._jsx_'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'jsx-curly-brace-presence',
   rule,
   parserOptions: {
@@ -465,7 +465,7 @@ run<RuleOptions>({
     },
   ),
 
-  invalid: invalids<RuleOptions>(
+  invalid: invalids<RuleOptions, MessageIds>(
     {
       code: '<App prop={`foo`} />',
       output: '<App prop="foo" />',

--- a/packages/eslint-plugin/rules/jsx-curly-brace-presence/jsx-curly-brace-presence._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-curly-brace-presence/jsx-curly-brace-presence._jsx_.test.ts
@@ -5,11 +5,12 @@
 
 // For better readability on tests involving quotes
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { BABEL_ESLINT, babelParserOptions, invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-curly-brace-presence._jsx_'
 
-run({
+run<RuleOptions>({
   name: 'jsx-curly-brace-presence',
   rule,
   parserOptions: {
@@ -18,7 +19,7 @@ run({
     },
   },
 
-  valid: valids(
+  valid: valids<RuleOptions>(
     {
       code: '<App {...props}>foo</App>',
     },
@@ -464,7 +465,7 @@ run({
     },
   ),
 
-  invalid: invalids(
+  invalid: invalids<RuleOptions>(
     {
       code: '<App prop={`foo`} />',
       output: '<App prop="foo" />',

--- a/packages/eslint-plugin/rules/jsx-curly-newline/jsx-curly-newline._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-curly-newline/jsx-curly-newline._jsx_.test.ts
@@ -2,6 +2,7 @@
  * @fileoverview enforce consistent line breaks inside jsx curly
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-curly-newline._jsx_'
@@ -12,11 +13,11 @@ const RIGHT_MISSING_ERROR = { messageId: 'expectedBefore', type: 'Punctuator' }
 const RIGHT_UNEXPECTED_ERROR = { messageId: 'unexpectedBefore', type: 'Punctuator' }
 // const EXPECTED_BETWEEN = {messageId: 'expectedBetween', type: 'Identifier'};
 
-const CONSISTENT = ['consistent']
-const NEVER = ['never']
-const MULTILINE_REQUIRE = [{ singleline: 'consistent', multiline: 'require' }]
+const CONSISTENT: RuleOptions = ['consistent']
+const NEVER: RuleOptions = ['never']
+const MULTILINE_REQUIRE: RuleOptions = [{ singleline: 'consistent', multiline: 'require' }]
 
-run({
+run<RuleOptions>({
   name: 'jsx-curly-newline',
   rule,
   parserOptions: {
@@ -25,7 +26,7 @@ run({
     },
   },
 
-  valid: valids(
+  valid: valids<RuleOptions>(
     // consistent option (default)
     {
       code: '<div>{foo}</div>',
@@ -128,7 +129,7 @@ run({
     },
   ),
 
-  invalid: invalids(
+  invalid: invalids<RuleOptions>(
     // consistent option (default)
     {
       code: `

--- a/packages/eslint-plugin/rules/jsx-curly-newline/jsx-curly-newline._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-curly-newline/jsx-curly-newline._jsx_.test.ts
@@ -2,22 +2,23 @@
  * @fileoverview enforce consistent line breaks inside jsx curly
  */
 
-import type { RuleOptions } from './types'
+import type { TestCaseError } from '#test'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-curly-newline._jsx_'
 
-const LEFT_MISSING_ERROR = { messageId: 'expectedAfter', type: 'Punctuator' }
-const LEFT_UNEXPECTED_ERROR = { messageId: 'unexpectedAfter', type: 'Punctuator' }
-const RIGHT_MISSING_ERROR = { messageId: 'expectedBefore', type: 'Punctuator' }
-const RIGHT_UNEXPECTED_ERROR = { messageId: 'unexpectedBefore', type: 'Punctuator' }
-// const EXPECTED_BETWEEN = {messageId: 'expectedBetween', type: 'Identifier'};
+const LEFT_MISSING_ERROR: TestCaseError<MessageIds> = { messageId: 'expectedAfter', type: 'Punctuator' }
+const LEFT_UNEXPECTED_ERROR: TestCaseError<MessageIds> = { messageId: 'unexpectedAfter', type: 'Punctuator' }
+const RIGHT_MISSING_ERROR: TestCaseError<MessageIds> = { messageId: 'expectedBefore', type: 'Punctuator' }
+const RIGHT_UNEXPECTED_ERROR: TestCaseError<MessageIds> = { messageId: 'unexpectedBefore', type: 'Punctuator' }
+// const EXPECTED_BETWEEN: TestCaseError<MessageIds> = {messageId: 'expectedBetween', type: 'Identifier'};
 
 const CONSISTENT: RuleOptions = ['consistent']
 const NEVER: RuleOptions = ['never']
 const MULTILINE_REQUIRE: RuleOptions = [{ singleline: 'consistent', multiline: 'require' }]
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'jsx-curly-newline',
   rule,
   parserOptions: {
@@ -129,7 +130,7 @@ run<RuleOptions>({
     },
   ),
 
-  invalid: invalids<RuleOptions>(
+  invalid: invalids<RuleOptions, MessageIds>(
     // consistent option (default)
     {
       code: `

--- a/packages/eslint-plugin/rules/jsx-curly-spacing/jsx-curly-spacing._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-curly-spacing/jsx-curly-spacing._jsx_.test.ts
@@ -4,11 +4,12 @@
  * @author Erik Wendel
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-curly-spacing._jsx_'
 
-run({
+run<RuleOptions>({
   name: 'jsx-curly-spacing',
   rule,
   parserOptions: {
@@ -17,7 +18,7 @@ run({
     },
   },
 
-  valid: valids(
+  valid: valids<RuleOptions>(
     {
       code: '<App foo={bar} />;',
     },
@@ -815,7 +816,7 @@ run({
     },
   ),
 
-  invalid: invalids(
+  invalid: invalids<RuleOptions>(
     {
       code: '<App foo={ bar }>{bar}</App>;',
       output: '<App foo={bar}>{bar}</App>;',

--- a/packages/eslint-plugin/rules/jsx-curly-spacing/jsx-curly-spacing._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-curly-spacing/jsx-curly-spacing._jsx_.test.ts
@@ -4,12 +4,12 @@
  * @author Erik Wendel
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-curly-spacing._jsx_'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'jsx-curly-spacing',
   rule,
   parserOptions: {
@@ -816,7 +816,7 @@ run<RuleOptions>({
     },
   ),
 
-  invalid: invalids<RuleOptions>(
+  invalid: invalids<RuleOptions, MessageIds>(
     {
       code: '<App foo={ bar }>{bar}</App>;',
       output: '<App foo={bar}>{bar}</App>;',

--- a/packages/eslint-plugin/rules/jsx-equals-spacing/jsx-equals-spacing._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-equals-spacing/jsx-equals-spacing._jsx_.test.ts
@@ -3,12 +3,12 @@
  * @author ryym
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, skipDueToMultiErrorSorting, valids } from '#test/parsers-jsx'
 import rule from './jsx-equals-spacing._jsx_'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'jsx-equals-spacing',
   rule,
   parserOptions: {
@@ -75,7 +75,7 @@ run<RuleOptions>({
     },
   ),
 
-  invalid: invalids<RuleOptions>(
+  invalid: invalids<RuleOptions, MessageIds>(
     skipDueToMultiErrorSorting ? [] : {
       code: '<App foo = {bar} />',
       output: '<App foo={bar} />',

--- a/packages/eslint-plugin/rules/jsx-equals-spacing/jsx-equals-spacing._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-equals-spacing/jsx-equals-spacing._jsx_.test.ts
@@ -3,11 +3,12 @@
  * @author ryym
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, skipDueToMultiErrorSorting, valids } from '#test/parsers-jsx'
 import rule from './jsx-equals-spacing._jsx_'
 
-run({
+run<RuleOptions>({
   name: 'jsx-equals-spacing',
   rule,
   parserOptions: {
@@ -16,7 +17,7 @@ run({
     },
   },
 
-  valid: valids(
+  valid: valids<RuleOptions>(
     {
       code: '<App />',
     },
@@ -74,7 +75,7 @@ run({
     },
   ),
 
-  invalid: invalids(
+  invalid: invalids<RuleOptions>(
     skipDueToMultiErrorSorting ? [] : {
       code: '<App foo = {bar} />',
       output: '<App foo={bar} />',

--- a/packages/eslint-plugin/rules/jsx-first-prop-new-line/jsx-first-prop-new-line._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-first-prop-new-line/jsx-first-prop-new-line._jsx_.test.ts
@@ -3,12 +3,12 @@
  * @author Joachim Seminck
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-first-prop-new-line._jsx_'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'jsx-first-prop-new-line',
   rule,
   parserOptions: {
@@ -147,7 +147,7 @@ run<RuleOptions>({
     },
   ),
 
-  invalid: invalids<RuleOptions>(
+  invalid: invalids<RuleOptions, MessageIds>(
     {
       code: `
         <Foo propOne="one" propTwo="two" />

--- a/packages/eslint-plugin/rules/jsx-first-prop-new-line/jsx-first-prop-new-line._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-first-prop-new-line/jsx-first-prop-new-line._jsx_.test.ts
@@ -3,11 +3,12 @@
  * @author Joachim Seminck
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-first-prop-new-line._jsx_'
 
-run({
+run<RuleOptions>({
   name: 'jsx-first-prop-new-line',
   rule,
   parserOptions: {
@@ -16,7 +17,7 @@ run({
     },
   },
 
-  valid: valids(
+  valid: valids<RuleOptions>(
     {
       code: '<Foo />',
       options: ['never'],
@@ -146,7 +147,7 @@ run({
     },
   ),
 
-  invalid: invalids(
+  invalid: invalids<RuleOptions>(
     {
       code: `
         <Foo propOne="one" propTwo="two" />

--- a/packages/eslint-plugin/rules/jsx-function-call-newline/jsx-function-call-newline._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-function-call-newline/jsx-function-call-newline._jsx_.test.ts
@@ -1,9 +1,9 @@
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-function-call-newline._jsx_'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'jsx-function-call-newline',
   rule,
   parserOptions: {
@@ -74,7 +74,7 @@ run<RuleOptions>({
       code: `new OBJ(\n<div />\n,\n<div ></div>)`,
     },
   ),
-  invalid: invalids<RuleOptions>(
+  invalid: invalids<RuleOptions, MessageIds>(
     {
       code: `fn(<div
         />)`,

--- a/packages/eslint-plugin/rules/jsx-function-call-newline/jsx-function-call-newline._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-function-call-newline/jsx-function-call-newline._jsx_.test.ts
@@ -1,8 +1,9 @@
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-function-call-newline._jsx_'
 
-run({
+run<RuleOptions>({
   name: 'jsx-function-call-newline',
   rule,
   parserOptions: {
@@ -11,7 +12,7 @@ run({
     },
   },
 
-  valid: valids(
+  valid: valids<RuleOptions>(
     {
       code: `fn(<div />)`,
     },
@@ -73,7 +74,7 @@ run({
       code: `new OBJ(\n<div />\n,\n<div ></div>)`,
     },
   ),
-  invalid: invalids(
+  invalid: invalids<RuleOptions>(
     {
       code: `fn(<div
         />)`,

--- a/packages/eslint-plugin/rules/jsx-indent-props/jsx-indent-props._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-indent-props/jsx-indent-props._jsx_.test.ts
@@ -3,12 +3,12 @@
  * @author Yannick Croissant
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-indent-props._jsx_'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'jsx-indent-props',
   rule,
   parserOptions: {
@@ -310,7 +310,7 @@ run<RuleOptions>({
     },
   ),
 
-  invalid: invalids<RuleOptions>(
+  invalid: invalids<RuleOptions, MessageIds>(
     {
       code: `
         <App

--- a/packages/eslint-plugin/rules/jsx-indent-props/jsx-indent-props._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-indent-props/jsx-indent-props._jsx_.test.ts
@@ -3,11 +3,12 @@
  * @author Yannick Croissant
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-indent-props._jsx_'
 
-run({
+run<RuleOptions>({
   name: 'jsx-indent-props',
   rule,
   parserOptions: {
@@ -17,7 +18,7 @@ run({
       jsx: true,
     },
   },
-  valid: valids(
+  valid: valids<RuleOptions>(
     {
       code: `
         <App foo
@@ -309,7 +310,7 @@ run({
     },
   ),
 
-  invalid: invalids(
+  invalid: invalids<RuleOptions>(
     {
       code: `
         <App

--- a/packages/eslint-plugin/rules/jsx-indent/jsx-indent._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-indent/jsx-indent._jsx_.test.ts
@@ -3,11 +3,12 @@
  * @author Yannick Croissant
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, skipDueToMultiErrorSorting, valids } from '#test/parsers-jsx'
 import rule from './jsx-indent._jsx_'
 
-run({
+run<RuleOptions>({
   name: 'jsx-indent',
   rule,
   parserOptions: {
@@ -16,7 +17,7 @@ run({
     },
   },
 
-  valid: valids(
+  valid: valids<RuleOptions>(
     {
       code: `
         <App></App>
@@ -1197,7 +1198,7 @@ const Component = () => (
     },
   ),
 
-  invalid: invalids(
+  invalid: invalids<RuleOptions>(
     {
       code: `
         <div>

--- a/packages/eslint-plugin/rules/jsx-indent/jsx-indent._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-indent/jsx-indent._jsx_.test.ts
@@ -3,12 +3,12 @@
  * @author Yannick Croissant
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, skipDueToMultiErrorSorting, valids } from '#test/parsers-jsx'
 import rule from './jsx-indent._jsx_'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'jsx-indent',
   rule,
   parserOptions: {
@@ -1198,7 +1198,7 @@ const Component = () => (
     },
   ),
 
-  invalid: invalids<RuleOptions>(
+  invalid: invalids<RuleOptions, MessageIds>(
     {
       code: `
         <div>

--- a/packages/eslint-plugin/rules/jsx-max-props-per-line/jsx-max-props-per-line._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-max-props-per-line/jsx-max-props-per-line._jsx_.test.ts
@@ -3,12 +3,12 @@
  * @author Yannick Croissant
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-max-props-per-line._jsx_'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'jsx-max-props-per-line',
   rule,
   parserOptions: {
@@ -135,7 +135,7 @@ run<RuleOptions>({
     },
   ),
 
-  invalid: invalids<RuleOptions>(
+  invalid: invalids<RuleOptions, MessageIds>(
     {
       code: `
         <App foo bar baz />;

--- a/packages/eslint-plugin/rules/jsx-max-props-per-line/jsx-max-props-per-line._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-max-props-per-line/jsx-max-props-per-line._jsx_.test.ts
@@ -3,11 +3,12 @@
  * @author Yannick Croissant
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-max-props-per-line._jsx_'
 
-run({
+run<RuleOptions>({
   name: 'jsx-max-props-per-line',
   rule,
   parserOptions: {
@@ -16,7 +17,7 @@ run({
     },
   },
 
-  valid: valids(
+  valid: valids<RuleOptions>(
     {
       code: '<App />',
     },
@@ -134,7 +135,7 @@ run({
     },
   ),
 
-  invalid: invalids(
+  invalid: invalids<RuleOptions>(
     {
       code: `
         <App foo bar baz />;

--- a/packages/eslint-plugin/rules/jsx-newline/jsx-newline._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-newline/jsx-newline._jsx_.test.ts
@@ -4,11 +4,12 @@
  * @author Joseph Stiles
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-newline._jsx_'
 
-run({
+run<RuleOptions>({
   name: 'jsx-newline',
   rule,
   parserOptions: {
@@ -17,7 +18,7 @@ run({
     },
   },
 
-  valid: valids(
+  valid: valids<RuleOptions>(
     {
       code: `
         <div>
@@ -194,7 +195,7 @@ run({
       options: [{ prevent: true, allowMultilines: true }],
     },
   ),
-  invalid: invalids(
+  invalid: invalids<RuleOptions>(
     {
       code: `
         <div>

--- a/packages/eslint-plugin/rules/jsx-newline/jsx-newline._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-newline/jsx-newline._jsx_.test.ts
@@ -4,12 +4,12 @@
  * @author Joseph Stiles
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-newline._jsx_'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'jsx-newline',
   rule,
   parserOptions: {
@@ -195,7 +195,7 @@ run<RuleOptions>({
       options: [{ prevent: true, allowMultilines: true }],
     },
   ),
-  invalid: invalids<RuleOptions>(
+  invalid: invalids<RuleOptions, MessageIds>(
     {
       code: `
         <div>

--- a/packages/eslint-plugin/rules/jsx-one-expression-per-line/jsx-one-expression-per-line._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-one-expression-per-line/jsx-one-expression-per-line._jsx_.test.ts
@@ -3,12 +3,12 @@
  * @author Mark Ivan Allen <Vydia.com>
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-one-expression-per-line._jsx_'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'jsx-one-expression-per-line',
   rule,
   parserOptions: {
@@ -305,7 +305,7 @@ run<RuleOptions>({
     },
   ),
 
-  invalid: invalids<RuleOptions>(
+  invalid: invalids<RuleOptions, MessageIds>(
     {
       code: `
         <App>{"foo"}</App>

--- a/packages/eslint-plugin/rules/jsx-one-expression-per-line/jsx-one-expression-per-line._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-one-expression-per-line/jsx-one-expression-per-line._jsx_.test.ts
@@ -3,11 +3,12 @@
  * @author Mark Ivan Allen <Vydia.com>
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-one-expression-per-line._jsx_'
 
-run({
+run<RuleOptions>({
   name: 'jsx-one-expression-per-line',
   rule,
   parserOptions: {
@@ -16,7 +17,7 @@ run({
     },
   },
 
-  valid: valids(
+  valid: valids<RuleOptions>(
     {
       code: '<App />',
     },
@@ -304,7 +305,7 @@ run({
     },
   ),
 
-  invalid: invalids(
+  invalid: invalids<RuleOptions>(
     {
       code: `
         <App>{"foo"}</App>

--- a/packages/eslint-plugin/rules/jsx-pascal-case/jsx-pascal-case._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-pascal-case/jsx-pascal-case._jsx_.test.ts
@@ -6,12 +6,12 @@
  * @author Sukka [https://skk.moe]
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-pascal-case._jsx_'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'jsx-pascal-case',
   rule,
   parserOptions: {
@@ -121,7 +121,7 @@ run<RuleOptions>({
     },
   ]),
 
-  invalid: invalids<RuleOptions>([
+  invalid: invalids<RuleOptions, MessageIds>([
     {
       code: '<Test_component />',
       errors: [

--- a/packages/eslint-plugin/rules/jsx-pascal-case/jsx-pascal-case._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-pascal-case/jsx-pascal-case._jsx_.test.ts
@@ -6,11 +6,12 @@
  * @author Sukka [https://skk.moe]
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-pascal-case._jsx_'
 
-run({
+run<RuleOptions>({
   name: 'jsx-pascal-case',
   rule,
   parserOptions: {
@@ -19,7 +20,7 @@ run({
     },
   },
 
-  valid: valids([
+  valid: valids<RuleOptions>([
     {
     // The rule must not warn on components that start with a lowercase
     // because they are interpreted as HTML elements by React
@@ -120,7 +121,7 @@ run({
     },
   ]),
 
-  invalid: invalids([
+  invalid: invalids<RuleOptions>([
     {
       code: '<Test_component />',
       errors: [

--- a/packages/eslint-plugin/rules/jsx-props-no-multi-spaces/jsx-props-no-multi-spaces._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-props-no-multi-spaces/jsx-props-no-multi-spaces._jsx_.test.ts
@@ -3,11 +3,12 @@
  * @author Adrian Moennich
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-props-no-multi-spaces._jsx_'
 
-run({
+run<RuleOptions>({
   name: 'jsx-props-no-multi-spaces',
   rule,
   parserOptions: {
@@ -16,7 +17,7 @@ run({
     },
   },
 
-  valid: valids(
+  valid: valids<RuleOptions>(
     {
       code: `
         <App />
@@ -136,7 +137,7 @@ run({
     },
   ),
 
-  invalid: invalids(
+  invalid: invalids<RuleOptions>(
     {
       code: `
         <App  foo />

--- a/packages/eslint-plugin/rules/jsx-props-no-multi-spaces/jsx-props-no-multi-spaces._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-props-no-multi-spaces/jsx-props-no-multi-spaces._jsx_.test.ts
@@ -3,12 +3,12 @@
  * @author Adrian Moennich
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-props-no-multi-spaces._jsx_'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'jsx-props-no-multi-spaces',
   rule,
   parserOptions: {
@@ -137,7 +137,7 @@ run<RuleOptions>({
     },
   ),
 
-  invalid: invalids<RuleOptions>(
+  invalid: invalids<RuleOptions, MessageIds>(
     {
       code: `
         <App  foo />

--- a/packages/eslint-plugin/rules/jsx-quotes/jsx-quotes._js_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-quotes/jsx-quotes._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Mathias Schreck <https://github.com/lo1tuma>
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'jsx-quotes',
   rule,
   parserOptions: {

--- a/packages/eslint-plugin/rules/jsx-quotes/jsx-quotes._js_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-quotes/jsx-quotes._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Mathias Schreck <https://github.com/lo1tuma>
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'jsx-quotes',
   rule,
   parserOptions: {

--- a/packages/eslint-plugin/rules/jsx-self-closing-comp/jsx-self-closing-comp._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-self-closing-comp/jsx-self-closing-comp._jsx_.test.ts
@@ -3,12 +3,12 @@
  * @author Yannick Croissant
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-self-closing-comp._jsx_'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'self-closing-comp',
   rule,
   parserOptions: {
@@ -166,7 +166,7 @@ run<RuleOptions>({
     },
   ),
 
-  invalid: invalids<RuleOptions>(
+  invalid: invalids<RuleOptions, MessageIds>(
     {
       code: 'var contentContainer = <div className="content"></div>;',
       output: 'var contentContainer = <div className="content" />;',

--- a/packages/eslint-plugin/rules/jsx-self-closing-comp/jsx-self-closing-comp._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-self-closing-comp/jsx-self-closing-comp._jsx_.test.ts
@@ -3,11 +3,12 @@
  * @author Yannick Croissant
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-self-closing-comp._jsx_'
 
-run({
+run<RuleOptions>({
   name: 'self-closing-comp',
   rule,
   parserOptions: {
@@ -16,7 +17,7 @@ run({
     },
   },
 
-  valid: valids(
+  valid: valids<RuleOptions>(
     {
       code: 'var HelloJohn = <Hello name="John" />;',
     },
@@ -165,7 +166,7 @@ run({
     },
   ),
 
-  invalid: invalids(
+  invalid: invalids<RuleOptions>(
     {
       code: 'var contentContainer = <div className="content"></div>;',
       output: 'var contentContainer = <div className="content" />;',

--- a/packages/eslint-plugin/rules/jsx-sort-props/jsx-sort-props._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-sort-props/jsx-sort-props._jsx_.test.ts
@@ -3,43 +3,44 @@
  * @author Yannick Croissant
  */
 
-import type { RuleOptions } from './types'
+import type { TestCaseError } from '#test'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-sort-props._jsx_'
 
-const expectedError = {
+const expectedError: TestCaseError<MessageIds> = {
   messageId: 'sortPropsByAlpha',
   type: 'JSXIdentifier',
 }
-const expectedCallbackError = {
+const expectedCallbackError: TestCaseError<MessageIds> = {
   messageId: 'listCallbacksLast',
   type: 'JSXIdentifier',
 }
-const expectedShorthandFirstError = {
+const expectedShorthandFirstError: TestCaseError<MessageIds> = {
   messageId: 'listShorthandFirst',
   type: 'JSXIdentifier',
 }
-const expectedShorthandLastError = {
+const expectedShorthandLastError: TestCaseError<MessageIds> = {
   messageId: 'listShorthandLast',
   type: 'JSXIdentifier',
 }
-const expectedMultilineFirstError = {
+const expectedMultilineFirstError: TestCaseError<MessageIds> = {
   messageId: 'listMultilineFirst',
   type: 'JSXIdentifier',
 }
-const expectedMultilineLastError = {
+const expectedMultilineLastError: TestCaseError<MessageIds> = {
   messageId: 'listMultilineLast',
   type: 'JSXIdentifier',
 }
-const expectedReservedFirstError = {
+const expectedReservedFirstError: TestCaseError<MessageIds> = {
   messageId: 'listReservedPropsFirst',
   type: 'JSXIdentifier',
 }
-const expectedEmptyReservedFirstError = {
+const expectedEmptyReservedFirstError: TestCaseError<MessageIds> = {
   messageId: 'listIsEmpty',
 }
-const expectedInvalidReservedFirstError = {
+const expectedInvalidReservedFirstError: TestCaseError<MessageIds> = {
   messageId: 'noUnreservedProps',
   data: { unreservedWords: 'notReserved' },
 }
@@ -99,7 +100,7 @@ const multilineAndShorthandAndCallbackLastArgs: RuleOptions = [
   },
 ]
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'jsx-sort-props',
   rule,
   parserOptions: {
@@ -284,7 +285,7 @@ run<RuleOptions>({
       options: [{ locale: 'sk-SK' }],
     },
   ),
-  invalid: invalids<RuleOptions>(
+  invalid: invalids<RuleOptions, MessageIds>(
     {
       code: '<App b a />;',
       errors: [expectedError],

--- a/packages/eslint-plugin/rules/jsx-sort-props/jsx-sort-props._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-sort-props/jsx-sort-props._jsx_.test.ts
@@ -3,6 +3,7 @@
  * @author Yannick Croissant
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-sort-props._jsx_'
@@ -42,55 +43,55 @@ const expectedInvalidReservedFirstError = {
   messageId: 'noUnreservedProps',
   data: { unreservedWords: 'notReserved' },
 }
-const callbacksLastArgs = [{ callbacksLast: true }]
-const ignoreCaseAndCallbackLastArgs = [
+const callbacksLastArgs: RuleOptions = [{ callbacksLast: true }]
+const ignoreCaseAndCallbackLastArgs: RuleOptions = [
   {
     callbacksLast: true,
     ignoreCase: true,
   },
 ]
-const reservedFirstAndCallbacksLastArgs = [
+const reservedFirstAndCallbacksLastArgs: RuleOptions = [
   {
     callbacksLast: true,
     reservedFirst: true,
   },
 ]
-const shorthandFirstArgs = [{ shorthandFirst: true }]
-const shorthandLastArgs = [{ shorthandLast: true }]
-const shorthandAndCallbackLastArgs = [
+const shorthandFirstArgs: RuleOptions = [{ shorthandFirst: true }]
+const shorthandLastArgs: RuleOptions = [{ shorthandLast: true }]
+const shorthandAndCallbackLastArgs: RuleOptions = [
   {
     callbacksLast: true,
     shorthandLast: true,
   },
 ]
-const ignoreCaseArgs = [{ ignoreCase: true }]
-const noSortAlphabeticallyArgs = [{ noSortAlphabetically: true }]
-const sortAlphabeticallyArgs = [{ noSortAlphabetically: false }]
-const reservedFirstAsBooleanArgs = [{ reservedFirst: true }]
-const reservedFirstAsArrayArgs = [{ reservedFirst: ['children', 'dangerouslySetInnerHTML', 'key'] }]
-const reservedFirstWithNoSortAlphabeticallyArgs = [
+const ignoreCaseArgs: RuleOptions = [{ ignoreCase: true }]
+const noSortAlphabeticallyArgs: RuleOptions = [{ noSortAlphabetically: true }]
+const sortAlphabeticallyArgs: RuleOptions = [{ noSortAlphabetically: false }]
+const reservedFirstAsBooleanArgs: RuleOptions = [{ reservedFirst: true }]
+const reservedFirstAsArrayArgs: RuleOptions = [{ reservedFirst: ['children', 'dangerouslySetInnerHTML', 'key'] }]
+const reservedFirstWithNoSortAlphabeticallyArgs: RuleOptions = [
   {
     noSortAlphabetically: true,
     reservedFirst: true,
   },
 ]
-const reservedFirstWithShorthandLast = [
+const reservedFirstWithShorthandLast: RuleOptions = [
   {
     reservedFirst: true,
     shorthandLast: true,
   },
 ]
-const reservedFirstAsEmptyArrayArgs = [{ reservedFirst: [] }]
-const reservedFirstAsInvalidArrayArgs = [{ reservedFirst: ['notReserved'] }]
-const multilineFirstArgs = [{ multiline: 'first' }]
-const multilineAndShorthandFirstArgs = [
+const reservedFirstAsEmptyArrayArgs: RuleOptions = [{ reservedFirst: [] }]
+const reservedFirstAsInvalidArrayArgs: RuleOptions = [{ reservedFirst: ['notReserved'] }]
+const multilineFirstArgs: RuleOptions = [{ multiline: 'first' }]
+const multilineAndShorthandFirstArgs: RuleOptions = [
   {
     multiline: 'first',
     shorthandFirst: true,
   },
 ]
-const multilineLastArgs = [{ multiline: 'last' }]
-const multilineAndShorthandAndCallbackLastArgs = [
+const multilineLastArgs: RuleOptions = [{ multiline: 'last' }]
+const multilineAndShorthandAndCallbackLastArgs: RuleOptions = [
   {
     multiline: 'last',
     shorthandLast: true,
@@ -98,7 +99,7 @@ const multilineAndShorthandAndCallbackLastArgs = [
   },
 ]
 
-run({
+run<RuleOptions>({
   name: 'jsx-sort-props',
   rule,
   parserOptions: {
@@ -107,7 +108,7 @@ run({
     },
   },
 
-  valid: valids(
+  valid: valids<RuleOptions>(
     { code: '<App />;' },
     { code: '<App {...this.props} />;' },
     { code: '<App a b c />;' },
@@ -283,7 +284,7 @@ run({
       options: [{ locale: 'sk-SK' }],
     },
   ),
-  invalid: invalids(
+  invalid: invalids<RuleOptions>(
     {
       code: '<App b a />;',
       errors: [expectedError],

--- a/packages/eslint-plugin/rules/jsx-tag-spacing/jsx-tag-spacing._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-tag-spacing/jsx-tag-spacing._jsx_.test.ts
@@ -3,7 +3,7 @@
  * @author Diogo Franco (Kovensky)
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-tag-spacing._jsx_'
@@ -64,7 +64,7 @@ function beforeClosingOptions(option: Option['beforeClosing']): RuleOptions {
 // Tests
 // -----------------------------------------------------------------------------
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'jsx-tag-spacing',
   rule,
   lang: 'js',
@@ -290,7 +290,7 @@ run<RuleOptions>({
     },
   ),
 
-  invalid: invalids<RuleOptions>(
+  invalid: invalids<RuleOptions, MessageIds>(
     {
       code: '<App/>',
       output: '<App />',

--- a/packages/eslint-plugin/rules/jsx-tag-spacing/jsx-tag-spacing._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-tag-spacing/jsx-tag-spacing._jsx_.test.ts
@@ -16,7 +16,7 @@ type Option = Exclude<RuleOptions[0], undefined>
 
 // generate options object that disables checks other than the tested one
 
-function closingSlashOptions(option: Option['closingSlash']) {
+function closingSlashOptions(option: Option['closingSlash']): RuleOptions {
   return [
     {
       closingSlash: option,
@@ -27,7 +27,7 @@ function closingSlashOptions(option: Option['closingSlash']) {
   ]
 }
 
-function beforeSelfClosingOptions(option: Option['beforeSelfClosing']) {
+function beforeSelfClosingOptions(option: Option['beforeSelfClosing']): RuleOptions {
   return [
     {
       closingSlash: 'allow',
@@ -38,7 +38,7 @@ function beforeSelfClosingOptions(option: Option['beforeSelfClosing']) {
   ]
 }
 
-function afterOpeningOptions(option: Option['afterOpening']) {
+function afterOpeningOptions(option: Option['afterOpening']): RuleOptions {
   return [
     {
       closingSlash: 'allow',
@@ -49,7 +49,7 @@ function afterOpeningOptions(option: Option['afterOpening']) {
   ]
 }
 
-function beforeClosingOptions(option: Option['beforeClosing']) {
+function beforeClosingOptions(option: Option['beforeClosing']): RuleOptions {
   return [
     {
       closingSlash: 'allow',
@@ -64,7 +64,7 @@ function beforeClosingOptions(option: Option['beforeClosing']) {
 // Tests
 // -----------------------------------------------------------------------------
 
-run({
+run<RuleOptions>({
   name: 'jsx-tag-spacing',
   rule,
   lang: 'js',
@@ -74,7 +74,7 @@ run({
     },
   },
 
-  valid: valids(
+  valid: valids<RuleOptions>(
     {
       code: '<App />',
     },
@@ -290,7 +290,7 @@ run({
     },
   ),
 
-  invalid: invalids(
+  invalid: invalids<RuleOptions>(
     {
       code: '<App/>',
       output: '<App />',

--- a/packages/eslint-plugin/rules/jsx-wrap-multilines/jsx-wrap-multilines._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-wrap-multilines/jsx-wrap-multilines._jsx_.test.ts
@@ -3,6 +3,7 @@
  * @author Yannick Croissant
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-wrap-multilines._jsx_'
@@ -11,7 +12,7 @@ import rule from './jsx-wrap-multilines._jsx_'
 // Constants/Code Snippets
 // ------------------------------------------------------------------------------
 
-const OPTIONS_ALL_NEW_LINES = {
+const OPTIONS_ALL_NEW_LINES: RuleOptions[0] = {
   declaration: 'parens-new-line',
   assignment: 'parens-new-line',
   return: 'parens-new-line',
@@ -620,7 +621,7 @@ function addNewLineSymbols(code: string) {
   return code.replace(/\(</g, '(\n<').replace(/>\)/g, '>\n)')
 }
 
-run({
+run<RuleOptions>({
   name: 'jsx-wrap-multilines',
   rule,
   parserOptions: {
@@ -631,7 +632,7 @@ run({
     },
   },
 
-  valid: valids(
+  valid: valids<RuleOptions>(
     {
       code: RETURN_SINGLE_LINE,
     },
@@ -913,7 +914,7 @@ run({
     },
   ),
 
-  invalid: invalids(
+  invalid: invalids<RuleOptions>(
     {
       code: RETURN_NO_PAREN,
       output: RETURN_PAREN,

--- a/packages/eslint-plugin/rules/jsx-wrap-multilines/jsx-wrap-multilines._jsx_.test.ts
+++ b/packages/eslint-plugin/rules/jsx-wrap-multilines/jsx-wrap-multilines._jsx_.test.ts
@@ -3,7 +3,7 @@
  * @author Yannick Croissant
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-wrap-multilines._jsx_'
@@ -621,7 +621,7 @@ function addNewLineSymbols(code: string) {
   return code.replace(/\(</g, '(\n<').replace(/>\)/g, '>\n)')
 }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'jsx-wrap-multilines',
   rule,
   parserOptions: {
@@ -914,7 +914,7 @@ run<RuleOptions>({
     },
   ),
 
-  invalid: invalids<RuleOptions>(
+  invalid: invalids<RuleOptions, MessageIds>(
     {
       code: RETURN_NO_PAREN,
       output: RETURN_PAREN,

--- a/packages/eslint-plugin/rules/key-spacing/key-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/key-spacing/key-spacing._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Brandon Mills
  */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'key-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/key-spacing/key-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/key-spacing/key-spacing._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Brandon Mills
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'key-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/key-spacing/key-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/key-spacing/key-spacing._ts_.test.ts
@@ -1,11 +1,11 @@
 // this rule tests the new lines, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'key-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/key-spacing/key-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/key-spacing/key-spacing._ts_.test.ts
@@ -1,10 +1,11 @@
 // this rule tests the new lines, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'key-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._js_.test.ts
@@ -3,8 +3,8 @@
  * @author Toru Nagashima
  */
 
-import type { TestCase } from '#test'
-import type { RuleOptions } from './types'
+import type { CompatConfigOptions, TestCaseError } from '#test'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import tsParser from '@typescript-eslint/parser'
 import rule from '.'
@@ -47,7 +47,7 @@ function override(keyword: string, value: { before?: boolean, after?: boolean })
  * @param keyword A keyword.
  * @returns An error message.
  */
-function expectedBefore(keyword: string) {
+function expectedBefore(keyword: string): TestCaseError<MessageIds>[] {
   return [{ messageId: 'expectedBefore', data: { value: keyword } }]
 }
 
@@ -56,7 +56,7 @@ function expectedBefore(keyword: string) {
  * @param keyword A keyword.
  * @returns An error message.
  */
-function expectedAfter(keyword: string) {
+function expectedAfter(keyword: string): TestCaseError<MessageIds>[] {
   return [{ messageId: 'expectedAfter', data: { value: keyword } }]
 }
 
@@ -66,7 +66,7 @@ function expectedAfter(keyword: string) {
  * @param keyword A keyword.
  * @returns Error messages.
  */
-function expectedBeforeAndAfter(keyword: string) {
+function expectedBeforeAndAfter(keyword: string): TestCaseError<MessageIds>[] {
   return [
     { messageId: 'expectedBefore', data: { value: keyword } },
     { messageId: 'expectedAfter', data: { value: keyword } },
@@ -78,7 +78,7 @@ function expectedBeforeAndAfter(keyword: string) {
  * @param keyword A keyword.
  * @returns An error message.
  */
-function unexpectedBefore(keyword: string) {
+function unexpectedBefore(keyword: string): TestCaseError<MessageIds>[] {
   return [{ messageId: 'unexpectedBefore', data: { value: keyword } }]
 }
 
@@ -87,7 +87,7 @@ function unexpectedBefore(keyword: string) {
  * @param keyword A keyword.
  * @returns An error message.
  */
-function unexpectedAfter(keyword: string) {
+function unexpectedAfter(keyword: string): TestCaseError<MessageIds>[] {
   return [{ messageId: 'unexpectedAfter', data: { value: keyword } }]
 }
 
@@ -97,21 +97,21 @@ function unexpectedAfter(keyword: string) {
  * @param keyword A keyword.
  * @returns Error messages.
  */
-function unexpectedBeforeAndAfter(keyword: string) {
+function unexpectedBeforeAndAfter(keyword: string): TestCaseError<MessageIds>[] {
   return [
     { messageId: 'unexpectedBefore', data: { value: keyword } },
     { messageId: 'unexpectedAfter', data: { value: keyword } },
   ]
 }
 
-const OVERRIDES_WITH: Partial<TestCase> = {
+const OVERRIDES_WITH: CompatConfigOptions = {
   parserOptions: {
     ecmaVersion: 3,
     sourceType: 'script',
   },
 }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'keyword-spacing',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._js_.test.ts
@@ -4,6 +4,7 @@
  */
 
 import type { TestCase } from '#test'
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import tsParser from '@typescript-eslint/parser'
 import rule from '.'
@@ -110,7 +111,7 @@ const OVERRIDES_WITH: Partial<TestCase> = {
   },
 }
 
-run({
+run<RuleOptions>({
   name: 'keyword-spacing',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._ts_.test.ts
@@ -2,7 +2,7 @@
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
 import type { TestCaseError } from '#test'
-import type { RuleOptions } from './types._ts_'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
@@ -40,7 +40,7 @@ function overrides(keyword: string, value: RuleOptions[0] = {}): RuleOptions[0] 
  * @param keyword A keyword.
  * @returns An error message.
  */
-function expectedBefore(keyword: string): TestCaseError[] {
+function expectedBefore(keyword: string): TestCaseError<MessageIds>[] {
   return [{ messageId: 'expectedBefore', data: { value: keyword } }]
 }
 
@@ -49,7 +49,7 @@ function expectedBefore(keyword: string): TestCaseError[] {
  * @param keyword A keyword.
  * @returns An error message.
  */
-function expectedAfter(keyword: string): TestCaseError[] {
+function expectedAfter(keyword: string): TestCaseError<MessageIds>[] {
   return [{ messageId: 'expectedAfter', data: { value: keyword } }]
 }
 
@@ -60,7 +60,7 @@ function expectedAfter(keyword: string): TestCaseError[] {
  */
 function unexpectedBefore(
   keyword: string,
-): TestCaseError[] {
+): TestCaseError<MessageIds>[] {
   return [{ messageId: 'unexpectedBefore', data: { value: keyword } }]
 }
 
@@ -71,11 +71,11 @@ function unexpectedBefore(
  */
 function unexpectedAfter(
   keyword: string,
-): TestCaseError[] {
+): TestCaseError<MessageIds>[] {
   return [{ messageId: 'unexpectedAfter', data: { value: keyword } }]
 }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'keyword-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._ts_.test.ts
@@ -75,7 +75,7 @@ function unexpectedAfter(
   return [{ messageId: 'unexpectedAfter', data: { value: keyword } }]
 }
 
-run({
+run<RuleOptions>({
   name: 'keyword-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/line-comment-position/line-comment-position._js_.test.ts
+++ b/packages/eslint-plugin/rules/line-comment-position/line-comment-position._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Alberto Rodríguez
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'line-comment-position',
   rule,
 

--- a/packages/eslint-plugin/rules/line-comment-position/line-comment-position._js_.test.ts
+++ b/packages/eslint-plugin/rules/line-comment-position/line-comment-position._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Alberto Rodríguez
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'line-comment-position',
   rule,
 

--- a/packages/eslint-plugin/rules/linebreak-style/linebreak-style._js_.test.ts
+++ b/packages/eslint-plugin/rules/linebreak-style/linebreak-style._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Erik Mueller
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'linebreak-style',
   rule,
 

--- a/packages/eslint-plugin/rules/linebreak-style/linebreak-style._js_.test.ts
+++ b/packages/eslint-plugin/rules/linebreak-style/linebreak-style._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Erik Mueller
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'linebreak-style',
   rule,
 

--- a/packages/eslint-plugin/rules/lines-around-comment/lines-around-comment._js_.test.ts
+++ b/packages/eslint-plugin/rules/lines-around-comment/lines-around-comment._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Jamund Ferguson
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'lines-around-comment',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/lines-around-comment/lines-around-comment._js_.test.ts
+++ b/packages/eslint-plugin/rules/lines-around-comment/lines-around-comment._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Jamund Ferguson
  */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'lines-around-comment',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/lines-around-comment/lines-around-comment._ts_.test.ts
+++ b/packages/eslint-plugin/rules/lines-around-comment/lines-around-comment._ts_.test.ts
@@ -1,9 +1,9 @@
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import { AST_TOKEN_TYPES } from '@typescript-eslint/utils'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'lines-around-comment',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/lines-around-comment/lines-around-comment._ts_.test.ts
+++ b/packages/eslint-plugin/rules/lines-around-comment/lines-around-comment._ts_.test.ts
@@ -1,9 +1,9 @@
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
-
 import { AST_TOKEN_TYPES } from '@typescript-eslint/utils'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'lines-around-comment',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/lines-between-class-members/lines-between-class-members._js_.test.ts
+++ b/packages/eslint-plugin/rules/lines-between-class-members/lines-between-class-members._js_.test.ts
@@ -3,13 +3,14 @@
  * @author 薛定谔的猫<hh_2013@foxmail.com>
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
 const alwaysError = { messageId: 'always' }
 const neverError = { messageId: 'never' }
 
-run({
+run<RuleOptions>({
   name: 'lines-between-class-members',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/lines-between-class-members/lines-between-class-members._js_.test.ts
+++ b/packages/eslint-plugin/rules/lines-between-class-members/lines-between-class-members._js_.test.ts
@@ -3,14 +3,15 @@
  * @author 薛定谔的猫<hh_2013@foxmail.com>
  */
 
-import type { RuleOptions } from './types'
+import type { TestCaseError } from '#test'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-const alwaysError = { messageId: 'always' }
-const neverError = { messageId: 'never' }
+const alwaysError: TestCaseError<MessageIds> = { messageId: 'always' }
+const neverError: TestCaseError<MessageIds> = { messageId: 'never' }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'lines-between-class-members',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/lines-between-class-members/lines-between-class-members._ts_.test.ts
+++ b/packages/eslint-plugin/rules/lines-between-class-members/lines-between-class-members._ts_.test.ts
@@ -1,11 +1,11 @@
 // this rule tests the new lines, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'lines-between-class-members',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/lines-between-class-members/lines-between-class-members._ts_.test.ts
+++ b/packages/eslint-plugin/rules/lines-between-class-members/lines-between-class-members._ts_.test.ts
@@ -1,10 +1,11 @@
 // this rule tests the new lines, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'lines-between-class-members',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/max-len/max-len._js_.test.ts
+++ b/packages/eslint-plugin/rules/max-len/max-len._js_.test.ts
@@ -3,13 +3,13 @@
  * @author Matt DuVall <http://www.mattduvall.com>
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
 const parserOptions = { ecmaVersion: 6 } as const
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'max-len',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/max-len/max-len._js_.test.ts
+++ b/packages/eslint-plugin/rules/max-len/max-len._js_.test.ts
@@ -3,12 +3,13 @@
  * @author Matt DuVall <http://www.mattduvall.com>
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
 const parserOptions = { ecmaVersion: 6 } as const
 
-run({
+run<RuleOptions>({
   name: 'max-len',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/max-statements-per-line/max-statements-per-line._js_.test.ts
+++ b/packages/eslint-plugin/rules/max-statements-per-line/max-statements-per-line._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Kenneth Williams
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'max-statements-per-line',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/max-statements-per-line/max-statements-per-line._js_.test.ts
+++ b/packages/eslint-plugin/rules/max-statements-per-line/max-statements-per-line._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Kenneth Williams
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'max-statements-per-line',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/member-delimiter-style/member-delimiter-style._ts_.test.ts
+++ b/packages/eslint-plugin/rules/member-delimiter-style/member-delimiter-style._ts_.test.ts
@@ -1,10 +1,11 @@
 // this rule tests the delimiter, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'member-delimiter-style',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/member-delimiter-style/member-delimiter-style._ts_.test.ts
+++ b/packages/eslint-plugin/rules/member-delimiter-style/member-delimiter-style._ts_.test.ts
@@ -1,11 +1,11 @@
 // this rule tests the delimiter, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'member-delimiter-style',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style._js_.test.ts
+++ b/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style._js_.test.ts
@@ -2,10 +2,11 @@
  * @fileoverview enforce a particular style for multiline comments
  * @author Teddy Katz
  */
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'multiline-comment-style',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style._js_.test.ts
+++ b/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style._js_.test.ts
@@ -2,11 +2,11 @@
  * @fileoverview enforce a particular style for multiline comments
  * @author Teddy Katz
  */
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'multiline-comment-style',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/multiline-ternary/multiline-ternary._js_.test.ts
+++ b/packages/eslint-plugin/rules/multiline-ternary/multiline-ternary._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Kai Cataldo
  */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'multiline-ternary',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/multiline-ternary/multiline-ternary._js_.test.ts
+++ b/packages/eslint-plugin/rules/multiline-ternary/multiline-ternary._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Kai Cataldo
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'multiline-ternary',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/new-parens/new-parens._js_.test.ts
+++ b/packages/eslint-plugin/rules/new-parens/new-parens._js_.test.ts
@@ -3,15 +3,16 @@
  * @author Ilya Volodin
  */
 
-import type { RuleOptions } from './types'
+import type { TestCaseError } from '#test'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import tsParser from '@typescript-eslint/parser'
 import rule from '.'
 
-const error = { messageId: 'missing', type: 'NewExpression' }
-const neverError = { messageId: 'unnecessary', type: 'NewExpression' }
+const error: TestCaseError<MessageIds> = { messageId: 'missing', type: 'NewExpression' }
+const neverError: TestCaseError<MessageIds> = { messageId: 'unnecessary', type: 'NewExpression' }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'new-parens',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/new-parens/new-parens._js_.test.ts
+++ b/packages/eslint-plugin/rules/new-parens/new-parens._js_.test.ts
@@ -3,6 +3,7 @@
  * @author Ilya Volodin
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import tsParser from '@typescript-eslint/parser'
 import rule from '.'
@@ -10,7 +11,7 @@ import rule from '.'
 const error = { messageId: 'missing', type: 'NewExpression' }
 const neverError = { messageId: 'unnecessary', type: 'NewExpression' }
 
-run({
+run<RuleOptions>({
   name: 'new-parens',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/newline-per-chained-call/newline-per-chained-call._js_.test.ts
+++ b/packages/eslint-plugin/rules/newline-per-chained-call/newline-per-chained-call._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Rajendra Patil
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'newline-per-chained-call',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/newline-per-chained-call/newline-per-chained-call._js_.test.ts
+++ b/packages/eslint-plugin/rules/newline-per-chained-call/newline-per-chained-call._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Rajendra Patil
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'newline-per-chained-call',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/no-confusing-arrow/no-confusing-arrow._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-confusing-arrow/no-confusing-arrow._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Jxck <https://github.com/Jxck>
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'no-confusing-arrow',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/no-confusing-arrow/no-confusing-arrow._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-confusing-arrow/no-confusing-arrow._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Jxck <https://github.com/Jxck>
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'no-confusing-arrow',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.test.ts
@@ -3,6 +3,7 @@
  * @author Michael Ficarra
  */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import tsParser from '@typescript-eslint/parser'
 import rule from '.'
@@ -35,7 +36,7 @@ function invalid(code: string, output: string | null, type?: string, line?: numb
   return result
 }
 
-run({
+run<RuleOptions>({
   name: 'no-extra-parens',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.test.ts
@@ -3,7 +3,8 @@
  * @author Michael Ficarra
  */
 
-import type { RuleOptions } from './types'
+import type { InvalidTestCase } from '#test'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import tsParser from '@typescript-eslint/parser'
 import rule from '.'
@@ -18,8 +19,8 @@ import rule from '.'
  * @returns result object
  * @private
  */
-function invalid(code: string, output: string | null, type?: string, line?: number | null, config?: any) {
-  const result = {
+function invalid(code: string, output: string | null, type?: string, line?: number | null, config?: any): InvalidTestCase<RuleOptions, MessageIds> {
+  return {
     code,
     output,
     parserOptions: config && config.parserOptions || {},
@@ -32,11 +33,9 @@ function invalid(code: string, output: string | null, type?: string, line?: numb
     ],
     options: config && config.options || [],
   }
-
-  return result
 }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'no-extra-parens',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.test.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.test.ts
@@ -1,10 +1,11 @@
 // this rule tests extra parens, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'no-extra-parens',
   rule,
   parserOptions: {

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.test.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.test.ts
@@ -1,11 +1,11 @@
 // this rule tests extra parens, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'no-extra-parens',
   rule,
   parserOptions: {

--- a/packages/eslint-plugin/rules/no-extra-semi/no-extra-semi._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-extra-semi/no-extra-semi._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Nicholas C. Zakas
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'no-extra-semi',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/no-extra-semi/no-extra-semi._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-extra-semi/no-extra-semi._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Nicholas C. Zakas
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'no-extra-semi',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/no-extra-semi/no-extra-semi._ts_.test.ts
+++ b/packages/eslint-plugin/rules/no-extra-semi/no-extra-semi._ts_.test.ts
@@ -1,10 +1,11 @@
 // this rule tests semis, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'no-extra-semi',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/no-extra-semi/no-extra-semi._ts_.test.ts
+++ b/packages/eslint-plugin/rules/no-extra-semi/no-extra-semi._ts_.test.ts
@@ -1,11 +1,11 @@
 // this rule tests semis, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'no-extra-semi',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/no-floating-decimal/no-floating-decimal._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-floating-decimal/no-floating-decimal._js_.test.ts
@@ -3,13 +3,14 @@
  * @author James Allardice
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
 const leadingError = { messageId: 'leading', type: 'Literal' }
 const trailingError = { messageId: 'trailing', type: 'Literal' }
 
-run({
+run<RuleOptions>({
   name: 'no-floating-decimal',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/no-floating-decimal/no-floating-decimal._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-floating-decimal/no-floating-decimal._js_.test.ts
@@ -3,14 +3,15 @@
  * @author James Allardice
  */
 
-import type { RuleOptions } from './types'
+import type { TestCaseError } from '#test'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-const leadingError = { messageId: 'leading', type: 'Literal' }
-const trailingError = { messageId: 'trailing', type: 'Literal' }
+const leadingError: TestCaseError<MessageIds> = { messageId: 'leading', type: 'Literal' }
+const trailingError: TestCaseError<MessageIds> = { messageId: 'trailing', type: 'Literal' }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'no-floating-decimal',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/no-mixed-operators/no-mixed-operators._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-mixed-operators/no-mixed-operators._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Toru Nagashima
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'no-mixed-operators',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/no-mixed-operators/no-mixed-operators._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-mixed-operators/no-mixed-operators._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Toru Nagashima
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'no-mixed-operators',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/no-mixed-spaces-and-tabs/no-mixed-spaces-and-tabs._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-mixed-spaces-and-tabs/no-mixed-spaces-and-tabs._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Jary Niebur
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'no-mixed-spaces-and-tabs',
   rule,
 

--- a/packages/eslint-plugin/rules/no-mixed-spaces-and-tabs/no-mixed-spaces-and-tabs._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-mixed-spaces-and-tabs/no-mixed-spaces-and-tabs._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Jary Niebur
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'no-mixed-spaces-and-tabs',
   rule,
 

--- a/packages/eslint-plugin/rules/no-multi-spaces/no-multi-spaces._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-multi-spaces/no-multi-spaces._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Vignesh Anand aka vegetableman
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'no-multi-spaces',
   rule,
 

--- a/packages/eslint-plugin/rules/no-multi-spaces/no-multi-spaces._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-multi-spaces/no-multi-spaces._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Vignesh Anand aka vegetableman
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'no-multi-spaces',
   rule,
 

--- a/packages/eslint-plugin/rules/no-multiple-empty-lines/no-multiple-empty-lines._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-multiple-empty-lines/no-multiple-empty-lines._js_.test.ts
@@ -3,7 +3,8 @@
  * @author Greg Cochard
  */
 
-import type { RuleOptions } from './types'
+import type { TestCaseError } from '#test'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
@@ -13,7 +14,7 @@ import rule from '.'
  * @returns the expected error message object
  * @private
  */
-function getExpectedError(lines: number) {
+function getExpectedError(lines: number): TestCaseError<MessageIds> {
   return {
     messageId: 'consecutiveBlank',
     data: {
@@ -31,7 +32,7 @@ function getExpectedError(lines: number) {
  * @returns the expected error message object
  * @private
  */
-function getExpectedErrorEOF(lines: number) {
+function getExpectedErrorEOF(lines: number): TestCaseError<MessageIds> {
   return {
     messageId: 'blankEndOfFile',
     data: {
@@ -48,7 +49,7 @@ function getExpectedErrorEOF(lines: number) {
  * @returns the expected error message object
  * @private
  */
-function getExpectedErrorBOF(lines: number) {
+function getExpectedErrorBOF(lines: number): TestCaseError<MessageIds> {
   return {
     messageId: 'blankBeginningOfFile',
     data: {
@@ -59,7 +60,7 @@ function getExpectedErrorBOF(lines: number) {
   }
 }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'no-multiple-empty-lines',
   rule,
 

--- a/packages/eslint-plugin/rules/no-multiple-empty-lines/no-multiple-empty-lines._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-multiple-empty-lines/no-multiple-empty-lines._js_.test.ts
@@ -3,6 +3,7 @@
  * @author Greg Cochard
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
@@ -58,7 +59,7 @@ function getExpectedErrorBOF(lines: number) {
   }
 }
 
-run({
+run<RuleOptions>({
   name: 'no-multiple-empty-lines',
   rule,
 

--- a/packages/eslint-plugin/rules/no-tabs/no-tabs._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-tabs/no-tabs._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Gyandeep Singh
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'no-tabs',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/no-tabs/no-tabs._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-tabs/no-tabs._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Gyandeep Singh
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'no-tabs',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/no-trailing-spaces/no-trailing-spaces._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-trailing-spaces/no-trailing-spaces._js_.test.ts
@@ -2,10 +2,11 @@
  * @fileoverview Disallow trailing spaces at the end of lines.
  * @author Nodeca Team <https://github.com/nodeca>
  */
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'no-trailing-spaces',
   rule,
 

--- a/packages/eslint-plugin/rules/no-trailing-spaces/no-trailing-spaces._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-trailing-spaces/no-trailing-spaces._js_.test.ts
@@ -2,11 +2,11 @@
  * @fileoverview Disallow trailing spaces at the end of lines.
  * @author Nodeca Team <https://github.com/nodeca>
  */
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'no-trailing-spaces',
   rule,
 

--- a/packages/eslint-plugin/rules/no-whitespace-before-property/no-whitespace-before-property._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-whitespace-before-property/no-whitespace-before-property._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Kai Cataldo
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'no-whitespace-before-property',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/no-whitespace-before-property/no-whitespace-before-property._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-whitespace-before-property/no-whitespace-before-property._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Kai Cataldo
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'no-whitespace-before-property',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/nonblock-statement-body-position/nonblock-statement-body-position._js_.test.ts
+++ b/packages/eslint-plugin/rules/nonblock-statement-body-position/nonblock-statement-body-position._js_.test.ts
@@ -3,14 +3,15 @@
  * @author Teddy Katz
  */
 
-import type { RuleOptions } from './types'
+import type { TestCaseError } from '#test'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-const EXPECTED_LINEBREAK = { messageId: 'expectLinebreak' }
-const UNEXPECTED_LINEBREAK = { messageId: 'expectNoLinebreak' }
+const EXPECTED_LINEBREAK: TestCaseError<MessageIds> = { messageId: 'expectLinebreak' }
+const UNEXPECTED_LINEBREAK: TestCaseError<MessageIds> = { messageId: 'expectNoLinebreak' }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'nonblock-statement-body-position',
   rule,
 

--- a/packages/eslint-plugin/rules/nonblock-statement-body-position/nonblock-statement-body-position._js_.test.ts
+++ b/packages/eslint-plugin/rules/nonblock-statement-body-position/nonblock-statement-body-position._js_.test.ts
@@ -3,13 +3,14 @@
  * @author Teddy Katz
  */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
 const EXPECTED_LINEBREAK = { messageId: 'expectLinebreak' }
 const UNEXPECTED_LINEBREAK = { messageId: 'expectNoLinebreak' }
 
-run({
+run<RuleOptions>({
   name: 'nonblock-statement-body-position',
   rule,
 

--- a/packages/eslint-plugin/rules/object-curly-newline/object-curly-newline._js_.test.ts
+++ b/packages/eslint-plugin/rules/object-curly-newline/object-curly-newline._js_.test.ts
@@ -3,11 +3,12 @@
  * @author Toru Nagashima
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { languageOptionsForBabelFlow } from '#test/parsers-flow'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'object-curly-newline',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/object-curly-newline/object-curly-newline._js_.test.ts
+++ b/packages/eslint-plugin/rules/object-curly-newline/object-curly-newline._js_.test.ts
@@ -3,12 +3,12 @@
  * @author Toru Nagashima
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { languageOptionsForBabelFlow } from '#test/parsers-flow'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'object-curly-newline',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/object-curly-newline/object-curly-newline._ts_.test.ts
+++ b/packages/eslint-plugin/rules/object-curly-newline/object-curly-newline._ts_.test.ts
@@ -47,7 +47,7 @@ function createInvalidRule(input: string[], out: string[], err: TestCaseError[],
   })
 }
 
-run({
+run<RuleOptions>({
   name: 'object-curly-newline',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/object-curly-newline/object-curly-newline._ts_.test.ts
+++ b/packages/eslint-plugin/rules/object-curly-newline/object-curly-newline._ts_.test.ts
@@ -253,7 +253,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'expectedLinebreakAfterOpeningBrace' },
           { line: 1, column: 2, messageId: 'expectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -267,7 +267,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'expectedLinebreakAfterOpeningBrace' },
           { line: 1, column: 12, messageId: 'expectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -281,7 +281,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'expectedLinebreakAfterOpeningBrace' },
           { line: 1, column: 21, messageId: 'expectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -297,7 +297,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'expectedLinebreakAfterOpeningBrace' },
           { line: 2, column: 12, messageId: 'expectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
     ].flatMap(c => createInvalidRule(c.code, c.output, c.errors, 'always')),
     ...[
@@ -312,7 +312,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'unexpectedLinebreakAfterOpeningBrace' },
           { line: 2, column: 1, messageId: 'unexpectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -326,7 +326,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'unexpectedLinebreakAfterOpeningBrace' },
           { line: 3, column: 1, messageId: 'unexpectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -340,7 +340,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'unexpectedLinebreakAfterOpeningBrace' },
           { line: 3, column: 1, messageId: 'unexpectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -356,7 +356,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'unexpectedLinebreakAfterOpeningBrace' },
           { line: 4, column: 1, messageId: 'unexpectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
     ].flatMap(c => createInvalidRule(c.code, c.output, c.errors, 'never')),
     ...[
@@ -371,7 +371,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'unexpectedLinebreakAfterOpeningBrace' },
           { line: 2, column: 1, messageId: 'unexpectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -385,7 +385,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'unexpectedLinebreakAfterOpeningBrace' },
           { line: 3, column: 1, messageId: 'unexpectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -399,7 +399,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'unexpectedLinebreakAfterOpeningBrace' },
           { line: 3, column: 1, messageId: 'unexpectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -415,7 +415,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'expectedLinebreakAfterOpeningBrace' },
           { line: 2, column: 12, messageId: 'expectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
     ].flatMap(c => createInvalidRule(c.code, c.output, c.errors, { multiline: true })),
     ...[
@@ -430,7 +430,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'unexpectedLinebreakAfterOpeningBrace' },
           { line: 2, column: 1, messageId: 'unexpectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -444,7 +444,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'unexpectedLinebreakAfterOpeningBrace' },
           { line: 3, column: 1, messageId: 'unexpectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -458,7 +458,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'expectedLinebreakAfterOpeningBrace' },
           { line: 1, column: 21, messageId: 'expectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -474,7 +474,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'expectedLinebreakAfterOpeningBrace' },
           { line: 2, column: 12, messageId: 'expectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
     ].flatMap(c => createInvalidRule(c.code, c.output, c.errors, { minProperties: 2 })),
     ...[
@@ -488,7 +488,7 @@ run<RuleOptions, MessageIds>({
         ],
         errors: [
           { line: 2, column: 1, messageId: 'unexpectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -500,7 +500,7 @@ run<RuleOptions, MessageIds>({
         ],
         errors: [
           { line: 1, column: 1, messageId: 'unexpectedLinebreakAfterOpeningBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -512,7 +512,7 @@ run<RuleOptions, MessageIds>({
         ],
         errors: [
           { line: 2, column: 1, messageId: 'unexpectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -524,7 +524,7 @@ run<RuleOptions, MessageIds>({
         ],
         errors: [
           { line: 1, column: 1, messageId: 'unexpectedLinebreakAfterOpeningBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
     ].flatMap(c => [
       ...createInvalidRule(c.code, c.output, c.errors),
@@ -542,7 +542,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'unexpectedLinebreakAfterOpeningBrace' },
           { line: 2, column: 1, messageId: 'unexpectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -556,7 +556,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'unexpectedLinebreakAfterOpeningBrace' },
           { line: 3, column: 1, messageId: 'unexpectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -572,7 +572,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'expectedLinebreakAfterOpeningBrace' },
           { line: 2, column: 12, messageId: 'expectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
     ].flatMap(c => createInvalidRule(c.code, c.output, c.errors, { multiline: true, minProperties: 2 })),
     ...[
@@ -586,7 +586,7 @@ run<RuleOptions, MessageIds>({
         ],
         errors: [
           { line: 2, column: 1, messageId: 'unexpectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -598,7 +598,7 @@ run<RuleOptions, MessageIds>({
         ],
         errors: [
           { line: 1, column: 1, messageId: 'unexpectedLinebreakAfterOpeningBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -610,7 +610,7 @@ run<RuleOptions, MessageIds>({
         ],
         errors: [
           { line: 2, column: 1, messageId: 'unexpectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -622,7 +622,7 @@ run<RuleOptions, MessageIds>({
         ],
         errors: [
           { line: 1, column: 1, messageId: 'unexpectedLinebreakAfterOpeningBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -638,7 +638,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'expectedLinebreakAfterOpeningBrace' },
           { line: 2, column: 12, messageId: 'expectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
     ].flatMap(c => createInvalidRule(c.code, c.output, c.errors, { multiline: true, consistent: true })),
     ...[
@@ -654,7 +654,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'expectedLinebreakAfterOpeningBrace' },
           { line: 1, column: 21, messageId: 'expectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -670,7 +670,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'expectedLinebreakAfterOpeningBrace' },
           { line: 2, column: 12, messageId: 'expectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
     ].flatMap(c => createInvalidRule(c.code, c.output, c.errors, { minProperties: 2, consistent: true })),
     ...[
@@ -686,7 +686,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'expectedLinebreakAfterOpeningBrace' },
           { line: 1, column: 21, messageId: 'expectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -702,7 +702,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 1, messageId: 'expectedLinebreakAfterOpeningBrace' },
           { line: 2, column: 12, messageId: 'expectedLinebreakBeforeClosingBrace' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
     ].flatMap(c => createInvalidRule(c.code, c.output, c.errors, { multiline: true, minProperties: 2, consistent: true })),
   ],

--- a/packages/eslint-plugin/rules/object-curly-newline/object-curly-newline._ts_.test.ts
+++ b/packages/eslint-plugin/rules/object-curly-newline/object-curly-newline._ts_.test.ts
@@ -1,6 +1,6 @@
-import type { TestCaseError } from '#test'
+import type { InvalidTestCase, TestCaseError } from '#test'
 import type { NodeTypes } from '#types'
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
@@ -25,7 +25,7 @@ function createValidRule(input: string[], options?: RuleOptions[0]) {
   )
 }
 
-function createInvalidRule(input: string[], out: string[], err: TestCaseError[], options?: RuleOptions[0]) {
+function createInvalidRule(input: string[], out: string[], err: TestCaseError<MessageIds>[], options?: RuleOptions[0]): InvalidTestCase<RuleOptions, MessageIds>[] {
   // add comment for better experience in `vitest` extension
   const code = `${input.join('\n')}// ${JSON.stringify(options) || 'default'}`
   const output = `${out.join('\n')}// ${JSON.stringify(options) || 'default'}`
@@ -47,7 +47,7 @@ function createInvalidRule(input: string[], out: string[], err: TestCaseError[],
   })
 }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'object-curly-newline',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing._js_.test.ts
@@ -3,12 +3,12 @@
  * @author Jamund Ferguson
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { languageOptionsForBabelFlow } from '#test/parsers-flow'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'object-curly-spacing',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing._js_.test.ts
@@ -3,11 +3,12 @@
  * @author Jamund Ferguson
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { languageOptionsForBabelFlow } from '#test/parsers-flow'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'object-curly-spacing',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing._ts_.test.ts
@@ -1,12 +1,12 @@
 // this rule tests the position of braces, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'object-curly-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing._ts_.test.ts
@@ -1,12 +1,12 @@
 // this rule tests the position of braces, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
-
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'object-curly-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/object-property-newline/object-property-newline._js_.test.ts
+++ b/packages/eslint-plugin/rules/object-property-newline/object-property-newline._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Vitor Balocco
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'object-property-newline',
   rule,
 

--- a/packages/eslint-plugin/rules/object-property-newline/object-property-newline._js_.test.ts
+++ b/packages/eslint-plugin/rules/object-property-newline/object-property-newline._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Vitor Balocco
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'object-property-newline',
   rule,
 

--- a/packages/eslint-plugin/rules/object-property-newline/object-property-newline._ts_.test.ts
+++ b/packages/eslint-plugin/rules/object-property-newline/object-property-newline._ts_.test.ts
@@ -92,7 +92,7 @@ run<RuleOptions, MessageIds>({
         ],
         errors: [
           { line: 1, column: 16, messageId: 'propertiesOnNewline' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -108,7 +108,7 @@ run<RuleOptions, MessageIds>({
         ],
         errors: [
           { line: 2, column: 15, messageId: 'propertiesOnNewline' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -122,7 +122,7 @@ run<RuleOptions, MessageIds>({
         errors: [
           { line: 1, column: 15, messageId: 'propertiesOnNewline' },
           { line: 1, column: 29, messageId: 'propertiesOnNewline' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
     ].flatMap<InvalidTestCase<RuleOptions, MessageIds>>(c => createInvalidRule(c.code, c.output, c.errors, false)),
     ...([
@@ -138,7 +138,7 @@ run<RuleOptions, MessageIds>({
         ],
         errors: [
           { line: 1, column: 16, messageId: 'propertiesOnNewlineAll' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
       {
         code: [
@@ -154,7 +154,7 @@ run<RuleOptions, MessageIds>({
         ],
         errors: [
           { line: 2, column: 15, messageId: 'propertiesOnNewlineAll' },
-        ],
+        ] as TestCaseError<MessageIds>[],
       },
     ]).flatMap<InvalidTestCase<RuleOptions, MessageIds>>(c => createInvalidRule(c.code, c.output, c.errors, true)),
   ],

--- a/packages/eslint-plugin/rules/object-property-newline/object-property-newline._ts_.test.ts
+++ b/packages/eslint-plugin/rules/object-property-newline/object-property-newline._ts_.test.ts
@@ -1,6 +1,6 @@
 import type { InvalidTestCase, TestCaseError, ValidTestCase } from '#test'
 import type { NodeTypes } from '#types'
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
@@ -25,7 +25,7 @@ function createValidRule(input: string[], option: boolean) {
   })
 }
 
-function createInvalidRule(input: string[], out: string[], err: TestCaseError[], option: boolean) {
+function createInvalidRule(input: string[], out: string[], err: TestCaseError<MessageIds>[], option: boolean) {
   // add comment for better experience in `vitest` extension
   const code = `${input.join('\n')}// ${JSON.stringify(option) || 'default'}`
   const output = `${out.join('\n')}// ${JSON.stringify(option) || 'default'}`
@@ -36,7 +36,7 @@ function createInvalidRule(input: string[], out: string[], err: TestCaseError[],
       column: e.line === 1 && typeof e.column === 'number' ? e.column + prefix.length : e.column,
     }))
 
-    const res: InvalidTestCase<RuleOptions>[] = [
+    const res: InvalidTestCase<RuleOptions, MessageIds>[] = [
       { code: `${prefix}${code}`, output: `${prefix}${output}`, errors, options: [{ allowAllPropertiesOnSameLine: option }] },
       { code: `${prefix}${code}`, output: `${prefix}${output}`, errors, options: [{ /* deprecated */ allowMultiplePropertiesPerLine: option }] },
     ]
@@ -47,7 +47,7 @@ function createInvalidRule(input: string[], out: string[], err: TestCaseError[],
   })
 }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'object-property-newline',
   rule,
   valid: [
@@ -124,8 +124,8 @@ run<RuleOptions>({
           { line: 1, column: 29, messageId: 'propertiesOnNewline' },
         ],
       },
-    ].flatMap(c => createInvalidRule(c.code, c.output, c.errors, false)),
-    ...[
+    ].flatMap<InvalidTestCase<RuleOptions, MessageIds>>(c => createInvalidRule(c.code, c.output, c.errors, false)),
+    ...([
       {
         code: [
           '{  id: number; name: string;',
@@ -156,6 +156,6 @@ run<RuleOptions>({
           { line: 2, column: 15, messageId: 'propertiesOnNewlineAll' },
         ],
       },
-    ].flatMap(c => createInvalidRule(c.code, c.output, c.errors, true)),
+    ]).flatMap<InvalidTestCase<RuleOptions, MessageIds>>(c => createInvalidRule(c.code, c.output, c.errors, true)),
   ],
 })

--- a/packages/eslint-plugin/rules/object-property-newline/object-property-newline._ts_.test.ts
+++ b/packages/eslint-plugin/rules/object-property-newline/object-property-newline._ts_.test.ts
@@ -1,5 +1,6 @@
 import type { InvalidTestCase, TestCaseError, ValidTestCase } from '#test'
 import type { NodeTypes } from '#types'
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
@@ -13,7 +14,7 @@ function createValidRule(input: string[], option: boolean) {
   const code = `${input.join('\n')}// ${JSON.stringify(option) || 'default'}`
 
   return Object.entries(prefixOfNodes).flatMap(([_, prefix]) => {
-    const res: ValidTestCase[] = [
+    const res: ValidTestCase<RuleOptions>[] = [
       { code: `${prefix}${code}`, options: [{ allowAllPropertiesOnSameLine: option }] },
       { code: `${prefix}${code}`, options: [{ /* deprecated */ allowMultiplePropertiesPerLine: option }] },
     ]
@@ -35,7 +36,7 @@ function createInvalidRule(input: string[], out: string[], err: TestCaseError[],
       column: e.line === 1 && typeof e.column === 'number' ? e.column + prefix.length : e.column,
     }))
 
-    const res: InvalidTestCase[] = [
+    const res: InvalidTestCase<RuleOptions>[] = [
       { code: `${prefix}${code}`, output: `${prefix}${output}`, errors, options: [{ allowAllPropertiesOnSameLine: option }] },
       { code: `${prefix}${code}`, output: `${prefix}${output}`, errors, options: [{ /* deprecated */ allowMultiplePropertiesPerLine: option }] },
     ]
@@ -46,7 +47,7 @@ function createInvalidRule(input: string[], out: string[], err: TestCaseError[],
   })
 }
 
-run({
+run<RuleOptions>({
   name: 'object-property-newline',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/one-var-declaration-per-line/one-var-declaration-per-line._js_.test.ts
+++ b/packages/eslint-plugin/rules/one-var-declaration-per-line/one-var-declaration-per-line._js_.test.ts
@@ -3,7 +3,8 @@
  * @author Alberto Rodríguez
  */
 
-import type { RuleOptions } from './types'
+import type { TestCaseError } from '#test'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
@@ -18,7 +19,7 @@ import rule from '.'
  * @param column column number
  * @returns Error object
  */
-function errorAt(line: number, column: number) {
+function errorAt(line: number, column: number): TestCaseError<MessageIds> {
   return {
     messageId: 'expectVarOnNewline',
     type: 'VariableDeclaration',
@@ -27,7 +28,7 @@ function errorAt(line: number, column: number) {
   }
 }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'one-var-declaration-per-line',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/one-var-declaration-per-line/one-var-declaration-per-line._js_.test.ts
+++ b/packages/eslint-plugin/rules/one-var-declaration-per-line/one-var-declaration-per-line._js_.test.ts
@@ -3,6 +3,7 @@
  * @author Alberto Rodríguez
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
@@ -26,7 +27,7 @@ function errorAt(line: number, column: number) {
   }
 }
 
-run({
+run<RuleOptions>({
   name: 'one-var-declaration-per-line',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/operator-linebreak/operator-linebreak._js_.test.ts
+++ b/packages/eslint-plugin/rules/operator-linebreak/operator-linebreak._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Benoît Zugmeyer
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'operator-linebreak',
   rule,
 

--- a/packages/eslint-plugin/rules/operator-linebreak/operator-linebreak._js_.test.ts
+++ b/packages/eslint-plugin/rules/operator-linebreak/operator-linebreak._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Benoît Zugmeyer
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'operator-linebreak',
   rule,
 

--- a/packages/eslint-plugin/rules/padded-blocks/padded-blocks._js_.test.ts
+++ b/packages/eslint-plugin/rules/padded-blocks/padded-blocks._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Mathias Schreck <https://github.com/lo1tuma>
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'padded-blocks',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/padded-blocks/padded-blocks._js_.test.ts
+++ b/packages/eslint-plugin/rules/padded-blocks/padded-blocks._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Mathias Schreck <https://github.com/lo1tuma>
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'padded-blocks',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements._js_.test.ts
+++ b/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Toru Nagashima
  */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'padding-line-between-statements',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements._js_.test.ts
+++ b/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Toru Nagashima
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'padding-line-between-statements',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements._ts_.test.ts
+++ b/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements._ts_.test.ts
@@ -1,10 +1,11 @@
 // this rule tests new lines which prettier tries to fix, breaking the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'padding-line-between-statements',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements._ts_.test.ts
+++ b/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements._ts_.test.ts
@@ -1,11 +1,11 @@
 // this rule tests new lines which prettier tries to fix, breaking the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'padding-line-between-statements',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/quote-props/quote-props._js_.test.ts
+++ b/packages/eslint-plugin/rules/quote-props/quote-props._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Mathias Bynens <http://mathiasbynens.be/>
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'quote-props',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/quote-props/quote-props._js_.test.ts
+++ b/packages/eslint-plugin/rules/quote-props/quote-props._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Mathias Bynens <http://mathiasbynens.be/>
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'quote-props',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/quote-props/quote-props._ts_.test.ts
+++ b/packages/eslint-plugin/rules/quote-props/quote-props._ts_.test.ts
@@ -1,7 +1,8 @@
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'quote-props',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/quote-props/quote-props._ts_.test.ts
+++ b/packages/eslint-plugin/rules/quote-props/quote-props._ts_.test.ts
@@ -1,8 +1,8 @@
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'quote-props',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/quotes/quotes._js_.test.ts
+++ b/packages/eslint-plugin/rules/quotes/quotes._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Matt DuVall <http://www.mattduvall.com/>, Michael Paulukonis
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'quotes',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/quotes/quotes._js_.test.ts
+++ b/packages/eslint-plugin/rules/quotes/quotes._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Matt DuVall <http://www.mattduvall.com/>, Michael Paulukonis
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'quotes',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/quotes/quotes._ts_.test.ts
+++ b/packages/eslint-plugin/rules/quotes/quotes._ts_.test.ts
@@ -1,7 +1,7 @@
 // this rule tests quotes, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
@@ -26,7 +26,7 @@ const useBacktick = {
   },
 }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'quotes',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/quotes/quotes._ts_.test.ts
+++ b/packages/eslint-plugin/rules/quotes/quotes._ts_.test.ts
@@ -1,6 +1,7 @@
 // this rule tests quotes, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
@@ -25,7 +26,7 @@ const useBacktick = {
   },
 }
 
-run({
+run<RuleOptions>({
   name: 'quotes',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/rest-spread-spacing/rest-spread-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/rest-spread-spacing/rest-spread-spacing._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Kai Cataldo
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'rest-spread-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/rest-spread-spacing/rest-spread-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/rest-spread-spacing/rest-spread-spacing._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Kai Cataldo
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'rest-spread-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/semi-spacing/semi-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/semi-spacing/semi-spacing._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Mathias Schreck
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'semi-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/semi-spacing/semi-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/semi-spacing/semi-spacing._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Mathias Schreck
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'semi-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/semi-spacing/semi-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/semi-spacing/semi-spacing._ts_.test.ts
@@ -1,7 +1,8 @@
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'semi-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/semi-spacing/semi-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/semi-spacing/semi-spacing._ts_.test.ts
@@ -1,8 +1,8 @@
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'semi-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/semi-style/semi-style._js_.test.ts
+++ b/packages/eslint-plugin/rules/semi-style/semi-style._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Toru Nagashima
  */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'semi-style',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/semi-style/semi-style._js_.test.ts
+++ b/packages/eslint-plugin/rules/semi-style/semi-style._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Toru Nagashima
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'semi-style',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/semi/semi._js_.test.ts
+++ b/packages/eslint-plugin/rules/semi/semi._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Nicholas C. Zakas
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'semi',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/semi/semi._js_.test.ts
+++ b/packages/eslint-plugin/rules/semi/semi._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Nicholas C. Zakas
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'semi',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/semi/semi._ts_.test.ts
+++ b/packages/eslint-plugin/rules/semi/semi._ts_.test.ts
@@ -2,7 +2,7 @@
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
 import type { InvalidTestCase, ValidTestCase } from '#test'
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
@@ -20,7 +20,7 @@ const extraSemicolon = {
   messageId: 'extraSemi' as const,
 }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'semi',
   rule,
   valid: [
@@ -1071,7 +1071,7 @@ run<RuleOptions>({
           },
         ],
       },
-    ].reduce<InvalidTestCase<RuleOptions>[]>((acc, test) => {
+    ].reduce<InvalidTestCase<RuleOptions, MessageIds>[]>((acc, test) => {
       acc.push({
         code: test.code.replace(/;/g, ''),
         output: test.code,

--- a/packages/eslint-plugin/rules/semi/semi._ts_.test.ts
+++ b/packages/eslint-plugin/rules/semi/semi._ts_.test.ts
@@ -256,7 +256,7 @@ run<RuleOptions>({
       'export default (foo) => foo.bar();',
       'export default foo = 42;',
       'export default foo += 42;',
-    ].reduce<ValidTestCase[]>((acc, code) => {
+    ].reduce<ValidTestCase<RuleOptions>[]>((acc, code) => {
       acc.push({
         code,
         options: ['always'],
@@ -1071,7 +1071,7 @@ run<RuleOptions>({
           },
         ],
       },
-    ].reduce<InvalidTestCase[]>((acc, test) => {
+    ].reduce<InvalidTestCase<RuleOptions>[]>((acc, test) => {
       acc.push({
         code: test.code.replace(/;/g, ''),
         output: test.code,

--- a/packages/eslint-plugin/rules/semi/semi._ts_.test.ts
+++ b/packages/eslint-plugin/rules/semi/semi._ts_.test.ts
@@ -20,7 +20,7 @@ const extraSemicolon = {
   messageId: 'extraSemi' as const,
 }
 
-run({
+run<RuleOptions>({
   name: 'semi',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/space-before-blocks/space-before-blocks._js_.test.ts
+++ b/packages/eslint-plugin/rules/space-before-blocks/space-before-blocks._js_.test.ts
@@ -3,25 +3,26 @@
  * @author Mathias Schreck <https://github.com/lo1tuma>
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import tsParser from '@typescript-eslint/parser'
 import rule from '.'
 
-const alwaysArgs = ['always']
-const neverArgs = ['never']
-const functionsOnlyArgs = [{ functions: 'always', keywords: 'never', classes: 'never' }]
-const keywordOnlyArgs = [{ functions: 'never', keywords: 'always', classes: 'never' }]
-const classesOnlyArgs = [{ functions: 'never', keywords: 'never', classes: 'always' }]
-const functionsAlwaysOthersOffArgs = [{ functions: 'always', keywords: 'off', classes: 'off' }]
-const keywordAlwaysOthersOffArgs = [{ functions: 'off', keywords: 'always', classes: 'off' }]
-const classesAlwaysOthersOffArgs = [{ functions: 'off', keywords: 'off', classes: 'always' }]
-const functionsNeverOthersOffArgs = [{ functions: 'never', keywords: 'off', classes: 'off' }]
-const keywordNeverOthersOffArgs = [{ functions: 'off', keywords: 'never', classes: 'off' }]
-const classesNeverOthersOffArgs = [{ functions: 'off', keywords: 'off', classes: 'never' }]
+const alwaysArgs: RuleOptions = ['always']
+const neverArgs: RuleOptions = ['never']
+const functionsOnlyArgs: RuleOptions = [{ functions: 'always', keywords: 'never', classes: 'never' }]
+const keywordOnlyArgs: RuleOptions = [{ functions: 'never', keywords: 'always', classes: 'never' }]
+const classesOnlyArgs: RuleOptions = [{ functions: 'never', keywords: 'never', classes: 'always' }]
+const functionsAlwaysOthersOffArgs: RuleOptions = [{ functions: 'always', keywords: 'off', classes: 'off' }]
+const keywordAlwaysOthersOffArgs: RuleOptions = [{ functions: 'off', keywords: 'always', classes: 'off' }]
+const classesAlwaysOthersOffArgs: RuleOptions = [{ functions: 'off', keywords: 'off', classes: 'always' }]
+const functionsNeverOthersOffArgs: RuleOptions = [{ functions: 'never', keywords: 'off', classes: 'off' }]
+const keywordNeverOthersOffArgs: RuleOptions = [{ functions: 'off', keywords: 'never', classes: 'off' }]
+const classesNeverOthersOffArgs: RuleOptions = [{ functions: 'off', keywords: 'off', classes: 'never' }]
 const expectedSpacingError = { messageId: 'missingSpace' }
 const expectedNoSpacingError = { messageId: 'unexpectedSpace' }
 
-run({
+run<RuleOptions>({
   name: 'space-before-blocks',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/space-before-blocks/space-before-blocks._js_.test.ts
+++ b/packages/eslint-plugin/rules/space-before-blocks/space-before-blocks._js_.test.ts
@@ -3,7 +3,8 @@
  * @author Mathias Schreck <https://github.com/lo1tuma>
  */
 
-import type { RuleOptions } from './types'
+import type { TestCaseError } from '#test'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import tsParser from '@typescript-eslint/parser'
 import rule from '.'
@@ -19,10 +20,10 @@ const classesAlwaysOthersOffArgs: RuleOptions = [{ functions: 'off', keywords: '
 const functionsNeverOthersOffArgs: RuleOptions = [{ functions: 'never', keywords: 'off', classes: 'off' }]
 const keywordNeverOthersOffArgs: RuleOptions = [{ functions: 'off', keywords: 'never', classes: 'off' }]
 const classesNeverOthersOffArgs: RuleOptions = [{ functions: 'off', keywords: 'off', classes: 'never' }]
-const expectedSpacingError = { messageId: 'missingSpace' }
-const expectedNoSpacingError = { messageId: 'unexpectedSpace' }
+const expectedSpacingError: TestCaseError<MessageIds> = { messageId: 'missingSpace' }
+const expectedNoSpacingError: TestCaseError<MessageIds> = { messageId: 'unexpectedSpace' }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'space-before-blocks',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/space-before-blocks/space-before-blocks._ts_.test.ts
+++ b/packages/eslint-plugin/rules/space-before-blocks/space-before-blocks._ts_.test.ts
@@ -1,10 +1,11 @@
 // this rule tests spacing, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'space-before-blocks',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/space-before-blocks/space-before-blocks._ts_.test.ts
+++ b/packages/eslint-plugin/rules/space-before-blocks/space-before-blocks._ts_.test.ts
@@ -1,11 +1,11 @@
 // this rule tests spacing, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'space-before-blocks',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/space-before-function-paren/space-before-function-paren._js_.test.ts
+++ b/packages/eslint-plugin/rules/space-before-function-paren/space-before-function-paren._js_.test.ts
@@ -3,11 +3,12 @@
  * @author Mathias Schreck <https://github.com/lo1tuma>
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import { languageOptionsForBabelFlow } from '#test/parsers-flow'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'space-before-function-paren',
   rule,
 

--- a/packages/eslint-plugin/rules/space-before-function-paren/space-before-function-paren._js_.test.ts
+++ b/packages/eslint-plugin/rules/space-before-function-paren/space-before-function-paren._js_.test.ts
@@ -3,12 +3,12 @@
  * @author Mathias Schreck <https://github.com/lo1tuma>
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { languageOptionsForBabelFlow } from '#test/parsers-flow'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'space-before-function-paren',
   rule,
 

--- a/packages/eslint-plugin/rules/space-before-function-paren/space-before-function-paren._ts_.test.ts
+++ b/packages/eslint-plugin/rules/space-before-function-paren/space-before-function-paren._ts_.test.ts
@@ -1,12 +1,12 @@
 // this rule tests the spacing, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
-
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'space-before-function-paren',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/space-before-function-paren/space-before-function-paren._ts_.test.ts
+++ b/packages/eslint-plugin/rules/space-before-function-paren/space-before-function-paren._ts_.test.ts
@@ -1,12 +1,12 @@
 // this rule tests the spacing, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'space-before-function-paren',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/space-in-parens/space-in-parens._js_.test.ts
+++ b/packages/eslint-plugin/rules/space-in-parens/space-in-parens._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Jonathan Rajavuori
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'space-in-parens',
   rule,
 

--- a/packages/eslint-plugin/rules/space-in-parens/space-in-parens._js_.test.ts
+++ b/packages/eslint-plugin/rules/space-in-parens/space-in-parens._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Jonathan Rajavuori
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'space-in-parens',
   rule,
 

--- a/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops._js_.test.ts
+++ b/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops._js_.test.ts
@@ -3,11 +3,12 @@
  * @author Michael Ficarra
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import tsParser from '@typescript-eslint/parser'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'space-infix-ops',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops._js_.test.ts
+++ b/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops._js_.test.ts
@@ -3,12 +3,12 @@
  * @author Michael Ficarra
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import tsParser from '@typescript-eslint/parser'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'space-infix-ops',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops._ts_.test.ts
+++ b/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops._ts_.test.ts
@@ -1,10 +1,11 @@
 // this rule tests spacing, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'space-infix-ops',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops._ts_.test.ts
+++ b/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops._ts_.test.ts
@@ -1,11 +1,11 @@
 // this rule tests spacing, which prettier will want to fix and break the tests
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'space-infix-ops',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/space-unary-ops/space-unary-ops._js_.test.ts
+++ b/packages/eslint-plugin/rules/space-unary-ops/space-unary-ops._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Marcin Kumorek
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'space-unary-ops',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/space-unary-ops/space-unary-ops._js_.test.ts
+++ b/packages/eslint-plugin/rules/space-unary-ops/space-unary-ops._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Marcin Kumorek
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'space-unary-ops',
   rule,
   lang: 'js',

--- a/packages/eslint-plugin/rules/spaced-comment/spaced-comment._js_.test.ts
+++ b/packages/eslint-plugin/rules/spaced-comment/spaced-comment._js_.test.ts
@@ -3,13 +3,13 @@
  * @author Gyandeep Singh
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
 const validShebangProgram = '#!/path/to/node\nvar a = 3;'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'spaced-comment',
   rule,
 

--- a/packages/eslint-plugin/rules/spaced-comment/spaced-comment._js_.test.ts
+++ b/packages/eslint-plugin/rules/spaced-comment/spaced-comment._js_.test.ts
@@ -3,12 +3,13 @@
  * @author Gyandeep Singh
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
 const validShebangProgram = '#!/path/to/node\nvar a = 3;'
 
-run({
+run<RuleOptions>({
   name: 'spaced-comment',
   rule,
 

--- a/packages/eslint-plugin/rules/switch-colon-spacing/switch-colon-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/switch-colon-spacing/switch-colon-spacing._js_.test.ts
@@ -3,16 +3,17 @@
  * @author Toru Nagashima
  */
 
-import type { RuleOptions } from './types'
+import type { TestCaseError } from '#test'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-const expectedBeforeError = { messageId: 'expectedBefore' }
-const expectedAfterError = { messageId: 'expectedAfter' }
-const unexpectedBeforeError = { messageId: 'unexpectedBefore' }
-const unexpectedAfterError = { messageId: 'unexpectedAfter' }
+const expectedBeforeError: TestCaseError<MessageIds> = { messageId: 'expectedBefore' }
+const expectedAfterError: TestCaseError<MessageIds> = { messageId: 'expectedAfter' }
+const unexpectedBeforeError: TestCaseError<MessageIds> = { messageId: 'unexpectedBefore' }
+const unexpectedAfterError: TestCaseError<MessageIds> = { messageId: 'unexpectedAfter' }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'switch-colon-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/switch-colon-spacing/switch-colon-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/switch-colon-spacing/switch-colon-spacing._js_.test.ts
@@ -3,6 +3,7 @@
  * @author Toru Nagashima
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
@@ -11,7 +12,7 @@ const expectedAfterError = { messageId: 'expectedAfter' }
 const unexpectedBeforeError = { messageId: 'unexpectedBefore' }
 const unexpectedAfterError = { messageId: 'unexpectedAfter' }
 
-run({
+run<RuleOptions>({
   name: 'switch-colon-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/template-curly-spacing/template-curly-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/template-curly-spacing/template-curly-spacing._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Toru Nagashima
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'template-curly-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/template-curly-spacing/template-curly-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/template-curly-spacing/template-curly-spacing._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Toru Nagashima
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'template-curly-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/template-tag-spacing/template-tag-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/template-tag-spacing/template-tag-spacing._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Jonathan Wilsson
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'template-tag-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/template-tag-spacing/template-tag-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/template-tag-spacing/template-tag-spacing._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Jonathan Wilsson
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'template-tag-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/type-annotation-spacing/type-annotation-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/type-annotation-spacing/type-annotation-spacing._ts_.test.ts
@@ -2,11 +2,11 @@
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
 import type { InvalidTestCase, ValidTestCase } from '#test'
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'type-annotation-spacing',
   rule,
   valid: [
@@ -3793,7 +3793,7 @@ type Foo = {
 // Optional Annotation Tests
 // ------------------------------------------------------------------------------
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'type-annotation-spacing',
   rule,
   valid: [
@@ -6554,7 +6554,7 @@ type Foo = {
 
 const operators = ['+?:', '-?:']
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'type-annotation-spacing',
   rule,
   valid: operators.reduce<ValidTestCase<RuleOptions>[]>(
@@ -6598,7 +6598,7 @@ run<RuleOptions>({
     ]),
     [],
   ),
-  invalid: operators.reduce<InvalidTestCase<RuleOptions>[]>(
+  invalid: operators.reduce<InvalidTestCase<RuleOptions, MessageIds>[]>(
     (invalidCases, operator) => invalidCases.concat([
       // space before + after cases
       {

--- a/packages/eslint-plugin/rules/type-annotation-spacing/type-annotation-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/type-annotation-spacing/type-annotation-spacing._ts_.test.ts
@@ -2,10 +2,11 @@
 /* /plugin-test-formatting": ["error", { formatWithPrettier: false }] */
 
 import type { InvalidTestCase, ValidTestCase } from '#test'
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'type-annotation-spacing',
   rule,
   valid: [
@@ -3792,7 +3793,7 @@ type Foo = {
 // Optional Annotation Tests
 // ------------------------------------------------------------------------------
 
-run({
+run<RuleOptions>({
   name: 'type-annotation-spacing',
   rule,
   valid: [
@@ -6553,10 +6554,10 @@ type Foo = {
 
 const operators = ['+?:', '-?:']
 
-run({
+run<RuleOptions>({
   name: 'type-annotation-spacing',
   rule,
-  valid: operators.reduce<ValidTestCase[]>(
+  valid: operators.reduce<ValidTestCase<RuleOptions>[]>(
     (validCases, operator) => validCases.concat([
       {
         code: `type Foo<T> = { [P in keyof T]${operator} T[P] }`,
@@ -6597,7 +6598,7 @@ run({
     ]),
     [],
   ),
-  invalid: operators.reduce<InvalidTestCase[]>(
+  invalid: operators.reduce<InvalidTestCase<RuleOptions>[]>(
     (invalidCases, operator) => invalidCases.concat([
       // space before + after cases
       {

--- a/packages/eslint-plugin/rules/type-generic-spacing/type-generic-spacing._plus_.test.ts
+++ b/packages/eslint-plugin/rules/type-generic-spacing/type-generic-spacing._plus_.test.ts
@@ -1,8 +1,8 @@
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from './type-generic-spacing._plus_'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'type-generic-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/type-generic-spacing/type-generic-spacing._plus_.test.ts
+++ b/packages/eslint-plugin/rules/type-generic-spacing/type-generic-spacing._plus_.test.ts
@@ -1,7 +1,8 @@
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from './type-generic-spacing._plus_'
 
-run({
+run<RuleOptions>({
   name: 'type-generic-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/type-named-tuple-spacing/type-named-tuple-spacing._plus_.test.ts
+++ b/packages/eslint-plugin/rules/type-named-tuple-spacing/type-named-tuple-spacing._plus_.test.ts
@@ -1,8 +1,8 @@
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from './type-named-tuple-spacing._plus_'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'type-named-tuple-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/type-named-tuple-spacing/type-named-tuple-spacing._plus_.test.ts
+++ b/packages/eslint-plugin/rules/type-named-tuple-spacing/type-named-tuple-spacing._plus_.test.ts
@@ -1,7 +1,8 @@
+import type { RuleOptions } from './types'
 import { $, run } from '#test'
 import rule from './type-named-tuple-spacing._plus_'
 
-run({
+run<RuleOptions>({
   name: 'type-named-tuple-spacing',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/wrap-iife/wrap-iife._js_.test.ts
+++ b/packages/eslint-plugin/rules/wrap-iife/wrap-iife._js_.test.ts
@@ -3,15 +3,16 @@
  * @author Ilya Volodin
  */
 
-import type { RuleOptions } from './types'
+import type { TestCaseError } from '#test'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-const wrapInvocationError = { messageId: 'wrapInvocation', type: 'CallExpression' }
-const wrapExpressionError = { messageId: 'wrapExpression', type: 'CallExpression' }
-const moveInvocationError = { messageId: 'moveInvocation', type: 'CallExpression' }
+const wrapInvocationError: TestCaseError<MessageIds> = { messageId: 'wrapInvocation', type: 'CallExpression' }
+const wrapExpressionError: TestCaseError<MessageIds> = { messageId: 'wrapExpression', type: 'CallExpression' }
+const moveInvocationError: TestCaseError<MessageIds> = { messageId: 'moveInvocation', type: 'CallExpression' }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'wrap-iife',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/wrap-iife/wrap-iife._js_.test.ts
+++ b/packages/eslint-plugin/rules/wrap-iife/wrap-iife._js_.test.ts
@@ -3,6 +3,7 @@
  * @author Ilya Volodin
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
@@ -10,7 +11,7 @@ const wrapInvocationError = { messageId: 'wrapInvocation', type: 'CallExpression
 const wrapExpressionError = { messageId: 'wrapExpression', type: 'CallExpression' }
 const moveInvocationError = { messageId: 'moveInvocation', type: 'CallExpression' }
 
-run({
+run<RuleOptions>({
   name: 'wrap-iife',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/wrap-regex/wrap-regex._js_.test.ts
+++ b/packages/eslint-plugin/rules/wrap-regex/wrap-regex._js_.test.ts
@@ -3,11 +3,11 @@
  * @author Nicholas C. Zakas
  */
 
-import type { RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'wrap-regex',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/wrap-regex/wrap-regex._js_.test.ts
+++ b/packages/eslint-plugin/rules/wrap-regex/wrap-regex._js_.test.ts
@@ -3,10 +3,11 @@
  * @author Nicholas C. Zakas
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-run({
+run<RuleOptions>({
   name: 'wrap-regex',
   rule,
   valid: [

--- a/packages/eslint-plugin/rules/yield-star-spacing/yield-star-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/yield-star-spacing/yield-star-spacing._js_.test.ts
@@ -3,6 +3,7 @@
  * @author Bryan Smith
  */
 
+import type { RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
@@ -11,7 +12,7 @@ const missingAfterError = { messageId: 'missingAfter', type: 'Punctuator' }
 const unexpectedBeforeError = { messageId: 'unexpectedBefore', type: 'Punctuator' }
 const unexpectedAfterError = { messageId: 'unexpectedAfter', type: 'Punctuator' }
 
-run({
+run<RuleOptions>({
   name: 'yield-star-spacing',
   rule,
 

--- a/packages/eslint-plugin/rules/yield-star-spacing/yield-star-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/yield-star-spacing/yield-star-spacing._js_.test.ts
@@ -3,16 +3,17 @@
  * @author Bryan Smith
  */
 
-import type { RuleOptions } from './types'
+import type { TestCaseError } from '#test'
+import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from '.'
 
-const missingBeforeError = { messageId: 'missingBefore', type: 'Punctuator' }
-const missingAfterError = { messageId: 'missingAfter', type: 'Punctuator' }
-const unexpectedBeforeError = { messageId: 'unexpectedBefore', type: 'Punctuator' }
-const unexpectedAfterError = { messageId: 'unexpectedAfter', type: 'Punctuator' }
+const missingBeforeError: TestCaseError<MessageIds> = { messageId: 'missingBefore', type: 'Punctuator' }
+const missingAfterError: TestCaseError<MessageIds> = { messageId: 'missingAfter', type: 'Punctuator' }
+const unexpectedBeforeError: TestCaseError<MessageIds> = { messageId: 'unexpectedBefore', type: 'Punctuator' }
+const unexpectedAfterError: TestCaseError<MessageIds> = { messageId: 'unexpectedAfter', type: 'Punctuator' }
 
-run<RuleOptions>({
+run<RuleOptions, MessageIds>({
   name: 'yield-star-spacing',
   rule,
 

--- a/packages/shared/test-utils/parsers-jsx.ts
+++ b/packages/shared/test-utils/parsers-jsx.ts
@@ -1,11 +1,11 @@
 /* eslint-disable antfu/no-top-level-await */
 import type { InvalidTestCaseBase, ValidTestCaseBase } from './runner'
 
-export interface InvalidTestCase extends InvalidTestCaseBase {
+export interface InvalidTestCase<RuleOptions> extends InvalidTestCaseBase<RuleOptions> {
   features?: string[]
 }
 
-export interface ValidTestCase extends ValidTestCaseBase {
+export interface ValidTestCase<RuleOptions> extends ValidTestCaseBase<RuleOptions> {
   features?: string[]
 }
 
@@ -33,7 +33,7 @@ function minEcmaVersion(features: any, parserOptions: any) {
 export const BABEL_ESLINT = await import('@babel/eslint-parser').then(m => m.default)
 export const TYPESCRIPT_ESLINT = await import('@typescript-eslint/parser').then(m => m.default)
 
-export function tsParserOptions(test: Partial<InvalidTestCase | ValidTestCase>, features: Set<string>) {
+export function tsParserOptions<RuleOptions>(test: Partial<InvalidTestCase<RuleOptions> | ValidTestCase<RuleOptions>>, features: Set<string>) {
   return {
     ...test.parserOptions,
     ecmaFeatures: {
@@ -44,7 +44,7 @@ export function tsParserOptions(test: Partial<InvalidTestCase | ValidTestCase>, 
   }
 }
 
-export function babelParserOptions(test: Partial<InvalidTestCase | ValidTestCase>, features: Set<string>) {
+export function babelParserOptions<RuleOptions>(test: Partial<InvalidTestCase<RuleOptions> | ValidTestCase<RuleOptions>>, features: Set<string>) {
   return Object.assign({}, test.parserOptions, {
     requireConfigFile: false,
     babelOptions: {
@@ -73,9 +73,9 @@ export function babelParserOptions(test: Partial<InvalidTestCase | ValidTestCase
   })
 }
 
-function applyAllParsers(tests: InvalidTestCase[]): InvalidTestCase[]
-function applyAllParsers(tests: ValidTestCase[]): ValidTestCase[]
-function applyAllParsers(tests: ValidTestCase[] | InvalidTestCase[]) {
+function applyAllParsers<RuleOptions>(tests: InvalidTestCase<RuleOptions>[]): InvalidTestCase<RuleOptions>[]
+function applyAllParsers<RuleOptions>(tests: ValidTestCase<RuleOptions>[]): ValidTestCase<RuleOptions>[]
+function applyAllParsers<RuleOptions>(tests: ValidTestCase<RuleOptions>[] | InvalidTestCase<RuleOptions>[]) {
   const t = tests.flatMap((test: any): any => {
     if (typeof test === 'string')
       test = { code: test }
@@ -184,12 +184,12 @@ function applyAllParsers(tests: ValidTestCase[] | InvalidTestCase[]) {
   return t
 }
 
-export function valids(...tests: (ValidTestCase | ValidTestCase[] | undefined | false)[]): ValidTestCase[] {
-  return applyAllParsers(tests.flat().filter(Boolean) as ValidTestCase[])
+export function valids<RuleOptions>(...tests: (ValidTestCase<RuleOptions> | ValidTestCase<RuleOptions>[] | undefined | false)[]): ValidTestCase<RuleOptions>[] {
+  return applyAllParsers(tests.flat().filter(Boolean) as ValidTestCase<RuleOptions>[])
 }
 
-export function invalids(...tests: (InvalidTestCase | InvalidTestCase[] | undefined | false)[]): InvalidTestCase[] {
-  return applyAllParsers(tests.flat().filter(Boolean) as InvalidTestCase[])
+export function invalids<RuleOptions>(...tests: (InvalidTestCase<RuleOptions> | InvalidTestCase<RuleOptions>[] | undefined | false)[]): InvalidTestCase<RuleOptions>[] {
+  return applyAllParsers(tests.flat().filter(Boolean) as InvalidTestCase<RuleOptions>[])
 }
 
 export const skipDueToMultiErrorSorting = true

--- a/packages/shared/test-utils/parsers-jsx.ts
+++ b/packages/shared/test-utils/parsers-jsx.ts
@@ -1,11 +1,11 @@
 /* eslint-disable antfu/no-top-level-await */
 import type { InvalidTestCaseBase, ValidTestCaseBase } from './runner'
 
-export interface InvalidTestCase<RuleOptions> extends InvalidTestCaseBase<RuleOptions> {
+export interface InvalidTestCase<RuleOptions = any, MessageIds extends string = string> extends InvalidTestCaseBase<RuleOptions, MessageIds> {
   features?: string[]
 }
 
-export interface ValidTestCase<RuleOptions> extends ValidTestCaseBase<RuleOptions> {
+export interface ValidTestCase<RuleOptions = any> extends ValidTestCaseBase<RuleOptions> {
   features?: string[]
 }
 
@@ -33,7 +33,7 @@ function minEcmaVersion(features: any, parserOptions: any) {
 export const BABEL_ESLINT = await import('@babel/eslint-parser').then(m => m.default)
 export const TYPESCRIPT_ESLINT = await import('@typescript-eslint/parser').then(m => m.default)
 
-export function tsParserOptions<RuleOptions>(test: Partial<InvalidTestCase<RuleOptions> | ValidTestCase<RuleOptions>>, features: Set<string>) {
+export function tsParserOptions<RuleOptions = any>(test: Partial<InvalidTestCase<RuleOptions> | ValidTestCase<RuleOptions>>, features: Set<string>) {
   return {
     ...test.parserOptions,
     ecmaFeatures: {
@@ -44,7 +44,7 @@ export function tsParserOptions<RuleOptions>(test: Partial<InvalidTestCase<RuleO
   }
 }
 
-export function babelParserOptions<RuleOptions>(test: Partial<InvalidTestCase<RuleOptions> | ValidTestCase<RuleOptions>>, features: Set<string>) {
+export function babelParserOptions<RuleOptions = any>(test: Partial<InvalidTestCase<RuleOptions> | ValidTestCase<RuleOptions>>, features: Set<string>) {
   return Object.assign({}, test.parserOptions, {
     requireConfigFile: false,
     babelOptions: {
@@ -73,9 +73,9 @@ export function babelParserOptions<RuleOptions>(test: Partial<InvalidTestCase<Ru
   })
 }
 
-function applyAllParsers<RuleOptions>(tests: InvalidTestCase<RuleOptions>[]): InvalidTestCase<RuleOptions>[]
-function applyAllParsers<RuleOptions>(tests: ValidTestCase<RuleOptions>[]): ValidTestCase<RuleOptions>[]
-function applyAllParsers<RuleOptions>(tests: ValidTestCase<RuleOptions>[] | InvalidTestCase<RuleOptions>[]) {
+function applyAllParsers<RuleOptions = any, MessageIds extends string = string>(tests: InvalidTestCase<RuleOptions, MessageIds>[]): InvalidTestCase<RuleOptions, MessageIds>[]
+function applyAllParsers<RuleOptions = any>(tests: ValidTestCase<RuleOptions>[]): ValidTestCase<RuleOptions>[]
+function applyAllParsers<RuleOptions = any, MessageIds extends string = string>(tests: ValidTestCase<RuleOptions>[] | InvalidTestCase<RuleOptions, MessageIds>[]) {
   const t = tests.flatMap((test: any): any => {
     if (typeof test === 'string')
       test = { code: test }
@@ -188,8 +188,8 @@ export function valids<RuleOptions>(...tests: (ValidTestCase<RuleOptions> | Vali
   return applyAllParsers(tests.flat().filter(Boolean) as ValidTestCase<RuleOptions>[])
 }
 
-export function invalids<RuleOptions>(...tests: (InvalidTestCase<RuleOptions> | InvalidTestCase<RuleOptions>[] | undefined | false)[]): InvalidTestCase<RuleOptions>[] {
-  return applyAllParsers(tests.flat().filter(Boolean) as InvalidTestCase<RuleOptions>[])
+export function invalids<RuleOptions = any, MessageIds extends string = string>(...tests: (InvalidTestCase<RuleOptions, MessageIds> | InvalidTestCase<RuleOptions, MessageIds>[] | undefined | false)[]): InvalidTestCase<RuleOptions, MessageIds>[] {
+  return applyAllParsers(tests.flat().filter(Boolean) as InvalidTestCase<RuleOptions, MessageIds>[])
 }
 
 export const skipDueToMultiErrorSorting = true

--- a/packages/shared/test-utils/runner.ts
+++ b/packages/shared/test-utils/runner.ts
@@ -7,12 +7,12 @@ export * from 'eslint-vitest-rule-tester'
 
 export { unindent as $ } from 'eslint-vitest-rule-tester'
 
-export interface ExtendedRuleTesterOptions extends RuleTesterInitOptions, TestCasesOptions {
+export interface ExtendedRuleTesterOptions<RuleOptions = any> extends RuleTesterInitOptions, TestCasesOptions<RuleOptions> {
   lang?: 'js' | 'ts'
 }
 
-export function run(options: ExtendedRuleTesterOptions) {
-  return _run({
+export function run<RuleOptions = any>(options: ExtendedRuleTesterOptions<RuleOptions>) {
+  return _run<RuleOptions>({
     recursive: false,
     verifyAfterFix: false,
     ...(options.lang === 'js' ? {} : { parser: tsParser as any }),

--- a/packages/shared/test-utils/runner.ts
+++ b/packages/shared/test-utils/runner.ts
@@ -7,12 +7,12 @@ export * from 'eslint-vitest-rule-tester'
 
 export { unindent as $ } from 'eslint-vitest-rule-tester'
 
-export interface ExtendedRuleTesterOptions<RuleOptions = any> extends RuleTesterInitOptions, TestCasesOptions<RuleOptions> {
+export interface ExtendedRuleTesterOptions<RuleOptions = any, MessageIds extends string = string> extends RuleTesterInitOptions, TestCasesOptions<RuleOptions, MessageIds> {
   lang?: 'js' | 'ts'
 }
 
-export function run<RuleOptions = any>(options: ExtendedRuleTesterOptions<RuleOptions>) {
-  return _run<RuleOptions>({
+export function run<RuleOptions = any, MessageIds extends string = string>(options: ExtendedRuleTesterOptions<RuleOptions, MessageIds>) {
+  return _run<RuleOptions, MessageIds>({
     recursive: false,
     verifyAfterFix: false,
     ...(options.lang === 'js' ? {} : { parser: tsParser as any }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,8 +121,8 @@ catalogs:
       specifier: ^4.2.0
       version: 4.2.0
     eslint-vitest-rule-tester:
-      specifier: ^2.1.0
-      version: 2.1.0
+      specifier: ^2.2.0
+      version: 2.2.0
     esno:
       specifier: ^4.8.0
       version: 4.8.0
@@ -351,7 +351,7 @@ importers:
         version: 4.2.0
       eslint-vitest-rule-tester:
         specifier: 'catalog:'
-        version: 2.1.0(eslint@9.20.0(jiti@2.4.2))(typescript@5.7.3)(vitest@3.0.5)
+        version: 2.2.0(eslint@9.20.0(jiti@2.4.2))(typescript@5.7.3)(vitest@3.0.5)
       esno:
         specifier: 'catalog:'
         version: 4.8.0
@@ -2571,8 +2571,8 @@ packages:
     resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  eslint-vitest-rule-tester@2.1.0:
-    resolution: {integrity: sha512-+uKXk6NlE1750N2L6ePnRJnWSrZ5vMWXPkE0IBZZ480IPPfvtJaoZS+1iQAWKzOItaJBvN1zJdVEGKn4pHgW4A==}
+  eslint-vitest-rule-tester@2.2.0:
+    resolution: {integrity: sha512-4qnX3piKH1a41zBFHE2fQUKZI2/yhhpqJyEOTDGwP1jZ1tkcwvkXbtYNDcTY3YmirqqlNPAWw0UvIPW1rcEtLw==}
     peerDependencies:
       eslint: ^9.0.0
       vitest: ^3.0.5
@@ -6572,7 +6572,7 @@ snapshots:
 
   eslint-visitor-keys@4.2.0: {}
 
-  eslint-vitest-rule-tester@2.1.0(eslint@9.20.0(jiti@2.4.2))(typescript@5.7.3)(vitest@3.0.5):
+  eslint-vitest-rule-tester@2.2.0(eslint@9.20.0(jiti@2.4.2))(typescript@5.7.3)(vitest@3.0.5):
     dependencies:
       '@types/eslint': 9.6.1
       '@typescript-eslint/utils': 8.28.0(eslint@9.20.0(jiti@2.4.2))(typescript@5.7.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,8 +121,8 @@ catalogs:
       specifier: ^4.2.0
       version: 4.2.0
     eslint-vitest-rule-tester:
-      specifier: ^1.1.0
-      version: 1.1.0
+      specifier: ^2.1.0
+      version: 2.1.0
     esno:
       specifier: ^4.8.0
       version: 4.8.0
@@ -351,7 +351,7 @@ importers:
         version: 4.2.0
       eslint-vitest-rule-tester:
         specifier: 'catalog:'
-        version: 1.1.0(eslint@9.20.0(jiti@2.4.2))(typescript@5.7.3)(vitest@3.0.5)
+        version: 2.1.0(eslint@9.20.0(jiti@2.4.2))(typescript@5.7.3)(vitest@3.0.5)
       esno:
         specifier: 'catalog:'
         version: 4.8.0
@@ -1457,51 +1457,61 @@ packages:
     resolution: {integrity: sha512-88fSzjC5xeH9S2Vg3rPgXJULkHcLYMkh8faix8DX4h4TIAL65ekwuQMA/g2CXq8W+NJC43V6fUpYZNjaX3+IIg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.34.6':
     resolution: {integrity: sha512-wM4ztnutBqYFyvNeR7Av+reWI/enK9tDOTKNF+6Kk2Q96k9bwhDDOlnCUNRPvromlVXo04riSliMBs/Z7RteEg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.34.6':
     resolution: {integrity: sha512-9RyprECbRa9zEjXLtvvshhw4CMrRa3K+0wcp3KME0zmBe1ILmvcVHnypZ/aIDXpRyfhSYSuN4EPdCCj5Du8FIA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.34.6':
     resolution: {integrity: sha512-qTmklhCTyaJSB05S+iSovfo++EwnIEZxHkzv5dep4qoszUMX5Ca4WM4zAVUMbfdviLgCSQOu5oU8YoGk1s6M9Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.34.6':
     resolution: {integrity: sha512-4Qmkaps9yqmpjY5pvpkfOerYgKNUGzQpFxV6rnS7c/JfYbDSU0y6WpbbredB5cCpLFGJEqYX40WUmxMkwhWCjw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.34.6':
     resolution: {integrity: sha512-Zsrtux3PuaxuBTX/zHdLaFmcofWGzaWW1scwLU3ZbW/X+hSsFbz9wDIp6XvnT7pzYRl9MezWqEqKy7ssmDEnuQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.34.6':
     resolution: {integrity: sha512-aK+Zp+CRM55iPrlyKiU3/zyhgzWBxLVrw2mwiQSYJRobCURb781+XstzvA8Gkjg/hbdQFuDw44aUOxVQFycrAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.34.6':
     resolution: {integrity: sha512-WoKLVrY9ogmaYPXwTH326+ErlCIgMmsoRSx6bO+l68YgJnlOXhygDYSZe/qbUJCSiCiZAQ+tKm88NcWuUXqOzw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.34.6':
     resolution: {integrity: sha512-Sht4aFvmA4ToHd2vFzwMFaQCiYm2lDFho5rPcvPBT5pCdC+GwHG6CMch4GQfmWTQ1SwRKS0dhDYb54khSrjDWw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.34.6':
     resolution: {integrity: sha512-zmmpOQh8vXc2QITsnCiODCDGXFC8LMi64+/oPpPx5qz3pqv0s6x46ps4xoycfUiVZps5PFn1gksZzo4RGTKT+A==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.34.6':
     resolution: {integrity: sha512-3/q1qUsO/tLqGBaD4uXsB6coVGB3usxw3qyeVb59aArCgedSF66MPdgRStUd7vbZOsko/CgVaY5fo2vkvPLWiA==}
@@ -1653,6 +1663,10 @@ packages:
     resolution: {integrity: sha512-OGqo7+dXHqI7Hfm+WqkZjKjsiRtFUQHPdGMXzk5mYXhJUedO7e/Y7i8AK3MyLMgZR93TX4bIzYrfyVjLC+0VSw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.28.0':
+    resolution: {integrity: sha512-u2oITX3BJwzWCapoZ/pXw6BCOl8rJP4Ij/3wPoGvY8XwvXflOzd1kLrDUUUAIEdJSFh+ASwdTHqtan9xSg8buw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/type-utils@8.23.0':
     resolution: {integrity: sha512-iIuLdYpQWZKbiH+RkCGc6iu+VwscP5rCtQ1lyQ7TYuKLrcZoeJVpcLiG8DliXVkUxirW/PWlmS+d6yD51L9jvA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1664,11 +1678,21 @@ packages:
     resolution: {integrity: sha512-1sK4ILJbCmZOTt9k4vkoulT6/y5CHJ1qUYxqpF1K/DBAd8+ZUL4LlSCxOssuH5m4rUaaN0uS0HlVPvd45zjduQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.28.0':
+    resolution: {integrity: sha512-bn4WS1bkKEjx7HqiwG2JNB3YJdC1q6Ue7GyGlwPHyt0TnVq6TtD/hiOdTZt71sq0s7UzqBFXD8t8o2e63tXgwA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.23.0':
     resolution: {integrity: sha512-LcqzfipsB8RTvH8FX24W4UUFk1bl+0yTOf9ZA08XngFwMg4Kj8A+9hwz8Cr/ZS4KwHrmo9PJiLZkOt49vPnuvQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.8.0'
+
+  '@typescript-eslint/typescript-estree@8.28.0':
+    resolution: {integrity: sha512-H74nHEeBGeklctAVUvmDkxB1mk+PAZ9FiOMPFncdqeRBXxk1lWSYraHw8V12b7aa6Sg9HOBNbGdSHobBPuQSuA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.9.0'
 
   '@typescript-eslint/utils@8.23.0':
     resolution: {integrity: sha512-uB/+PSo6Exu02b5ZEiVtmY6RVYO7YU5xqgzTIVZwTHvvK3HsL8tZZHFaTLFtRG3CsV4A5mhOv+NZx5BlhXPyIA==}
@@ -1677,8 +1701,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
+  '@typescript-eslint/utils@8.28.0':
+    resolution: {integrity: sha512-OELa9hbTYciYITqgurT1u/SzpQVtDLmQMFzy/N8pQE+tefOyCWT79jHsav294aTqV1q1u+VzqDGbuujvRYaeSQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
   '@typescript-eslint/visitor-keys@8.23.0':
     resolution: {integrity: sha512-oWWhcWDLwDfu++BGTZcmXWqpwtkwb5o7fxUIGksMQQDSdPW9prsSnfIOZMlsj4vBOSrcnjIUZMiIjODgGosFhQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.28.0':
+    resolution: {integrity: sha512-hbn8SZ8w4u2pRwgQ1GlUrPKE+t2XvcCW5tTRF7j6SMYIuYG37XuzIW44JCZPa36evi0Oy2SnM664BlIaAuQcvg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript/vfs@1.6.0':
@@ -2536,8 +2571,8 @@ packages:
     resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  eslint-vitest-rule-tester@1.1.0:
-    resolution: {integrity: sha512-rilURDIBbHZKUDXdnlDnewJ3A5NdiK9HpYgdaeKY7rPpn+nI1KfvB/DyYMc0R8KgL9ziu5lbXVmWukgX0JPbAQ==}
+  eslint-vitest-rule-tester@2.1.0:
+    resolution: {integrity: sha512-+uKXk6NlE1750N2L6ePnRJnWSrZ5vMWXPkE0IBZZ480IPPfvtJaoZS+1iQAWKzOItaJBvN1zJdVEGKn4pHgW4A==}
     peerDependencies:
       eslint: ^9.0.0
       vitest: ^3.0.5
@@ -5375,6 +5410,11 @@ snapshots:
       '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/visitor-keys': 8.23.0(patch_hash=e6yskaf2s6m32jqdnfk2cmkgju)
 
+  '@typescript-eslint/scope-manager@8.28.0':
+    dependencies:
+      '@typescript-eslint/types': 8.28.0
+      '@typescript-eslint/visitor-keys': 8.28.0(patch_hash=e6yskaf2s6m32jqdnfk2cmkgju)
+
   '@typescript-eslint/type-utils@8.23.0(eslint@9.20.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.7.3)
@@ -5388,10 +5428,26 @@ snapshots:
 
   '@typescript-eslint/types@8.23.0': {}
 
+  '@typescript-eslint/types@8.28.0': {}
+
   '@typescript-eslint/typescript-estree@8.23.0(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/visitor-keys': 8.23.0(patch_hash=e6yskaf2s6m32jqdnfk2cmkgju)
+      debug: 4.4.0
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.1
+      ts-api-utils: 2.0.1(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.28.0(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.28.0
+      '@typescript-eslint/visitor-keys': 8.28.0(patch_hash=e6yskaf2s6m32jqdnfk2cmkgju)
       debug: 4.4.0
       fast-glob: 3.3.3
       is-glob: 4.0.3
@@ -5413,9 +5469,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.28.0(eslint@9.20.0(jiti@2.4.2))(typescript@5.7.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.0(jiti@2.4.2))
+      '@typescript-eslint/scope-manager': 8.28.0
+      '@typescript-eslint/types': 8.28.0
+      '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.7.3)
+      eslint: 9.20.0(jiti@2.4.2)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.23.0(patch_hash=e6yskaf2s6m32jqdnfk2cmkgju)':
     dependencies:
       '@typescript-eslint/types': 8.23.0
+      eslint-visitor-keys: 4.2.0
+
+  '@typescript-eslint/visitor-keys@8.28.0(patch_hash=e6yskaf2s6m32jqdnfk2cmkgju)':
+    dependencies:
+      '@typescript-eslint/types': 8.28.0
       eslint-visitor-keys: 4.2.0
 
   '@typescript/vfs@1.6.0(typescript@5.7.3)':
@@ -6500,11 +6572,10 @@ snapshots:
 
   eslint-visitor-keys@4.2.0: {}
 
-  eslint-vitest-rule-tester@1.1.0(eslint@9.20.0(jiti@2.4.2))(typescript@5.7.3)(vitest@3.0.5):
+  eslint-vitest-rule-tester@2.1.0(eslint@9.20.0(jiti@2.4.2))(typescript@5.7.3)(vitest@3.0.5):
     dependencies:
-      '@antfu/utils': 8.1.0
       '@types/eslint': 9.6.1
-      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.20.0(jiti@2.4.2))(typescript@5.7.3)
       eslint: 9.20.0(jiti@2.4.2)
       vitest: 3.0.5(@types/debug@4.1.12)(@types/node@22.13.1)(@vitest/ui@3.0.5)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.7.0)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,7 +41,7 @@ catalog:
   eslint: ^9.20.0
   eslint-plugin-format: ^1.0.1
   eslint-visitor-keys: ^4.2.0
-  eslint-vitest-rule-tester: ^2.1.0
+  eslint-vitest-rule-tester: ^2.2.0
   esno: ^4.8.0
   espree: ^10.3.0
   estraverse: ^5.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,7 +41,7 @@ catalog:
   eslint: ^9.20.0
   eslint-plugin-format: ^1.0.1
   eslint-visitor-keys: ^4.2.0
-  eslint-vitest-rule-tester: ^1.1.0
+  eslint-vitest-rule-tester: ^2.1.0
   esno: ^4.8.0
   espree: ^10.3.0
   estraverse: ^5.3.0


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

- update `eslint-vitest-rule-tester` to v2.1.0
- use rule options generic type
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context
Maybe `messageId` generic type support can be in `eslint-vitest-rule-tester`
https://github.com/antfu/eslint-vitest-rule-tester/pull/14

<!-- e.g. is there anything you'd like reviewers to focus on? -->
