### PR TITLE
docs: incorrect error tip should display

### DIFF
--- a/packages/eslint-plugin/rules/member-delimiter-style/README._ts_.md
+++ b/packages/eslint-plugin/rules/member-delimiter-style/README._ts_.md
@@ -108,7 +108,6 @@ Examples of code for this rule with the default config:
 
 ::: incorrect
 
-<!-- prettier-ignore -->
 ```ts
 /*eslint @stylistic/member-delimiter-style: "error"*/
 
@@ -137,9 +136,10 @@ type FooBar = { name: string, greet(): string }
 type FooBar = { name: string; greet(): string; }
 ```
 
+:::
+
 ::: correct
 
-<!-- prettier-ignore -->
 ```ts
 /*eslint @stylistic/member-delimiter-style: "error"*/
 
@@ -159,6 +159,8 @@ type Bar = { name: string }
 
 type FooBar = { name: string; greet(): string }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/packages/eslint-plugin/rules/type-annotation-spacing/README._ts_.md
+++ b/packages/eslint-plugin/rules/type-annotation-spacing/README._ts_.md
@@ -41,7 +41,6 @@ This rule aims to enforce specific spacing patterns around type annotations and 
 
 ::: incorrect
 
-<!-- prettier-ignore -->
 ```ts
 /*eslint @stylistic/ts/type-annotation-spacing: "error"*/
 
@@ -70,9 +69,10 @@ type Foo = () =>{};
 type Foo = ()=> {};
 ```
 
+:::
+
 ::: correct
 
-<!-- prettier-ignore -->
 ```ts
 /*eslint @stylistic/ts/type-annotation-spacing: "error"*/
 
@@ -86,6 +86,8 @@ class Foo {
 
 type Foo = () => {};
 ```
+
+:::
 
 ## Options
 
@@ -97,7 +99,6 @@ Examples of **incorrect** code for this rule with the `{ "before": false, "after
 
 ::: incorrect
 
-<!-- prettier-ignore -->
 ```ts
 /*eslint @stylistic/ts/type-annotation-spacing: ["error", { "before": false, "after": true }]*/
 
@@ -126,11 +127,12 @@ type Foo = () =>{};
 type Foo = () => {};
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "before": false, "after": true }` option:
 
 ::: correct
 
-<!-- prettier-ignore -->
 ```ts
 /*eslint @stylistic/ts/type-annotation-spacing: ["error", { "before": false, "after": true }]*/
 
@@ -144,6 +146,8 @@ class Foo {
 
 type Foo = ()=> {};
 ```
+
+:::
 
 ### before
 
@@ -153,7 +157,6 @@ Examples of **incorrect** code for this rule with the `{ "before": true, "after"
 
 ::: incorrect
 
-<!-- prettier-ignore -->
 ```ts
 /*eslint @stylistic/ts/type-annotation-spacing: ["error", { "before": true, "after": true }]*/
 
@@ -182,11 +185,12 @@ type Foo = () =>{};
 type Foo = ()=> {};
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "before": true, "after": true }` option:
 
 ::: correct
 
-<!-- prettier-ignore -->
 ```ts
 /*eslint @stylistic/ts/type-annotation-spacing: ["error", { "before": true, "after": true }]*/
 
@@ -201,6 +205,8 @@ class Foo {
 type Foo = () => {};
 ```
 
+:::
+
 ### overrides - colon
 
 Examples of **incorrect** code for this rule with the `{ "before": false, "after": false, "overrides": { "colon": { "before": true, "after": true } } }` option:
@@ -209,7 +215,6 @@ Examples of **incorrect** code for this rule with the `{ "before": false, "after
 
 ::: incorrect
 
-<!-- prettier-ignore -->
 ```ts
 /*eslint @stylistic/ts/type-annotation-spacing: ["error", { "before": false, "after": false, "overrides": { "colon": { "before": true, "after": true } } }]*/
 
@@ -238,11 +243,12 @@ type Foo = ()=> {};
 type Foo = () => {};
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "before": false, "after": false, "overrides": { "colon": { "before": true, "after": true } } }` option:
 
 ::: correct
 
-<!-- prettier-ignore -->
 ```ts
 /*eslint @stylistic/ts/type-annotation-spacing: ["error", { "before": false, "after": false, "overrides": { "colon": { "before": true, "after": true } } }]*/
 
@@ -261,6 +267,8 @@ type Foo = {
 type Foo = ()=>{};
 ```
 
+:::
+
 ### overrides - arrow
 
 Examples of **incorrect** code for this rule with the `{ "before": false, "after": false, "overrides": { "arrow": { "before": true, "after": true } } }` option:
@@ -269,7 +277,6 @@ Examples of **incorrect** code for this rule with the `{ "before": false, "after
 
 ::: incorrect
 
-<!-- prettier-ignore -->
 ```ts
 /*eslint @stylistic/ts/type-annotation-spacing: ["error", { "before": false, "after": false, "overrides": { "arrow": { "before": true, "after": true } } }]*/
 
@@ -298,11 +305,12 @@ type Foo = () =>{};
 type Foo = ()=> {};
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "before": false, "after": false, "overrides": { "arrow": { "before": true, "after": true } } }` option:
 
 ::: correct
 
-<!-- prettier-ignore -->
 ```ts
 /*eslint @stylistic/ts/type-annotation-spacing: ["error", { "before": false, "after": false, "overrides": { "arrow": { "before": true, "after": true } } }]*/
 
@@ -316,6 +324,8 @@ class Foo {
 
 type Foo = () => {};
 ```
+
+:::
 
 ## When Not To Use It
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Some error tip can't display.

In current docs page:
![image](https://github.com/user-attachments/assets/fddde238-2243-433a-a4eb-1403b153395c)

after this commit:
![image](https://github.com/user-attachments/assets/59601727-fced-4a11-bd2d-216b742f6a53)

### Linked Issues

### Additional context

This pr also change the doc of `member-delimiter-style` but we still can't see the error tip. here is the reason #746 . but at the browser elements inspects, we can see the trigger element is added. just it is empty.

<!-- e.g. is there anything you'd like reviewers to focus on? -->
