### PR TITLE
feat(no-extra-parens): allow spread syntax to wrap parentheses

### DIFF
--- a/packages/eslint-plugin/rules/no-extra-parens/README._js_.md
+++ b/packages/eslint-plugin/rules/no-extra-parens/README._js_.md
@@ -61,6 +61,7 @@ This rule has an object option for exceptions to the `"all"` option:
 - `"enforceForFunctionPrototypeMethods": false` allows extra parentheses around immediate `.call` and `.apply` method calls on function expressions and around function expressions in the same context.
 - `"allowParensAfterCommentPattern": "any-string-pattern"` allows extra parentheses preceded by a comment that matches a regular expression.
 - `"nestedConditionalExpressions": false` allows extra parentheses in nested conditional(ternary) expressions
+- `"allowNodesInSpreadElement": []` allows extra parentheses to be added to nodes within the spread syntax
 
 ### all
 
@@ -444,6 +445,32 @@ Examples of **correct** code for this rule with the `"all"` and `{ "nestedCondit
 
 a ? (b ? c : d) : e;
 a ? b : (c ? d : e);
+```
+
+:::
+
+### allowNodesInSpreadElement
+
+Examples of **correct** code for this rule with the `"all"` and `{ "allowNodesInSpreadElement": ["LogicalExpression", "ConditionalExpression"] }` options:
+
+::: correct
+
+```js
+/* eslint no-extra-parens: [
+    "error",
+    "all",
+    { "allowNodesInSpreadElement": ["LogicalExpression", "ConditionalExpression"] }
+ ] */
+
+const x = [
+    ...a ? [1, 2, 3] : [],
+    ...(a ? [1, 2, 3] : []),
+]
+
+const fruits = {
+    ...isSummer && { watermelon: 30 },
+    ...(isSummer && { watermelon: 30 }),
+};
 ```
 
 :::

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.test.ts
@@ -6,7 +6,6 @@
 import type { InvalidTestCase } from '#test'
 import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
-import tsParser from '@typescript-eslint/parser'
 import rule from '.'
 
 /**
@@ -788,10 +787,41 @@ run<RuleOptions, MessageIds>({
       options: ['functions'],
     },
 
-    // https://github.com/eslint/eslint/issues/17173
     {
-      code: 'const x = (1 satisfies number).toFixed();',
-      parser: tsParser,
+      code: $`
+        const x = [
+          ...a ? [1, 2, 3] : [],
+          ...(a ? [1, 2, 3] : []),
+        ]
+      `,
+      options: ['all', { allowNodesInSpreadElement: ['ConditionalExpression'] }],
+    },
+    {
+      code: $`
+        const x = [
+          ...b ?? c,
+          ...(b ?? c),
+        ]
+      `,
+      options: ['all', { allowNodesInSpreadElement: ['LogicalExpression'] }],
+    },
+    {
+      code: $`
+        const fruits = {
+          ...isSummer && { watermelon: 30 },
+          ...(isSummer && { watermelon: 30 }),
+        };
+      `,
+      options: ['all', { allowNodesInSpreadElement: ['LogicalExpression'] }],
+    },
+    {
+      code: $`
+        async function example() {
+          const promiseArray = Promise.resolve([1, 2, 3]);
+          console.log(...(await promiseArray));
+        }
+      `,
+      options: ['all', { allowNodesInSpreadElement: ['AwaitExpression'] }],
     },
   ],
 

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.ts
@@ -72,6 +72,7 @@ export default createRule<RuleOptions, MessageIds>({
                 enforceForFunctionPrototypeMethods: { type: 'boolean' },
                 allowParensAfterCommentPattern: { type: 'string' },
                 nestedConditionalExpressions: { type: 'boolean' },
+                allowNodesInSpreadElement: { type: 'array', items: { type: 'string' } },
               },
               additionalProperties: false,
             },
@@ -108,6 +109,8 @@ export default createRule<RuleOptions, MessageIds>({
       && context.options[1].enforceForFunctionPrototypeMethods === false
     const ALLOW_PARENS_AFTER_COMMENT_PATTERN = ALL_NODES && context.options[1] && context.options[1].allowParensAfterCommentPattern
     const ALLOW_NESTED_TERNARY = ALL_NODES && context.options[1] && context.options[1].nestedConditionalExpressions === false
+    const ALLOW_NODES_IN_SPREAD = ALL_NODES && context.options[1]
+      && new Set(context.options[1].allowNodesInSpreadElement || [])
 
     // @ts-expect-error other properties are not used
     const PRECEDENCE_OF_ASSIGNMENT_EXPR = precedence({ type: 'AssignmentExpression' })
@@ -625,6 +628,9 @@ export default createRule<RuleOptions, MessageIds>({
      * @param node The node of spread elements/properties to check.
      */
     function checkSpreadOperator(node: Tree.SpreadElement) {
+      if (ALLOW_NODES_IN_SPREAD && ALLOW_NODES_IN_SPREAD.has(node.argument.type))
+        return
+
       if (hasExcessParensWithPrecedence(node.argument, PRECEDENCE_OF_ASSIGNMENT_EXPR))
         report(node.argument)
     }

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.test.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.test.ts
@@ -527,6 +527,10 @@ run<RuleOptions, MessageIds>({
         },
       },
     },
