### PR TITLE
fix(indent): wrong PropertyDefinition value offset when ts type have multiple line

### DIFF
--- a/packages/eslint-plugin/rules/indent/indent._ts_.test.ts
+++ b/packages/eslint-plugin/rules/indent/indent._ts_.test.ts
@@ -2,7 +2,7 @@
 
 import type { InvalidTestCase, TestCaseError, TestCasesOptions, ValidTestCase } from '#test'
 import type { MessageIds, RuleOptions } from './types'
-import { run } from '#test'
+import { $, run } from '#test'
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import rule from '.'
 
@@ -778,6 +778,47 @@ const map2 = Object.keys(map)
     result[key] = map[key];
     return result;
   }, {});
+      `,
+      options: [2],
+    },
+    {
+      code: $`
+        class Some {
+          range: {
+            index?: number
+            length?: number
+          } = {
+            index: 0,
+            length: 0
+          }
+        }
+      `,
+      options: [2],
+    },
+    {
+      code: $`
+        const some: {
+          index?: number
+          length?: number
+        } = {
+          index: 0,
+          length: 0
+        }
+      `,
+      options: [2],
+    },
+    {
+      code: $`
+        const some: {
+          index?: number
+          length?: number
+        } = {
+          index: 0,
+          length: 0
+        } as {
+          index?: number
+          length?: number
+        }
       `,
       options: [2],
     },

--- a/packages/eslint-plugin/rules/indent/indent._ts_.ts
+++ b/packages/eslint-plugin/rules/indent/indent._ts_.ts
@@ -1562,7 +1562,7 @@ export default createRule<RuleOptions, MessageIds>({
       PropertyDefinition(node) {
         const firstToken = sourceCode.getFirstToken(node)!
         const maybeSemicolonToken = sourceCode.getLastToken(node)!
-        let keyLastToken = null
+        let keyLastToken: Tree.Token | null = null
 
         // Indent key.
         if (node.computed) {
@@ -1587,9 +1587,11 @@ export default createRule<RuleOptions, MessageIds>({
         if (node.value) {
           const eqToken = sourceCode.getTokenBefore(node.value, isEqToken)!
           const valueToken = sourceCode.getTokenAfter(eqToken)!
+          const typeToken = sourceCode.getTokenBefore(eqToken)!
 
           offsets.setDesiredOffset(eqToken, keyLastToken, 1)
-          offsets.setDesiredOffset(valueToken, eqToken, 1)
+          // value token set offset by equal token or ts type token
+          offsets.setDesiredOffset(valueToken, keyLastToken === typeToken ? eqToken : typeToken, 1)
           if (isSemicolonToken(maybeSemicolonToken))
             offsets.setDesiredOffset(maybeSemicolonToken, eqToken, 1)
         }


### PR DESCRIPTION

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

close #773 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
