### PR TITLE
fix(keyword-spacing): handle catch with parameter

### DIFF
--- a/packages/eslint-plugin/rules/keyword-spacing/README.md
+++ b/packages/eslint-plugin/rules/keyword-spacing/README.md
@@ -36,6 +36,8 @@ This rule has an object option:
 - `"after": false` disallows spaces after keywords
 - `"overrides"` allows overriding spacing style for specified keywords
 
+> `catch` has two additional options `beforeWithParam` and `afterWithParam`, and their default values inherit from `before` and `after`. which are used to specify the case when catch has parameters
+
 ### before
 
 Examples of **incorrect** code for this rule with the default `{ "before": true }` option:
@@ -280,7 +282,7 @@ if(foo) {
 
 ### overrides
 
-Examples of **correct** code for this rule with the `{ "overrides": { "if": { "after": false }, "for": { "after": false }, "while": { "after": false }, "static": { "after": false }, "as": { "after": false } } }` option:
+Examples of **correct** code for this rule with the `{ "overrides": { "if": { "after": false }, "for": { "after": false }, "while": { "after": false }, "static": { "after": false }, "as": { "after": false }, "catch": { "afterWithParam": false } } }` option:
 
 ::: correct
 
@@ -290,7 +292,8 @@ Examples of **correct** code for this rule with the `{ "overrides": { "if": { "a
   "for": { "after": false },
   "while": { "after": false },
   "static": { "after": false },
-  "as": { "after": false }
+  "as": { "after": false },
+  "catch": { "afterWithParam": false }
 } }]*/
 
 if(foo) {
@@ -314,6 +317,13 @@ class C {
 }
 
 export { C as"my class" };
+
+try {
+
+}
+catch(e) {
+
+}
 ```
 
 :::

--- a/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._js_.test.ts
@@ -355,10 +355,14 @@ run<RuleOptions, MessageIds>({
 
     'try {} catch (e) {}',
     { code: 'try{}catch(e) {}', options: [NEITHER] },
-    { code: 'try{} catch (e) {}', options: [override('catch', BOTH)] },
-    { code: 'try {}catch(e) {}', options: [override('catch', NEITHER)] },
+    { code: 'try{} catch {}', options: [override('catch', BOTH)] },
+    { code: 'try {}catch{}', options: [override('catch', NEITHER)] },
+    { code: 'try{} catch (e) {}', options: [{ ...NEITHER, overrides: { catch: { beforeWithParam: true, afterWithParam: true } } }] },
+    { code: 'try {}catch(e) {}', options: [{ ...BOTH, overrides: { catch: { beforeWithParam: false, afterWithParam: false } } }] },
     'try {}\ncatch (e) {}',
     { code: 'try{}\ncatch(e) {}', options: [NEITHER] },
+    { code: 'try{} catch (e) {}\ntry{} catch {}', options: [override('catch', BOTH)] },
+    { code: 'try {}catch(e) {}\ntry {}catch{}', options: [override('catch', NEITHER)] },
 
     // ----------------------------------------------------------------------
     // class
@@ -1990,16 +1994,50 @@ run<RuleOptions, MessageIds>({
       errors: unexpectedBeforeAndAfter('catch'),
     },
     {
+      code: 'try{}catch{}',
+      output: 'try{} catch {}',
+      options: [override('catch', BOTH)],
+      errors: expectedBeforeAndAfter('catch'),
+    },
+    {
+      code: 'try {} catch {}',
+      output: 'try {}catch{}',
+      options: [override('catch', NEITHER)],
+      errors: unexpectedBeforeAndAfter('catch'),
+    },
+    {
       code: 'try{}catch(e) {}',
       output: 'try{} catch (e) {}',
-      options: [override('catch', BOTH)],
+      options: [{ ...NEITHER, overrides: { catch: { beforeWithParam: true, afterWithParam: true } } }],
       errors: expectedBeforeAndAfter('catch'),
     },
     {
       code: 'try {} catch (e) {}',
       output: 'try {}catch(e) {}',
-      options: [override('catch', NEITHER)],
+      options: [{ ...BOTH, overrides: { catch: { beforeWithParam: false, afterWithParam: false } } }],
       errors: unexpectedBeforeAndAfter('catch'),
+    },
+    {
+      code: 'try{}catch{}\ntry{}catch(e){}',
+      output: 'try{} catch {}\ntry{} catch (e){}',
+      options: [override('catch', BOTH)],
+      errors: [
+        { messageId: 'expectedBefore', data: { value: 'catch' } },
+        { messageId: 'expectedAfter', data: { value: 'catch' } },
+        { messageId: 'expectedBefore', data: { value: 'catch' } },
+        { messageId: 'expectedAfter', data: { value: 'catch' } },
+      ],
+    },
+    {
+      code: 'try {} catch {}\ntry {} catch (e){}',
+      output: 'try {}catch{}\ntry {}catch(e){}',
+      options: [override('catch', NEITHER)],
+      errors: [
+        { messageId: 'unexpectedBefore', data: { value: 'catch' } },
+        { messageId: 'unexpectedAfter', data: { value: 'catch' } },
+        { messageId: 'unexpectedBefore', data: { value: 'catch' } },
+        { messageId: 'unexpectedAfter', data: { value: 'catch' } },
+      ],
     },
 
     // ----------------------------------------------------------------------

--- a/packages/eslint-plugin/rules/keyword-spacing/types.d.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/types.d.ts
@@ -1,6 +1,6 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: 6RaHSpkd0xngnBtv0uggStdq40cIo2NW9uru1q_OApM */
+/* @checksum: mjz3J14NjLUeF0SMzva3RhG-E8kevFeoYmWFlCUgWdY */
 
 export interface KeywordSpacingSchema0 {
   before?: boolean
@@ -29,6 +29,8 @@ export interface KeywordSpacingSchema0 {
     catch?: {
       before?: boolean
       after?: boolean
+      beforeWithParam?: boolean
+      afterWithParam?: boolean
     }
     char?: {
       before?: boolean


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Current rule have a special problem

```ts
/*eslint @stylistic/keyword-spacing: ["error", { after: true }]*/

try {  }
catch (error) {  }

try {  }
catch {  }

// or
/*eslint @stylistic/keyword-spacing: ["error", { after: true, overrides: { catch: { after: false } } }]*/

try {  }
catch(error) {  }

try {  }
catch{  }
```

I add a new options `catchWithParam`. That handle `catch` when it have param. So we can override behavior when the catch with parameter.

```ts
/*eslint keyword-spacing: ["error", { after: true, overrides: { catchWithParam: { after: false } } }]*/

try {  }
catch(e) {  }

try {  }
catch {  }
```

### Linked Issues

fixed #681

### Additional context

I don't know if add a "not keyword" option is a good idea. If you have better idea I'd love to change.

