### PR TITLE
fix(space-before-blocks): check space before `TSModuleBlock` nodes

### DIFF
--- a/packages/eslint-plugin/rules/space-before-blocks/space-before-blocks._ts_.test.ts
+++ b/packages/eslint-plugin/rules/space-before-blocks/space-before-blocks._ts_.test.ts
@@ -81,6 +81,61 @@ run<RuleOptions, MessageIds>({
       `,
       options: [{ classes: 'off' }],
     },
+    {
+      code: $`
+        namespace Test{
+          type foo = number;
+        }
+        declare module 'foo'{
+          type foo = number;
+        }
+      `,
+      options: ['never'],
+    },
+    {
+      code: $`
+        namespace Test {
+          type foo = number;
+        }
+        declare module 'foo' {
+          type foo = number;
+        }
+      `,
+      options: ['always'],
+    },
+    {
+      code: $`
+        namespace Test{
+          type foo = number;
+        }
+        declare module 'foo'{
+          type foo = number;
+        }
+      `,
+      options: [{ classes: 'never' }],
+    },
+    {
+      code: $`
+        namespace Test {
+          type foo = number;
+        }
+        declare module 'foo' {
+          type foo = number;
+        }
+      `,
+      options: [{ classes: 'always' }],
+    },
+    {
+      code: $`
+        namespace Test{
+          type foo = number;
+        }
+        declare module 'foo'{
+          type foo = number;
+        }
+      `,
+      options: [{ classes: 'off' }],
+    },
   ],
   invalid: [
     {
@@ -234,6 +289,114 @@ run<RuleOptions, MessageIds>({
         },
       ],
       options: [{ classes: 'never' }],
+    },
+    {
+      code: $`
+        namespace Test {
+          type foo = number;
+        }
+        declare module 'foo' {
+          type foo = number;
+        }
+      `,
+      output: $`
+        namespace Test{
+          type foo = number;
+        }
+        declare module 'foo'{
+          type foo = number;
+        }
+      `,
+      errors: [
+        {
+          messageId: 'unexpectedSpace',
+        },
+        {
+          messageId: 'unexpectedSpace',
+        },
+      ],
+      options: ['never'],
+    },
+    {
+      code: $`
+        namespace Test{
+          type foo = number;
+        }
+        declare module 'foo'{
+          type foo = number;
+        }
+      `,
+      output: $`
+        namespace Test {
+          type foo = number;
+        }
+        declare module 'foo' {
+          type foo = number;
+        }
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+        },
+        {
+          messageId: 'missingSpace',
+        },
+      ],
+      options: ['always'],
+    },
+    {
+      code: $`
+        namespace Test {
+          type foo = number;
+        }
+        declare module 'foo' {
+          type foo = number;
+        }
+      `,
+      output: $`
+        namespace Test{
+          type foo = number;
+        }
+        declare module 'foo'{
+          type foo = number;
+        }
+      `,
+      errors: [
+        {
+          messageId: 'unexpectedSpace',
+        },
+        {
+          messageId: 'unexpectedSpace',
+        },
+      ],
+      options: [{ classes: 'never' }],
+    },
+    {
+      code: $`
+        namespace Test{
+          type foo = number;
+        }
+        declare module 'foo'{
+          type foo = number;
+        }
+      `,
+      output: $`
+        namespace Test {
+          type foo = number;
+        }
+        declare module 'foo' {
+          type foo = number;
+        }
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+        },
+        {
+          messageId: 'missingSpace',
+        },
+      ],
+      options: [{ classes: 'always' }],
     },
   ],
 })

--- a/packages/eslint-plugin/rules/space-before-blocks/space-before-blocks._ts_.ts
+++ b/packages/eslint-plugin/rules/space-before-blocks/space-before-blocks._ts_.ts
@@ -128,7 +128,7 @@ export default createRule<RuleOptions, MessageIds>({
           requireSpace = alwaysFunctions
           requireNoSpace = neverFunctions
         }
-        else if (node.type === 'ClassBody' || node.type === 'TSEnumBody' || node.type === 'TSInterfaceBody') {
+        else if (node.type === 'ClassBody' || node.type === 'TSEnumBody' || node.type === 'TSInterfaceBody' || node.type === 'TSModuleBlock') {
           requireSpace = alwaysClasses
           requireNoSpace = neverClasses
         }
@@ -177,6 +177,7 @@ export default createRule<RuleOptions, MessageIds>({
       },
       TSEnumBody: checkPrecedingSpace,
       TSInterfaceBody: checkPrecedingSpace,
+      TSModuleBlock: checkPrecedingSpace,
     }
   },
 })


### PR DESCRIPTION
This PR supports checking for space before `TSModuleBlock` nodes.