### PR TITLE
fix(indent): handle `ChainExpression` and `AwaitExpression` when `offsetTernaryExpressionsOffsetCallExpressions`

### DIFF
--- a/packages/eslint-plugin/rules/indent/indent._js_.test.ts
+++ b/packages/eslint-plugin/rules/indent/indent._js_.test.ts
@@ -2338,6 +2338,41 @@ run({
         offsetTernaryExpressionsOffsetCallExpressions: false,
       }],
     },
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/750
+    {
+      code: $`
+        isHeader(1)
+          ? renderSectionHeader?.(
+            typeof item === "string" ? item : "",
+            virtualRow.size,
+          )
+          : renderItem(
+            item,
+            virtualRow.size,
+          )
+      `,
+      options: [2, {
+        offsetTernaryExpressions: true,
+        offsetTernaryExpressionsOffsetCallExpressions: false,
+      }],
+    },
+    {
+      code: $`
+        isHeader(1)
+          ? renderSectionHeader?.(
+              typeof item === "string" ? item : "",
+              virtualRow.size,
+            )
+          : renderItem(
+              item,
+              virtualRow.size,
+            )
+      `,
+      options: [2, {
+        offsetTernaryExpressions: true,
+        offsetTernaryExpressionsOffsetCallExpressions: true,
+      }],
+    },
 
     $`
       [
@@ -14652,6 +14687,35 @@ run({
             ,
         )
       `,
+    },
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/750
+    {
+      code: $`
+        isHeader(1)
+          ? renderSectionHeader?.(
+            typeof item === "string" ? item : "",
+            virtualRow.size,
+          )
+          : renderItem(
+            item,
+            virtualRow.size,
+          )
+      `,
+      output: $`
+        isHeader(1)
+          ? renderSectionHeader?.(
+              typeof item === "string" ? item : "",
+              virtualRow.size,
+            )
+          : renderItem(
+              item,
+              virtualRow.size,
+            )
+      `,
+      options: [2, {
+        offsetTernaryExpressions: true,
+        offsetTernaryExpressionsOffsetCallExpressions: true,
+      }],
     },
   ],
 })

