### PR TITLE
docs: `if` property had incorrect name

### DIFF
--- a/packages/eslint-plugin/rules/curly-newline/README.md
+++ b/packages/eslint-plugin/rules/curly-newline/README.md
@@ -32,7 +32,8 @@ You can specify different options for different kinds of blocks:
 }
 ```
 
-- `"IfStatement"` - An `if` statement body
+- `"IfStatementConsequent"` - An `if` statement body
+- `"IfStatementAlternative"` - An `else` statement body
 - `"ForStatement"` - A `for` statement body
 - `"ForInStatement"` - A `for..in` statement body
 - `"ForOfStatement"` - A `for..of` statement body


### PR DESCRIPTION
### Description

Creating a config file using the current documentation gave me the following

> Key "rules": Key "@stylistic/curly-newline": Value {"IfStatement":"always"} should be string. Value {"IfStatement":"always"} should be equal to one of the allowed values. Value {"IfStatement":"always"} should NOT have additional properties. Unexpected property "IfStatement". Expected properties: "IfStatementConsequent", "IfStatementAlternative", "DoWhileStatement", "ForInStatement", "ForOfStatement", "ForStatement", "WhileStatement", "SwitchStatement", "SwitchCase", "TryStatementBlock", "TryStatementHandler", "TryStatementFinalizer", "BlockStatement", "ArrowFunctionExpression", "FunctionDeclaration", "FunctionExpression", "Property", "ClassBody", "StaticBlock", "WithStatement", "TSEnumBody", "TSInterfaceBody", "TSModuleBlock", "multiline", "minElements", "consistent". Value {"IfStatement":"always"} should match exactly one schema in oneOf.

### Linked Issues

Caused by #548

### Additional context

[ESLint Playground](https://eslint-online-playground.netlify.app/#eNp1Uk1vwjAM/StWDgsgaMfEBSamSdtl5x0Jhyx1UVibdknKh4D/PjcpE5029VC/xH7Pfs6JybpOt3InnbK69mn8uRQPsqwLTLaOLRhvHILzVivPH4URRlXGeZBTWMKUDiL86EPVh1kfYh/mv2BVER4MYfkUToXROQxIUBiAuzuS6gJ1DQZZiADOZ+L+CfMQDoUZwqmNiHgwJMKLMGzM0BXa+IQ0c71JyjCrLuvKepr2WCDktiqBP7dAO69VGismddFstIletB8eQlGGuWwKD6tWKuiRoi7QLWDFR6N0RHby9TheRA66Ot0I8EUQvnQ5tmmLO6bbPlRji+PE4J7aQU70XQpaW1neVXd1AG/5u5ceSzR+AVwWe3l01ySANL1NeKEF4FfzV2rsaj0m8yJYkwFkYy3Vp9y0b6Uy5GCQFSzD3SvWaDI0SqMTjCaNPIL952ibJNgsmSVTwTpV0a0p3s2Th3lyL1hogfbILt/qK+A4)
