### PR TITLE
fix(keyword-spacing): check spaces around the `type` keyword in `export` declarations

### DIFF
--- a/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._ts_.test.ts
@@ -272,6 +272,103 @@ run<RuleOptions, MessageIds>({
       options: [BOTH],
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
+    {
+      code: 'export type { foo } from "foo";',
+      options: [BOTH],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      code: 'export type * as Foo from \'foo\'',
+      options: [BOTH],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      code: 'export type { SavedQueries } from "./SavedQueries.js";',
+      options: [
+        {
+          before: true,
+          after: false,
+          overrides: {
+            else: { after: true },
+            return: { after: true },
+            try: { after: true },
+            catch: { after: false },
+            case: { after: true },
+            const: { after: true },
+            throw: { after: true },
+            let: { after: true },
+            do: { after: true },
+            of: { after: true },
+            as: { after: true },
+            finally: { after: true },
+            from: { after: true },
+            import: { after: true },
+            export: { after: true },
+            default: { after: true },
+            // The new option:
+            type: { after: true },
+          },
+        },
+      ],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      // Space after export is not configurable from option since it's invalid syntax with export type
+      code: 'export type { SavedQueries } from "./SavedQueries.js";',
+      options: [
+        {
+          before: true,
+          after: true,
+          overrides: {
+            export: { after: false },
+          },
+        },
+      ],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      code: 'export type{SavedQueries} from \'./SavedQueries.js\';',
+      options: [
+        {
+          before: true,
+          after: false,
+          overrides: {
+            from: { after: true },
+          },
+        },
+      ],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      code: 'export type{SavedQueries} from\'./SavedQueries.js\';',
+      options: [
+        {
+          before: true,
+          after: false,
+        },
+      ],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      code: 'export type {} from "foo";',
+      options: [BOTH],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      code: 'export type { foo1, foo2 } from "foo";',
+      options: [BOTH],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      code: 'export type { foo1 as _foo1, foo2 as _foo2 } from "foo";',
+      options: [BOTH],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      code: 'export type { foo as bar } from "foo";',
+      options: [BOTH],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
   ],
   invalid: [
     // ----------------------------------------------------------------------
@@ -384,6 +481,64 @@ run<RuleOptions, MessageIds>({
     {
       code: 'import type {SavedQueries} from \'./SavedQueries.js\';',
       output: 'import type{SavedQueries} from\'./SavedQueries.js\';',
+      options: [
+        {
+          before: true,
+          after: false,
+        },
+      ],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [
+        { messageId: 'unexpectedAfter', data: { value: 'type' } },
+        { messageId: 'unexpectedAfter', data: { value: 'from' } },
+      ],
+    },
+    {
+      code: 'export type{ foo } from "foo";',
+      output: 'export type { foo } from "foo";',
+      options: [{ after: true, before: true }],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: expectedAfter('type'),
+    },
+    {
+      code: 'export type { foo } from"foo";',
+      output: 'export type{ foo } from"foo";',
+      options: [{ after: false, before: true }],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: unexpectedAfter('type'),
+    },
+    {
+      code: 'export type* as foo from "foo";',
+      output: 'export type * as foo from "foo";',
+      options: [{ after: true, before: true }],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: expectedAfter('type'),
+    },
+    {
+      code: 'export type * as foo from"foo";',
+      output: 'export type* as foo from"foo";',
+      options: [{ after: false, before: true }],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: unexpectedAfter('type'),
+    },
+    {
+      code: 'export type {SavedQueries} from \'./SavedQueries.js\';',
+      output: 'export type{SavedQueries} from \'./SavedQueries.js\';',
+      options: [
+        {
+          before: true,
+          after: false,
+          overrides: {
+            from: { after: true },
+          },
+        },
+      ],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: unexpectedAfter('type'),
+    },
+    {
+      code: 'export type {SavedQueries} from \'./SavedQueries.js\';',
+      output: 'export type{SavedQueries} from\'./SavedQueries.js\';',
       options: [
         {
           before: true,

--- a/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._ts_.test.ts
@@ -369,6 +369,14 @@ run<RuleOptions, MessageIds>({
       options: [BOTH],
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
+    {
+      code: 'import type{}from"foo";',
+      options: [NEITHER],
+    },
+    {
+      code: 'export type{}from"foo";',
+      options: [NEITHER],
+    },
   ],
   invalid: [
     // ----------------------------------------------------------------------
@@ -548,6 +556,26 @@ run<RuleOptions, MessageIds>({
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         { messageId: 'unexpectedAfter', data: { value: 'type' } },
+        { messageId: 'unexpectedAfter', data: { value: 'from' } },
+      ],
+    },
+    {
+      code: 'import type {} from "foo";',
+      output: 'import type{}from"foo";',
+      options: [NEITHER],
+      errors: [
+        { messageId: 'unexpectedAfter', data: { value: 'type' } },
+        { messageId: 'unexpectedBefore', data: { value: 'from' } },
+        { messageId: 'unexpectedAfter', data: { value: 'from' } },
+      ],
+    },
+    {
+      code: 'export type {} from "foo";',
+      output: 'export type{}from"foo";',
+      options: [NEITHER],
+      errors: [
+        { messageId: 'unexpectedAfter', data: { value: 'type' } },
+        { messageId: 'unexpectedBefore', data: { value: 'from' } },
         { messageId: 'unexpectedAfter', data: { value: 'from' } },
       ],
     },

--- a/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._ts_.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._ts_.ts
@@ -375,6 +375,80 @@ export default createRule<RuleOptions, MessageIds>({
         checkSpacingBefore(fromToken, PREV_TOKEN_M)
         checkSpacingAfter(fromToken, NEXT_TOKEN_M)
       }
+
+      checkSpacingForTypeKeywordInImportExport(node)
+    }
+
+    /**
+     * Report the `type` keyword in `import type`, `export type`, and `export type *` declaration nodes
+     * if there is invalid use of spaces around the `type` keyword.
+     * @param node A node to report.
+     */
+    function checkSpacingForTypeKeywordInImportExport(
+      node:
+        | Tree.ExportNamedDeclaration
+        | Tree.ExportDefaultDeclaration
+        | Tree.ExportAllDeclaration
+        | Tree.ImportDeclaration,
+    ) {
+      let kind: undefined | string
+
+      switch (node.type) {
+        case AST_NODE_TYPES.ImportDeclaration: {
+          if (node.specifiers?.[0]?.type === AST_NODE_TYPES.ImportDefaultSpecifier) {
+            return
+          }
+          kind = node.importKind
+          break
+        }
+
+        // case AST_NODE_TYPES.ExportDefaultDeclaration:
+        case AST_NODE_TYPES.ExportAllDeclaration:
+        case AST_NODE_TYPES.ExportNamedDeclaration: {
+          kind = node.exportKind
+          break
+        }
+      }
+
+      if (kind !== 'type') {
+        return
+      }
+
+      const { type: typeOptionOverride = {} } = overrides ?? {}
+      const typeToken = sourceCode.getFirstToken(node, { skip: 1 })!
+      const punctuatorToken = sourceCode.getTokenAfter(typeToken)!
+      const spacesBetweenTypeAndPunctuator = punctuatorToken.range[0] - typeToken.range[1]
+
+      if (
+        (typeOptionOverride.after ?? after) === true
+        && spacesBetweenTypeAndPunctuator === 0
+      ) {
+        context.report({
+          loc: typeToken.loc,
+          messageId: 'expectedAfter',
+          data: { value: 'type' },
+          fix(fixer) {
+            return fixer.insertTextAfter(typeToken, ' ')
+          },
+        })
+      }
+
+      if (
+        (typeOptionOverride.after ?? after) === false
+        && spacesBetweenTypeAndPunctuator > 0
+      ) {
+        context.report({
+          loc: typeToken.loc,
+          messageId: 'unexpectedAfter',
+          data: { value: 'type' },
+          fix(fixer) {
+            return fixer.removeRange([
+              typeToken.range[1],
+              typeToken.range[1] + spacesBetweenTypeAndPunctuator,
+            ])
+          },
+        })
+      }
     }
 
     /**
@@ -487,51 +561,7 @@ export default createRule<RuleOptions, MessageIds>({
       ExportDefaultDeclaration: checkSpacingForModuleDeclaration,
       ExportAllDeclaration: checkSpacingForModuleDeclaration,
       FunctionDeclaration: checkSpacingForFunction,
-      ImportDeclaration(node) {
-        checkSpacingForModuleDeclaration(node)
-
-        if (node.importKind === 'type') {
-          const { type: typeOptionOverride = {} } = overrides ?? {}
-          const typeToken = sourceCode.getFirstToken(node, { skip: 1 })!
-          const punctuatorToken = sourceCode.getTokenAfter(typeToken)!
-          if (
-            node.specifiers?.[0]?.type === AST_NODE_TYPES.ImportDefaultSpecifier
-          )
-            return
-
-          const spacesBetweenTypeAndPunctuator
-            = punctuatorToken.range[0] - typeToken.range[1]
-          if (
-            (typeOptionOverride.after ?? after) === true
-            && spacesBetweenTypeAndPunctuator === 0
-          ) {
-            context.report({
-              loc: typeToken.loc,
-              messageId: 'expectedAfter',
-              data: { value: 'type' },
-              fix(fixer) {
-                return fixer.insertTextAfter(typeToken, ' ')
-              },
-            })
-          }
-          if (
-            (typeOptionOverride.after ?? after) === false
-            && spacesBetweenTypeAndPunctuator > 0
-          ) {
-            context.report({
-              loc: typeToken.loc,
-              messageId: 'unexpectedAfter',
-              data: { value: 'type' },
-              fix(fixer) {
-                return fixer.removeRange([
-                  typeToken.range[1],
-                  typeToken.range[1] + spacesBetweenTypeAndPunctuator,
-                ])
-              },
-            })
-          }
-        }
-      },
+      ImportDeclaration: checkSpacingForModuleDeclaration,
       VariableDeclaration: checkSpacingAroundFirstToken,
 
       // Expressions

--- a/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._ts_.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._ts_.ts
@@ -376,7 +376,9 @@ export default createRule<RuleOptions, MessageIds>({
         checkSpacingAfter(fromToken, NEXT_TOKEN_M)
       }
 
-      checkSpacingForTypeKeywordInImportExport(node)
+      // ExportDefaultDeclaration never have a `type` keyword
+      if (node.type !== 'ExportDefaultDeclaration')
+        checkSpacingForTypeKeywordInImportExport(node)
     }
 
     /**
@@ -387,7 +389,6 @@ export default createRule<RuleOptions, MessageIds>({
     function checkSpacingForTypeKeywordInImportExport(
       node:
         | Tree.ExportNamedDeclaration
-        | Tree.ExportDefaultDeclaration
         | Tree.ExportAllDeclaration
         | Tree.ImportDeclaration,
     ) {
@@ -402,7 +403,6 @@ export default createRule<RuleOptions, MessageIds>({
           break
         }
 
-        // case AST_NODE_TYPES.ExportDefaultDeclaration:
         case AST_NODE_TYPES.ExportAllDeclaration:
         case AST_NODE_TYPES.ExportNamedDeclaration: {
           kind = node.exportKind

--- a/packages/eslint-plugin/rules/keyword-spacing/types._ts_.d.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/types._ts_.d.ts
@@ -10,18 +10,6 @@ export interface KeywordSpacingSchema0 {
       before?: boolean
       after?: boolean
     }
-    as?: {
-      before?: boolean
-      after?: boolean
-    }
-    async?: {
-      before?: boolean
-      after?: boolean
-    }
-    await?: {
-      before?: boolean
-      after?: boolean
-    }
     boolean?: {
       before?: boolean
       after?: boolean
@@ -114,15 +102,7 @@ export interface KeywordSpacingSchema0 {
       before?: boolean
       after?: boolean
     }
-    from?: {
-      before?: boolean
-      after?: boolean
-    }
     function?: {
-      before?: boolean
-      after?: boolean
-    }
-    get?: {
       before?: boolean
       after?: boolean
     }
@@ -158,10 +138,6 @@ export interface KeywordSpacingSchema0 {
       before?: boolean
       after?: boolean
     }
-    let?: {
-      before?: boolean
-      after?: boolean
-    }
     long?: {
       before?: boolean
       after?: boolean
@@ -175,10 +151,6 @@ export interface KeywordSpacingSchema0 {
       after?: boolean
     }
     null?: {
-      before?: boolean
-      after?: boolean
-    }
-    of?: {
       before?: boolean
       after?: boolean
     }
@@ -199,14 +171,6 @@ export interface KeywordSpacingSchema0 {
       after?: boolean
     }
     return?: {
-      before?: boolean
-      after?: boolean
-    }
-    satisfies?: {
-      before?: boolean
-      after?: boolean
-    }
-    set?: {
       before?: boolean
       after?: boolean
     }
@@ -275,6 +239,42 @@ export interface KeywordSpacingSchema0 {
       after?: boolean
     }
     with?: {
+      before?: boolean
+      after?: boolean
+    }
+    as?: {
+      before?: boolean
+      after?: boolean
+    }
+    async?: {
+      before?: boolean
+      after?: boolean
+    }
+    await?: {
+      before?: boolean
+      after?: boolean
+    }
+    from?: {
+      before?: boolean
+      after?: boolean
+    }
+    get?: {
+      before?: boolean
+      after?: boolean
+    }
+    let?: {
+      before?: boolean
+      after?: boolean
+    }
+    of?: {
+      before?: boolean
+      after?: boolean
+    }
+    satisfies?: {
+      before?: boolean
+      after?: boolean
+    }
+    set?: {
       before?: boolean
       after?: boolean
     }

--- a/packages/eslint-plugin/rules/keyword-spacing/types.d.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/types.d.ts
@@ -10,18 +10,6 @@ export interface KeywordSpacingSchema0 {
       before?: boolean
       after?: boolean
     }
-    as?: {
-      before?: boolean
-      after?: boolean
-    }
-    async?: {
-      before?: boolean
-      after?: boolean
-    }
-    await?: {
-      before?: boolean
-      after?: boolean
-    }
     boolean?: {
       before?: boolean
       after?: boolean
@@ -114,15 +102,7 @@ export interface KeywordSpacingSchema0 {
       before?: boolean
       after?: boolean
     }
-    from?: {
-      before?: boolean
-      after?: boolean
-    }
     function?: {
-      before?: boolean
-      after?: boolean
-    }
-    get?: {
       before?: boolean
       after?: boolean
     }
@@ -158,10 +138,6 @@ export interface KeywordSpacingSchema0 {
       before?: boolean
       after?: boolean
     }
-    let?: {
-      before?: boolean
-      after?: boolean
-    }
     long?: {
       before?: boolean
       after?: boolean
@@ -175,10 +151,6 @@ export interface KeywordSpacingSchema0 {
       after?: boolean
     }
     null?: {
-      before?: boolean
-      after?: boolean
-    }
-    of?: {
       before?: boolean
       after?: boolean
     }
@@ -199,14 +171,6 @@ export interface KeywordSpacingSchema0 {
       after?: boolean
     }
     return?: {
-      before?: boolean
-      after?: boolean
-    }
-    satisfies?: {
-      before?: boolean
-      after?: boolean
-    }
-    set?: {
       before?: boolean
       after?: boolean
     }
@@ -275,6 +239,42 @@ export interface KeywordSpacingSchema0 {
       after?: boolean
     }
     with?: {
+      before?: boolean
+      after?: boolean
+    }
+    as?: {
+      before?: boolean
+      after?: boolean
+    }
+    async?: {
+      before?: boolean
+      after?: boolean
+    }
+    await?: {
+      before?: boolean
+      after?: boolean
+    }
+    from?: {
+      before?: boolean
+      after?: boolean
+    }
+    get?: {
+      before?: boolean
+      after?: boolean
+    }
+    let?: {
+      before?: boolean
+      after?: boolean
+    }
+    of?: {
+      before?: boolean
+      after?: boolean
+    }
+    satisfies?: {
+      before?: boolean
+      after?: boolean
+    }
+    set?: {
       before?: boolean
       after?: boolean
     }


### PR DESCRIPTION
Currently, the `keyword-spacing` rule only checks spacing around the `type` keyword in `import type` declarations.  
It does not handle `export type {}` or `export type *` syntax, resulting in inconsistent spacing behavior.

This PR adds support for spacing checks around the `type` keyword in `export` declarations.