--- a/packages/eslint-plugin/rules/indent/indent._js_.test.ts
+++ b/packages/eslint-plugin/rules/indent/indent._js_.test.ts
@@ -2374,6 +2374,40 @@ run({
       }],
     },
 
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/756
+    {
+      code: $`
+        menus
+          ? await Promise.all(
+            menus.map(async (menu) => ({
+              menuName: menu.name,
+              menu: await resolveUrlToFile(menu.fileUrl),
+            })),
+          )
+          : []
+      `,
+      options: [2, {
+        offsetTernaryExpressions: true,
+        offsetTernaryExpressionsOffsetCallExpressions: false,
+      }],
+    },
+    {
+      code: $`
+        menus
+          ? await Promise.all(
+              menus.map(async (menu) => ({
+                menuName: menu.name,
+                menu: await resolveUrlToFile(menu.fileUrl),
+              })),
+            )
+          : []
+      `,
+      options: [2, {
+        offsetTernaryExpressions: true,
+        offsetTernaryExpressionsOffsetCallExpressions: true,
+      }],
+    },
+
     $`
       [
           foo ?
@@ -14711,6 +14745,33 @@ run({
               item,
               virtualRow.size,
             )
+      `,
+      options: [2, {
+        offsetTernaryExpressions: true,
+        offsetTernaryExpressionsOffsetCallExpressions: true,
+      }],
+    },
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/756
+    {
+      code: $`
+        menus
+          ? await Promise.all(
+            menus.map(async (menu) => ({
+              menuName: menu.name,
+              menu: await resolveUrlToFile(menu.fileUrl),
+            })),
+          )
+          : []
+      `,
+      output: $`
+        menus
+          ? await Promise.all(
+              menus.map(async (menu) => ({
+                menuName: menu.name,
+                menu: await resolveUrlToFile(menu.fileUrl),
+              })),
+            )
+          : []
       `,
       options: [2, {
         offsetTernaryExpressions: true,

--- a/packages/eslint-plugin/rules/indent/indent._ts_.ts
+++ b/packages/eslint-plugin/rules/indent/indent._ts_.ts
@@ -6,7 +6,7 @@
 
 import type { ASTNode, JSONSchema, RuleFunction, RuleListener, SourceCode, Token, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
-import { createGlobalLinebreakMatcher, isClosingBraceToken, isClosingBracketToken, isClosingParenToken, isColonToken, isCommentToken, isEqToken, isNotClosingParenToken, isNotOpeningParenToken, isNotSemicolonToken, isOpeningBraceToken, isOpeningBracketToken, isOpeningParenToken, isQuestionDotToken, isSemicolonToken, isTokenOnSameLine, STATEMENT_LIST_PARENTS } from '#utils/ast'
+import { createGlobalLinebreakMatcher, isClosingBraceToken, isClosingBracketToken, isClosingParenToken, isColonToken, isCommentToken, isEqToken, isNotClosingParenToken, isNotOpeningParenToken, isNotSemicolonToken, isOpeningBraceToken, isOpeningBracketToken, isOpeningParenToken, isQuestionDotToken, isSemicolonToken, isTokenOnSameLine, skipChainExpression, STATEMENT_LIST_PARENTS } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 
@@ -1244,7 +1244,7 @@ export default createRule<RuleOptions, MessageIds>({
           if (options.offsetTernaryExpressions) {
             if (firstConsequentToken.type === 'Punctuator')
               offset = 2
-            if (options.offsetTernaryExpressionsOffsetCallExpressions && node.consequent.type === 'CallExpression')
+            if (options.offsetTernaryExpressionsOffsetCallExpressions && skipChainExpression(node.consequent).type === 'CallExpression')
               offset = 2
           }
 
@@ -1272,7 +1272,7 @@ export default createRule<RuleOptions, MessageIds>({
             if (options.offsetTernaryExpressions) {
               if (firstAlternateToken.type === 'Punctuator')
                 offset = 2
-              if (options.offsetTernaryExpressionsOffsetCallExpressions && node.alternate.type === 'CallExpression')
+              if (options.offsetTernaryExpressionsOffsetCallExpressions && skipChainExpression(node.alternate).type === 'CallExpression')
                 offset = 2
             }
             /**

--- a/packages/eslint-plugin/rules/indent/indent._ts_.ts
+++ b/packages/eslint-plugin/rules/indent/indent._ts_.ts
@@ -1244,8 +1244,14 @@ export default createRule<RuleOptions, MessageIds>({
           if (options.offsetTernaryExpressions) {
             if (firstConsequentToken.type === 'Punctuator')
               offset = 2
-            if (options.offsetTernaryExpressionsOffsetCallExpressions && skipChainExpression(node.consequent).type === 'CallExpression')
+
+            const consequentType = skipChainExpression(node.consequent).type
+            if (
+              options.offsetTernaryExpressionsOffsetCallExpressions
+              && (consequentType === 'CallExpression' || consequentType === 'AwaitExpression')
+            ) {
               offset = 2
+            }
           }
 
           offsets.setDesiredOffset(
@@ -1272,8 +1278,14 @@ export default createRule<RuleOptions, MessageIds>({
             if (options.offsetTernaryExpressions) {
               if (firstAlternateToken.type === 'Punctuator')
                 offset = 2
-              if (options.offsetTernaryExpressionsOffsetCallExpressions && skipChainExpression(node.alternate).type === 'CallExpression')
+
+              const alternateType = skipChainExpression(node.alternate).type
+              if (
+                options.offsetTernaryExpressionsOffsetCallExpressions
+                && (alternateType === 'CallExpression' || alternateType === 'AwaitExpression')
+              ) {
                 offset = 2
+              }
             }
             /**
              * If the alternate and consequent do not share part of a line, offset the alternate from the first


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

fixes #750 , fixes #756 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
