### PR TITLE
docs(object-curly-newline): add additional options for typescript rule

### DIFF
--- a/packages/eslint-plugin/rules/object-curly-newline/README._ts_.md
+++ b/packages/eslint-plugin/rules/object-curly-newline/README._ts_.md
@@ -7,3 +7,8 @@ description: Enforce consistent line breaks after opening and before closing bra
 This rule extends the base [`object-curly-newline`](/rules/js/object-curly-newline) rule.
 
 It adds support for TypeScript's object types.
+
+## Additional Options
+
+- `"TSTypeLiteral"`: configuration for TypeScript type literals
+- `"TSInterfaceBody"`: configuration for TypeScript interfaces


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
The docs for `ts/object-curly-newline`  does not mention the TypeScript specific configuration options. 
This PR adds `"TSTypeLiteral`" and `"TSInterfaceBody"`
 ### Linked Issues

No related issue found.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
