### PR TITLE
feat(object-property-newline)!: remove deprecated option

### DIFF
--- a/packages/eslint-plugin/rules/object-property-newline/README.md
+++ b/packages/eslint-plugin/rules/object-property-newline/README.md
@@ -84,7 +84,7 @@ Another benefit of this rule is specificity of diffs when a property is changed:
 
 ### Optional Exception
 
-The rule offers one object option, `allowAllPropertiesOnSameLine` (a deprecated synonym is `allowMultiplePropertiesPerLine`). If you set it to `true`, object literals such as the first two above, with all property specifications on the same line, will be permitted, but one like
+The rule offers one object option, `allowAllPropertiesOnSameLine`. If you set it to `true`, object literals such as the first two above, with all property specifications on the same line, will be permitted, but one like
 
 ```js
 const newObject = {

--- a/packages/eslint-plugin/rules/object-property-newline/object-property-newline._js_.test.ts
+++ b/packages/eslint-plugin/rules/object-property-newline/object-property-newline._js_.test.ts
@@ -53,9 +53,6 @@ run<RuleOptions, MessageIds>({
     { code: 'var obj = {k1: [\'foo\', \'bar\'], k2: \'val1\', k3: \'val2\'};', options: [{ allowAllPropertiesOnSameLine: true }] },
     { code: 'var obj = {\nk1: [\'foo\', \'bar\'], k2: \'val1\', k3: \'val2\'\n};', options: [{ allowAllPropertiesOnSameLine: true }] },
     { code: 'var obj = {\nk1: \'val1\', k2: {e1: \'foo\', e2: \'bar\'}, k3: \'val2\'\n};', options: [{ allowAllPropertiesOnSameLine: true }] },
-
-    // allowMultiplePropertiesPerLine: true (deprecated)
-    { code: 'var obj = { k1: \'val1\', k2: \'val2\', k3: \'val3\' };', options: [{ allowMultiplePropertiesPerLine: true }] },
   ],
 
   invalid: [
@@ -632,23 +629,6 @@ run<RuleOptions, MessageIds>({
       output: 'foo({\n...{},\nk1: \'val1\',\nk2: \'val2\'\n})',
       options: [{ allowAllPropertiesOnSameLine: true }],
       parserOptions: { ecmaVersion: 2018 },
-      errors: [
-        {
-          messageId: 'propertiesOnNewlineAll',
-          type: 'ObjectExpression',
-          line: 3,
-          column: 13,
-          endLine: 3,
-          endColumn: 15,
-        },
-      ],
-    },
-
-    // allowMultiplePropertiesPerLine: true (deprecated)
-    {
-      code: 'var obj = {\nk1: \'val1\',\nk2: \'val2\', k3: \'val3\'\n};',
-      output: 'var obj = {\nk1: \'val1\',\nk2: \'val2\',\nk3: \'val3\'\n};',
-      options: [{ allowMultiplePropertiesPerLine: true }],
       errors: [
         {
           messageId: 'propertiesOnNewlineAll',

--- a/packages/eslint-plugin/rules/object-property-newline/object-property-newline._ts_.test.ts
+++ b/packages/eslint-plugin/rules/object-property-newline/object-property-newline._ts_.test.ts
@@ -16,7 +16,6 @@ function createValidRule(input: string[], option: boolean) {
   return Object.entries(prefixOfNodes).flatMap(([_, prefix]) => {
     const res: ValidTestCase<RuleOptions>[] = [
       { code: `${prefix}${code}`, options: [{ allowAllPropertiesOnSameLine: option }] },
-      { code: `${prefix}${code}`, options: [{ /* deprecated */ allowMultiplePropertiesPerLine: option }] },
     ]
     if (!option)
       res.push({ code: `${prefix}${code}` })
@@ -38,7 +37,6 @@ function createInvalidRule(input: string[], out: string[], err: TestCaseError<Me
 
     const res: InvalidTestCase<RuleOptions, MessageIds>[] = [
       { code: `${prefix}${code}`, output: `${prefix}${output}`, errors, options: [{ allowAllPropertiesOnSameLine: option }] },
-      { code: `${prefix}${code}`, output: `${prefix}${output}`, errors, options: [{ /* deprecated */ allowMultiplePropertiesPerLine: option }] },
     ]
     if (!option)
       res.push({ code: `${prefix}${code}`, output: `${prefix}${output}`, errors })

--- a/packages/eslint-plugin/rules/object-property-newline/object-property-newline.ts
+++ b/packages/eslint-plugin/rules/object-property-newline/object-property-newline.ts
@@ -17,10 +17,6 @@ export default createRule<RuleOptions, MessageIds>({
             type: 'boolean',
             default: false,
           },
-          allowMultiplePropertiesPerLine: { // Deprecated
-            type: 'boolean',
-            default: false,
-          },
         },
         additionalProperties: false,
       },
@@ -34,14 +30,12 @@ export default createRule<RuleOptions, MessageIds>({
   defaultOptions: [
     {
       allowAllPropertiesOnSameLine: false,
-      allowMultiplePropertiesPerLine: false,
     },
   ],
 
   create(context) {
-    const allowSameLine = context.options[0] && (
-      (context.options[0].allowAllPropertiesOnSameLine || context.options[0].allowMultiplePropertiesPerLine /* Deprecated */)
-    )
+    const allowSameLine = context.options[0] && (context.options[0].allowAllPropertiesOnSameLine)
+
     const messageId = allowSameLine
       ? 'propertiesOnNewlineAll'
       : 'propertiesOnNewline'

--- a/packages/eslint-plugin/rules/object-property-newline/types.d.ts
+++ b/packages/eslint-plugin/rules/object-property-newline/types.d.ts
@@ -1,10 +1,9 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: 5Mb8fSzqK56KnzBecs-OMMnNTvsiNJ4SHgS3e2dzAPY */
+/* @checksum: soIHpiM5cFCk368MarW27c-YxxnV_-4kK7HlPO1MR1A */
 
 export interface ObjectPropertyNewlineSchema0 {
   allowAllPropertiesOnSameLine?: boolean
-  allowMultiplePropertiesPerLine?: boolean
 }
 
 export type ObjectPropertyNewlineRuleOptions = [


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Since `allowMultiplePropertiesPerLine` was deprecated from [the time it was migrated upstream](https://github.com/eslint-stylistic/eslint-stylistic/commit/4673a27aa94ca1d57a7e6aa4c8698a8fc4d138d7), I think it's time to remove it.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
