### PR TITLE
docs: fix eslint error

### DIFF
--- a/packages/eslint-plugin/rules/max-len/README._js_.md
+++ b/packages/eslint-plugin/rules/max-len/README._js_.md
@@ -164,7 +164,7 @@ Examples of **correct** code for this rule with the `{ "ignoreStrings": true }` 
 ```js
 /*eslint max-len: ["error", { "ignoreStrings": true }]*/
 
-var longString = 'this is a really really really really really long string!';
+var longString = 'this is a really really really really really really really long string!';
 ```
 
 :::
@@ -204,7 +204,10 @@ Examples of **correct** code for this rule with the `ignorePattern` option:
 ::: correct
 
 ```js
-/*eslint max-len: ["error", { "ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\\(" }]*/
+/*eslint max-len: [
+  "error",
+  { "ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\\(" }
+]*/
 
 var dep = require('really/really/really/really/really/really/really/really/long/module');
 ```


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

The string line not have 80 char length

```
// origin line 77 length will not trigger error even not have option `ignoreStrings`
var longString = 'this is a really really really really really long string!';

// after fix have 91 length, that will trigger eslint error
var longString = 'this is a really really really really really really really long string!';
```

And fix eslint comment error

![image](https://github.com/user-attachments/assets/0442d937-21f6-4305-a3ac-f112d9e1349a)

![image](https://github.com/user-attachments/assets/65b2db77-a883-42d2-921d-70714b60771f)

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