+    // https://github.com/eslint/eslint/issues/17173
+    {
+      code: 'const x = (1 satisfies number).toFixed();',
+    },
   ],
 
   invalid: [

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.ts
@@ -64,6 +64,7 @@ export default createRule<RuleOptions, MessageIds>({
                 enforceForFunctionPrototypeMethods: { type: 'boolean' },
                 allowParensAfterCommentPattern: { type: 'string' },
                 nestedConditionalExpressions: { type: 'boolean' },
+                allowNodesInSpreadElement: { type: 'array', items: { type: 'string' } },
               },
               additionalProperties: false,
             },
@@ -106,6 +107,8 @@ export default createRule<RuleOptions, MessageIds>({
       && context.options[1].allowParensAfterCommentPattern
     const ALLOW_NESTED_TERNARY = ALL_NODES && context.options[1]
       && context.options[1].nestedConditionalExpressions === false
+    const ALLOW_NODES_IN_SPREAD = ALL_NODES && context.options[1]
+      && new Set(context.options[1].allowNodesInSpreadElement || [])
 
     // @ts-expect-error other properties are not used
     const PRECEDENCE_OF_ASSIGNMENT_EXPR = precedence({ type: 'AssignmentExpression' })
@@ -1363,6 +1366,9 @@ export default createRule<RuleOptions, MessageIds>({
       },
       SpreadElement(node) {
         if (isTypeAssertion(node.argument))
+          return
+
+        if (ALLOW_NODES_IN_SPREAD && ALLOW_NODES_IN_SPREAD.has(node.argument.type))
           return
 
         if (!hasExcessParensWithPrecedence(node.argument, PRECEDENCE_OF_ASSIGNMENT_EXPR))

--- a/packages/eslint-plugin/rules/no-extra-parens/types.d.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/types.d.ts
@@ -1,6 +1,6 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: l9oVuVvODt */
+/* @checksum: S0uX1jluIc */
 
 export type NoExtraParensSchema0 =
   | []
@@ -25,6 +25,7 @@ export type NoExtraParensSchema0 =
       enforceForFunctionPrototypeMethods?: boolean
       allowParensAfterCommentPattern?: string
       nestedConditionalExpressions?: boolean
+      allowNodesInSpreadElement?: string[]
     },
   ]
 


### PR DESCRIPTION


### Description

Add a new option `allowNodesInSpreadElement` that allow some of nodes to wrap parentheses

### Linked Issues

close #664, close #407

### Additional context

I changed the `_js_` file because docs need js version file to check code.
