### PR TITLE
feat: no longer deps on `typescript`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -88,7 +88,7 @@ export default antfu(
       'ts/no-restricted-imports': ['error', {
         patterns: [
           {
-            group: ['@typescript-eslint/utils', '@typescript-eslint/utils/*'],
+            group: ['@typescript-eslint/utils', '@typescript-eslint/utils/*', '@typescript-eslint/types'],
             importNames: [
               'TSESTree',
               'TSESLint',
@@ -137,7 +137,7 @@ export default antfu(
       'ts/no-restricted-imports': ['error', {
         patterns: [
           {
-            group: ['@typescript-eslint/utils'],
+            group: ['@typescript-eslint/utils', '@typescript-eslint/types'],
             importNames: ['AST_NODE_TYPES', 'AST_TOKEN_TYPES', 'ASTUtils'],
             message: 'Import from "#utils/ast" instead',
           },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/picomatch": "catalog:",
     "@types/semver": "catalog:",
     "@typescript-eslint/parser": "catalog:",
+    "@typescript-eslint/types": "catalog:",
     "@typescript-eslint/utils": "catalog:",
     "@vitest/coverage-v8": "catalog:test",
     "@vitest/ui": "catalog:test",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -138,7 +138,8 @@
     "eslint": ">=9.0.0"
   },
   "dependencies": {
-    "@typescript-eslint/utils": "catalog:",
+    "@eslint-community/eslint-utils": "catalog:",
+    "@typescript-eslint/types": "catalog:",
     "eslint-visitor-keys": "catalog:",
     "espree": "catalog:",
     "estraverse": "catalog:",

--- a/packages/shared/types/index.ts
+++ b/packages/shared/types/index.ts
@@ -6,13 +6,13 @@ import type * as ESTree from 'estree'
 // TypeScript Enabled Types (recommended, should be used in most cases)
 export type ASTNode = TSESTree.Node
 export type Token = TSESTree.Token
-export { TSESTree as Tree }
+export type { TSESTree as Tree }
 export type NodeTypes = `${AST_NODE_TYPES}`
-export { JSONSchema } from '@typescript-eslint/utils'
-export {
+export type { JSONSchema } from '@typescript-eslint/utils'
+export type {
   RuleWithMetaAndName,
 } from '@typescript-eslint/utils/eslint-utils'
-export {
+export type {
   EcmaVersion,
   ReportDescriptor,
   ReportFixFunction,

--- a/packages/shared/utils/ast.ts
+++ b/packages/shared/utils/ast.ts
@@ -3,7 +3,7 @@ export * from './ast/general'
 export {
   AST_NODE_TYPES,
   AST_TOKEN_TYPES,
-} from '@typescript-eslint/utils'
+} from '@typescript-eslint/types'
 
 // eslint-disable-next-line ts/no-restricted-imports
 export * from '@typescript-eslint/utils/ast-utils'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     '@antfu/utils':
       specifier: ^9.2.0
       version: 9.2.0
+    '@eslint-community/eslint-utils':
+      specifier: ^4.7.0
+      version: 4.7.0
     '@rollup/plugin-alias':
       specifier: ^5.1.1
       version: 5.1.1
@@ -43,6 +46,9 @@ catalogs:
       specifier: ^7.7.0
       version: 7.7.0
     '@typescript-eslint/parser':
+      specifier: ^8.32.1
+      version: 8.33.1
+    '@typescript-eslint/types':
       specifier: ^8.32.1
       version: 8.33.1
     '@typescript-eslint/utils':
@@ -268,6 +274,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: 'catalog:'
         version: 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/types':
+        specifier: 'catalog:'
+        version: 8.33.1
       '@typescript-eslint/utils':
         specifier: 'catalog:'
         version: 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
@@ -434,9 +443,12 @@ importers:
 
   packages/eslint-plugin:
     dependencies:
-      '@typescript-eslint/utils':
+      '@eslint-community/eslint-utils':
         specifier: 'catalog:'
-        version: 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
+        version: 4.7.0(eslint@9.28.0(jiti@2.4.2))
+      '@typescript-eslint/types':
+        specifier: 'catalog:'
+        version: 8.33.1
       eslint:
         specifier: '>=9.0.0'
         version: 9.28.0(jiti@2.4.2)
@@ -1195,67 +1207,56 @@ packages:
     resolution: {integrity: sha512-UsQD5fyLWm2Fe5CDM7VPYAo+UC7+2Px4Y+N3AcPh/LdZu23YcuGPegQly++XEVaC8XUTFVPscl5y5Cl1twEI4A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.42.0':
     resolution: {integrity: sha512-/i8NIrlgc/+4n1lnoWl1zgH7Uo0XK5xK3EDqVTf38KvyYgCU/Rm04+o1VvvzJZnVS5/cWSd07owkzcVasgfIkQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.42.0':
     resolution: {integrity: sha512-eoujJFOvoIBjZEi9hJnXAbWg+Vo1Ov8n/0IKZZcPZ7JhBzxh2A+2NFyeMZIRkY9iwBvSjloKgcvnjTbGKHE44Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.42.0':
     resolution: {integrity: sha512-/3NrcOWFSR7RQUQIuZQChLND36aTU9IYE4j+TB40VU78S+RA0IiqHR30oSh6P1S9f9/wVOenHQnacs/Byb824g==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.42.0':
     resolution: {integrity: sha512-O8AplvIeavK5ABmZlKBq9/STdZlnQo7Sle0LLhVA7QT+CiGpNVe197/t8Aph9bhJqbDVGCHpY2i7QyfEDDStDg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.42.0':
     resolution: {integrity: sha512-6Qb66tbKVN7VyQrekhEzbHRxXXFFD8QKiFAwX5v9Xt6FiJ3BnCVBuyBxa2fkFGqxOCSGGYNejxd8ht+q5SnmtA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.42.0':
     resolution: {integrity: sha512-KQETDSEBamQFvg/d8jajtRwLNBlGc3aKpaGiP/LvEbnmVUKlFta1vqJqTrvPtsYsfbE/DLg5CC9zyXRX3fnBiA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.42.0':
     resolution: {integrity: sha512-qMvnyjcU37sCo/tuC+JqeDKSuukGAd+pVlRl/oyDbkvPJ3awk6G6ua7tyum02O3lI+fio+eM5wsVd66X0jQtxw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.42.0':
     resolution: {integrity: sha512-I2Y1ZUgTgU2RLddUHXTIgyrdOwljjkmcZ/VilvaEumtS3Fkuhbw4p4hgHc39Ypwvo2o7sBFNl2MquNvGCa55Iw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.42.0':
     resolution: {integrity: sha512-Gfm6cV6mj3hCUY8TqWa63DB8Mx3NADoFwiJrMpoZ1uESbK8FQV3LXkhfry+8bOniq9pqY1OdsjFWNsSbfjPugw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.42.0':
     resolution: {integrity: sha512-g86PF8YZ9GRqkdi0VoGlcDUb4rYtQKyTD1IVtxxN4Hpe7YqLBShA7oHMKU6oKTCi3uxwW4VkIGnOaH/El8de3w==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.42.0':
     resolution: {integrity: sha512-+axkdyDGSp6hjyzQ5m1pgcvQScfHnMCcsXkx8pTgy/6qBmWVhtRVlgxjWwDp67wEXXUr0x+vD6tp5W4x6V7u1A==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ catalog:
   '@antfu/eslint-config': ^4.13.2
   '@antfu/eslint-define-config': 1.23.0-2
   '@antfu/utils': ^9.2.0
+  '@eslint-community/eslint-utils': ^4.7.0
   '@rollup/plugin-alias': ^5.1.1
   '@rollup/plugin-commonjs': ^28.0.3
   '@rollup/plugin-node-resolve': ^16.0.1
@@ -15,6 +16,7 @@ catalog:
   '@types/picomatch': ^4.0.0
   '@types/semver': ^7.7.0
   '@typescript-eslint/parser': ^8.32.1
+  '@typescript-eslint/types': ^8.32.1
   '@typescript-eslint/utils': ^8.32.1
   change-case: ^5.4.4
   escape-string-regexp: ^5.0.0


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This is an experiment to see if we can remove typescript as a peer dependency completely.
We can check the size using pkg.pr.new by opening the PR.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Related to #571

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Before: 37MB (plugin size: 776KB) <https://pkg-size.dev/@stylistic/eslint-plugin>
After: 12MB (plugin size: 803KB) <https://pkg-size.dev/https:%2F%2Fpkg.pr.new%2F@stylistic%2Feslint-plugin@838>
