### PR TITLE
feat(no-multi-spaces): treat tabs as multiple spaces

### DIFF
--- a/packages/eslint-plugin/rules/no-multi-spaces/README.md
+++ b/packages/eslint-plugin/rules/no-multi-spaces/README.md
@@ -79,7 +79,7 @@ This rule's configuration consists of an object with the following properties:
 
 - `"ignoreEOLComments": true` (defaults to `false`) ignores multiple spaces before comments that occur at the end of lines
 - `"exceptions": { "Property": true, "ImportAttribute": true }` (`"Property"` and `"ImportAttribute"` are the nodes specified by default) specifies nodes to ignore
-- `"includeTabs": false` (defaults to `true`) consider multiple tabs or spaces mixed with tabs as multiple spaces
+- `"includeTabs": boolean | 'as-multiple-spaces'` (defaults to `true`) consider tabs or spaces mixed with tabs as multiple spaces
 
 ### ignoreEOLComments
 
@@ -212,7 +212,7 @@ import someOtherMod from 'some-other-mod';
 
 ### includeTabs
 
-Consider multiple tabs (`\t`) or spaces mixed with tabs as multiple spaces for this rule. This option defaults to `true`.
+Consider multiple tab characters (if `true`), a single tab character (if `as-multiple-spaces`), or spaces mixed with tabs as multiple spaces for this rule. This option defaults to `true`.
 
 Example of **incorrect** code for this rule with the `{ "includeTabs": true }` option:
 

--- a/packages/eslint-plugin/rules/no-multi-spaces/no-multi-spaces.test.ts
+++ b/packages/eslint-plugin/rules/no-multi-spaces/no-multi-spaces.test.ts
@@ -94,6 +94,9 @@ run<RuleOptions, MessageIds>({
 
     // https://github.com/eslint/eslint/issues/9001
     'a'.repeat(2e5),
+
+    { code: 'void\tbar', options: [{ includeTabs: true }] },
+    { code: 'void\t\tbar', options: [{ includeTabs: false }] },
   ],
 
   invalid: [
@@ -711,6 +714,15 @@ run<RuleOptions, MessageIds>({
           data: { displayValue: '"json"' },
         },
       ],
+    },
+    {
+      code: 'void\tfoo',
+      output: 'void foo',
+      options: [{ includeTabs: 'as-multiple-spaces' }],
+      errors: [{
+        messageId: 'multipleSpaces',
+        data: { displayValue: 'foo' },
+      }],
     },
   ],
 })

--- a/packages/eslint-plugin/rules/no-multi-spaces/no-multi-spaces.ts
+++ b/packages/eslint-plugin/rules/no-multi-spaces/no-multi-spaces.ts
@@ -37,7 +37,10 @@ export default createRule<RuleOptions, MessageIds>({
             default: false,
           },
           includeTabs: {
-            type: 'boolean',
+            oneOf: [
+              { type: 'boolean' },
+              { type: 'string', enum: ['as-multiple-spaces'] },
+            ],
             default: true,
           },
         },
@@ -57,7 +60,11 @@ export default createRule<RuleOptions, MessageIds>({
     const exceptions = Object.assign({ Property: true, ImportAttribute: true }, options.exceptions)
     const hasExceptions = Object.keys(exceptions).some(key => exceptions[key])
 
-    const spacesRe = options.includeTabs === false ? / {2}/ : /[ \t]{2}/
+    const spacesRe = options.includeTabs === false
+      ? / {2}/
+      : options.includeTabs === 'as-multiple-spaces'
+        ? /(?:\t| {2})/
+        : /[ \t]{2}/
 
     /**
      * Formats value of given comment token for error message by truncating its length.

--- a/packages/eslint-plugin/rules/no-multi-spaces/types.d.ts
+++ b/packages/eslint-plugin/rules/no-multi-spaces/types.d.ts
@@ -1,13 +1,13 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: hY74YhES9eoNEfu5brdpFWXsHAnaqm_qaqolYKkrxes */
+/* @checksum: w-cQC8WLDQV7ZHyRFgDZlAcqALcP9MozGIpOT2a7L_s */
 
 export interface NoMultiSpacesSchema0 {
   exceptions?: {
     [k: string]: boolean
   }
   ignoreEOLComments?: boolean
-  includeTabs?: boolean
+  includeTabs?: boolean | 'as-multiple-spaces'
 }
 
 export type NoMultiSpacesRuleOptions = [


### PR DESCRIPTION
### Description

As I've proposed in the linked issues, I think `no-multi-spaces` should be able to handle single tab characters as multiple spaces. Even though "single tab" is neither "multi" nor "space" as the rule name suggests, I think this functionality it fits here very well and solves the problems described in the linked issues.

### Linked Issues

#783 #784

