### PR TITLE
fix(eslint-plugin): only export interfaces in index

### DIFF
--- a/packages/eslint-plugin/dts/index.d.ts
+++ b/packages/eslint-plugin/dts/index.d.ts
@@ -2,10 +2,10 @@ import type { ESLint } from 'eslint'
 import type { Configs } from './configs'
 import type { Rules } from './rules'
 
-export type * from './configs'
-export type * from './options'
-export type * from './rule-options'
-export type * from './rules'
+export type { Configs } from './configs'
+export type { StylisticCustomizeOptions } from './options'
+export type { RuleOptions, UnprefixedRuleOptions } from './rule-options'
+export type { Rules } from './rules'
 
 declare const plugin: {
   rules: Rules


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

The source code does not export the `customize` function or the `configs` object. But they are exported in the types, because `export type * from '...'` exports also the declare const stuff.

Instead we need to only export interfaces not declarations.

### Linked Issues
fix https://github.com/eslint-stylistic/eslint-stylistic/issues/762

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
