### PR TITLE
refactor: unify the usage of `isTokenOnSameLine` and `isSingleLine`

### DIFF
--- a/packages/eslint-plugin/rules/array-bracket-newline/array-bracket-newline.ts
+++ b/packages/eslint-plugin/rules/array-bracket-newline/array-bracket-newline.ts
@@ -195,17 +195,17 @@ export default createRule<RuleOptions, MessageIds>({
         || (
           options.multiline
           && elements.length > 0
-          && firstIncComment.loc!.start.line !== lastIncComment.loc!.end.line
+          && !isTokenOnSameLine(lastIncComment, firstIncComment)
         )
         || (
           elements.length === 0
           && firstIncComment.type === 'Block'
-          && firstIncComment.loc!.start.line !== lastIncComment.loc!.end.line
+          && !isTokenOnSameLine(lastIncComment, firstIncComment)
           && firstIncComment === lastIncComment
         )
         || (
           options.consistent
-          && openBracket.loc.end.line !== first.loc.start.line
+          && !isTokenOnSameLine(openBracket, first)
         )
       )
 

--- a/packages/eslint-plugin/rules/array-element-newline/array-element-newline.ts
+++ b/packages/eslint-plugin/rules/array-element-newline/array-element-newline.ts
@@ -225,8 +225,8 @@ export default createRule<RuleOptions, MessageIds>({
        */
       if (options.multiline) {
         elementBreak = elements
-          .filter((element: any) => element !== null)
-          .some((element: any) => element!.loc.start.line !== element!.loc.end.line)
+          .filter(element => element !== null)
+          .some(element => element.loc.start.line !== element.loc.end.line)
       }
 
       let linebreaksCount = 0

--- a/packages/eslint-plugin/rules/comma-dangle/comma-dangle.ts
+++ b/packages/eslint-plugin/rules/comma-dangle/comma-dangle.ts
@@ -1,6 +1,6 @@
 import type { EcmaVersion, Tree } from '#types'
 import type { MessageIds, RuleOptions, Value } from './types'
-import { AST_NODE_TYPES, getNextLocation, isCommaToken } from '#utils/ast'
+import { AST_NODE_TYPES, getNextLocation, isCommaToken, isTokenOnSameLine } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 type Extract<T> = T extends Record<any, any> ? T : never
@@ -212,7 +212,7 @@ export default createRule<RuleOptions, MessageIds>({
       if (!lastToken)
         return false
 
-      return lastToken.loc.end.line !== penultimateToken.loc.end.line
+      return !isTokenOnSameLine(lastToken, penultimateToken)
     }
 
     /**

--- a/packages/eslint-plugin/rules/curly-newline/curly-newline.ts
+++ b/packages/eslint-plugin/rules/curly-newline/curly-newline.ts
@@ -184,7 +184,7 @@ export default createRule<RuleOptions, MessageIds>({
       let last = sourceCode.getTokenBefore(closeBrace, { includeComments: true })!
 
       const needsLineBreaks = elementCount >= options.minElements
-        || (options.multiline && elementCount > 0 && first.loc.start.line !== last.loc.end.line)
+        || (options.multiline && elementCount > 0 && !isTokenOnSameLine(last, first))
 
       const hasCommentsFirstToken = isCommentToken(first)
       const hasCommentsLastToken = isCommentToken(last)

--- a/packages/eslint-plugin/rules/function-paren-newline/function-paren-newline.ts
+++ b/packages/eslint-plugin/rules/function-paren-newline/function-paren-newline.ts
@@ -80,7 +80,7 @@ export default createRule<RuleOptions, MessageIds>({
         return hasLeftNewline
 
       if (multilineOption || multilineArgumentsOption)
-        return elements.some((element, index) => index !== elements.length - 1 && element.loc.end.line !== elements[index + 1].loc.start.line)
+        return elements.some((element, index) => index !== elements.length - 1 && !isTokenOnSameLine(element, elements[index + 1]))
 
       if (consistentOption)
         return hasLeftNewline
@@ -159,7 +159,7 @@ export default createRule<RuleOptions, MessageIds>({
       for (let i = 0; i <= elements.length - 2; i++) {
         const currentElement = elements[i]
         const nextElement = elements[i + 1]
-        const hasNewLine = currentElement.loc.end.line !== nextElement.loc.start.line
+        const hasNewLine = !isTokenOnSameLine(currentElement, nextElement)
 
         if (!hasNewLine && needsNewlines) {
           context.report({

--- a/packages/eslint-plugin/rules/implicit-arrow-linebreak/implicit-arrow-linebreak.ts
+++ b/packages/eslint-plugin/rules/implicit-arrow-linebreak/implicit-arrow-linebreak.ts
@@ -5,7 +5,7 @@
 
 import type { Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
-import { isCommentToken, isNotOpeningParenToken } from '#utils/ast'
+import { isCommentToken, isNotOpeningParenToken, isTokenOnSameLine } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 export default createRule<RuleOptions, MessageIds>({
@@ -46,14 +46,16 @@ export default createRule<RuleOptions, MessageIds>({
       const arrowToken = sourceCode.getTokenBefore(node.body, isNotOpeningParenToken)!
       const firstTokenOfBody = sourceCode.getTokenAfter(arrowToken)!
 
-      if (arrowToken.loc.end.line === firstTokenOfBody.loc.start.line && option === 'below') {
+      const onSameLine = isTokenOnSameLine(arrowToken, firstTokenOfBody)
+
+      if (onSameLine && option === 'below') {
         context.report({
           node: firstTokenOfBody,
           messageId: 'expected',
           fix: fixer => fixer.insertTextBefore(firstTokenOfBody, '\n'),
         })
       }
-      else if (arrowToken.loc.end.line !== firstTokenOfBody.loc.start.line && option === 'beside') {
+      else if (!onSameLine && option === 'beside') {
         context.report({
           node: firstTokenOfBody,
           messageId: 'unexpected',

--- a/packages/eslint-plugin/rules/indent/indent.ts
+++ b/packages/eslint-plugin/rules/indent/indent.ts
@@ -1006,7 +1006,7 @@ export default createRule<RuleOptions, MessageIds>({
           ? sourceCode.getTokenBefore(node.callee, { skip: calleeParenCount - 1 })!
           : sourceCode.getFirstToken(node.callee)!
         const lastTokenOfCallee = sourceCode.getTokenBefore(dotToken)!
-        const offsetBase = lastTokenOfCallee.loc.end.line === openingParen.loc.start.line
+        const offsetBase = isTokenOnSameLine(lastTokenOfCallee, openingParen)
           ? lastTokenOfCallee
           : firstTokenOfCallee
 
@@ -1190,7 +1190,7 @@ export default createRule<RuleOptions, MessageIds>({
          *   baz // as a result, `baz` is offset by 1 rather than 2
          * )
          */
-        if (lastConsequentToken.loc.end.line === firstAlternateToken.loc.start.line) {
+        if (isTokenOnSameLine(lastConsequentToken, firstAlternateToken)) {
           offsets.setDesiredOffset(firstAlternateToken, firstConsequentToken, 0)
         }
         else {
@@ -1271,7 +1271,7 @@ export default createRule<RuleOptions, MessageIds>({
        *   .bar
        *   .baz // <-- offset by 1 from `foo`
        */
-      const offsetBase = lastObjectToken.loc.end.line === firstPropertyToken.loc.start.line
+      const offsetBase = isTokenOnSameLine(lastObjectToken, firstPropertyToken)
         ? lastObjectToken
         : firstObjectToken
 
@@ -1709,8 +1709,8 @@ export default createRule<RuleOptions, MessageIds>({
             ? sourceCode.getFirstToken(previousQuasi)
             : null
 
-          const startsOnSameLine = previousQuasi.loc.end.line === expression.loc.start.line
-          const endsOnSameLine = nextQuasi.loc.start.line === expression.loc.end.line
+          const startsOnSameLine = isTokenOnSameLine(previousQuasi, expression)
+          const endsOnSameLine = isTokenOnSameLine(expression, nextQuasi)
 
           if (tokenToAlignFrom || (endsOnSameLine && !startsOnSameLine)) {
             offsets.setDesiredOffsets([previousQuasi.range[1], nextQuasi.range[0]], tokenToAlignFrom, 1)

--- a/packages/eslint-plugin/rules/jsx-curly-newline/jsx-curly-newline.ts
+++ b/packages/eslint-plugin/rules/jsx-curly-newline/jsx-curly-newline.ts
@@ -4,6 +4,7 @@
 
 import type { ASTNode, RuleContext, Token } from '#types'
 import type { MessageIds, RuleOptions } from './types'
+import { isTokenOnSameLine } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 function getNormalizedOption(context: Readonly<RuleContext<MessageIds, RuleOptions>>) {
@@ -78,16 +79,6 @@ export default createRule<RuleOptions, MessageIds>({
   create(context) {
     const sourceCode = context.sourceCode
     const option = getNormalizedOption(context)
-
-    /**
-     * Determines whether two adjacent tokens are on the same line.
-     * @param left - The left token object.
-     * @param right - The right token object.
-     * @returns Whether or not the tokens are on the same line.
-     */
-    function isTokenOnSameLine(left: ASTNode | Token, right: ASTNode | Token) {
-      return left.loc.end.line === right.loc.start.line
-    }
 
     /**
      * Determines whether there should be newlines inside curlys

--- a/packages/eslint-plugin/rules/jsx-function-call-newline/jsx-function-call-newline.ts
+++ b/packages/eslint-plugin/rules/jsx-function-call-newline/jsx-function-call-newline.ts
@@ -5,6 +5,7 @@
 
 import type { ASTNode, RuleContext, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
+import { isTokenOnSameLine } from '#utils/ast'
 import { isJSX } from '#utils/ast/jsx'
 import { createRule } from '#utils/create-rule'
 
@@ -45,7 +46,7 @@ export default createRule<RuleOptions, MessageIds>({
     function needsOpeningNewLine(node: ASTNode) {
       const previousToken = context.sourceCode.getTokenBefore(node)!
 
-      if (previousToken.loc.end.line === node.loc.start.line)
+      if (isTokenOnSameLine(previousToken, node))
         return true
 
       return false

--- a/packages/eslint-plugin/rules/jsx-wrap-multilines/jsx-wrap-multilines.ts
+++ b/packages/eslint-plugin/rules/jsx-wrap-multilines/jsx-wrap-multilines.ts
@@ -5,7 +5,7 @@
 
 import type { ASTNode, Token } from '#types'
 import type { MessageIds, RuleOptions } from './types'
-import { isParenthesized } from '#utils/ast'
+import { isParenthesized, isTokenOnSameLine } from '#utils/ast'
 import { isJSX } from '#utils/ast/jsx'
 import { createRule } from '#utils/create-rule'
 
@@ -98,7 +98,7 @@ export default createRule<RuleOptions, MessageIds>({
       if (!isParenthesized(node, context.sourceCode))
         return false
 
-      if (previousToken.loc.end.line === node.loc.start.line)
+      if (isTokenOnSameLine(previousToken, node))
         return true
 
       return false
@@ -110,7 +110,7 @@ export default createRule<RuleOptions, MessageIds>({
       if (!isParenthesized(node, context.sourceCode))
         return false
 
-      if (node.loc.end.line === nextToken.loc.end.line)
+      if (isTokenOnSameLine(node, nextToken))
         return true
 
       return false

--- a/packages/eslint-plugin/rules/key-spacing/key-spacing.ts
+++ b/packages/eslint-plugin/rules/key-spacing/key-spacing.ts
@@ -7,6 +7,7 @@ import {
   isClosingBracketToken,
   isColonToken,
   isOpeningBraceToken,
+  isTokenOnSameLine,
   LINEBREAK_MATCHER,
 } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
@@ -346,7 +347,7 @@ export default createRule<RuleOptions, MessageIds>({
       }
       const openingBrace = sourceCode.getTokenBefore(node.attributes[0], isOpeningBraceToken)!
       const closingBrace = sourceCode.getTokenAfter(node.attributes[node.attributes.length - 1], isClosingBraceToken)!
-      return (closingBrace.loc.end.line === openingBrace.loc.start.line)
+      return (isTokenOnSameLine(closingBrace, openingBrace))
     }
 
     /**
@@ -358,7 +359,7 @@ export default createRule<RuleOptions, MessageIds>({
       const [firstProp] = properties
       const lastProp = properties.at(-1)!
 
-      return firstProp.loc.start.line === lastProp.loc.end.line
+      return isTokenOnSameLine(lastProp, firstProp)
     }
 
     /**
@@ -773,7 +774,7 @@ export default createRule<RuleOptions, MessageIds>({
     ): node is KeyTypeNodeWithTypeAnnotation {
       return (
         isKeyTypeNode(node)
-        && node.typeAnnotation.loc.start.line === node.loc.end.line
+        && isTokenOnSameLine(node, node.typeAnnotation)
       )
     }
 

--- a/packages/eslint-plugin/rules/line-comment-position/line-comment-position.ts
+++ b/packages/eslint-plugin/rules/line-comment-position/line-comment-position.ts
@@ -3,7 +3,7 @@
  * @author Alberto Rodríguez
  */
 import type { MessageIds, RuleOptions } from './types'
-import { COMMENTS_IGNORE_PATTERN } from '#utils/ast'
+import { COMMENTS_IGNORE_PATTERN, isTokenOnSameLine } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 export default createRule<RuleOptions, MessageIds>({
@@ -92,7 +92,7 @@ export default createRule<RuleOptions, MessageIds>({
             return
 
           const previous = sourceCode.getTokenBefore(node, { includeComments: true })
-          const isOnSameLine = previous && previous.loc.end.line === node.loc.start.line
+          const isOnSameLine = previous && isTokenOnSameLine(previous, node)
 
           if (above) {
             if (isOnSameLine) {

--- a/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style.ts
+++ b/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style.ts
@@ -5,7 +5,7 @@
 
 import type { Token, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
-import { COMMENTS_IGNORE_PATTERN, LINEBREAK_MATCHER } from '#utils/ast'
+import { COMMENTS_IGNORE_PATTERN, isTokenOnSameLine, LINEBREAK_MATCHER } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 export default createRule<RuleOptions, MessageIds>({
@@ -363,7 +363,7 @@ export default createRule<RuleOptions, MessageIds>({
 
         const tokenAfter = sourceCode.getTokenAfter(firstComment, { includeComments: true })
 
-        if (tokenAfter && firstComment.loc.end.line === tokenAfter.loc.start.line)
+        if (tokenAfter && isTokenOnSameLine(firstComment, tokenAfter))
           return
 
         context.report({

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens.ts
@@ -17,6 +17,7 @@ import {
   isOpeningBracketToken,
   isOpeningParenToken,
   isParenthesized as isParenthesizedRaw,
+  isTokenOnSameLine,
   isTopLevelExpressionStatement,
   isTypeAssertion,
   skipChainExpression,
@@ -506,7 +507,7 @@ export default createRule<RuleOptions, MessageIds>({
      * @private
      */
     function hasExcessParensNoLineTerminator(token: Token, node: ASTNode) {
-      if (token.loc.end.line === node.loc.start.line)
+      if (isTokenOnSameLine(token, node))
         return hasExcessParens(node)
 
       return hasDoubleExcessParens(node)
@@ -1424,7 +1425,7 @@ export default createRule<RuleOptions, MessageIds>({
           const { argument } = node
           const operatorToken = sourceCode.getLastToken(node)!
 
-          if (argument.loc.end.line === operatorToken.loc.start.line) {
+          if (isTokenOnSameLine(argument, operatorToken)) {
             checkArgumentWithPrecedence(node)
           }
           else {

--- a/packages/eslint-plugin/rules/nonblock-statement-body-position/nonblock-statement-body-position.ts
+++ b/packages/eslint-plugin/rules/nonblock-statement-body-position/nonblock-statement-body-position.ts
@@ -5,6 +5,7 @@
 
 import type { JSONSchema, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
+import { isTokenOnSameLine } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 type KeywordName = keyof NonNullable<NonNullable<RuleOptions['1']>['overrides']>
@@ -79,14 +80,16 @@ export default createRule<RuleOptions, MessageIds>({
 
       const tokenBefore = sourceCode.getTokenBefore(node)!
 
-      if (tokenBefore.loc.end.line === node.loc.start.line && option === 'below') {
+      const onSameLine = isTokenOnSameLine(tokenBefore, node)
+
+      if (onSameLine && option === 'below') {
         context.report({
           node,
           messageId: 'expectLinebreak',
           fix: fixer => fixer.insertTextBefore(node, '\n'),
         })
       }
-      else if (tokenBefore.loc.end.line !== node.loc.start.line && option === 'beside') {
+      else if (!onSameLine && option === 'beside') {
         context.report({
           node,
           messageId: 'expectNoLinebreak',

--- a/packages/eslint-plugin/rules/object-curly-newline/object-curly-newline.ts
+++ b/packages/eslint-plugin/rules/object-curly-newline/object-curly-newline.ts
@@ -211,7 +211,7 @@ export default createRule<RuleOptions, MessageIds>({
         || (
           options.multiline
           && objectProperties.length > 0
-          && first.loc.start.line !== last.loc.end.line
+          && !isTokenOnSameLine(last, first)
         )
     }
 

--- a/packages/eslint-plugin/rules/object-property-newline/object-property-newline.ts
+++ b/packages/eslint-plugin/rules/object-property-newline/object-property-newline.ts
@@ -1,5 +1,6 @@
 import type { ASTNode, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
+import { isTokenOnSameLine } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 export default createRule<RuleOptions, MessageIds>({
@@ -48,7 +49,7 @@ export default createRule<RuleOptions, MessageIds>({
           const firstTokenOfFirstProperty = sourceCode.getFirstToken(children[0])!
           const lastTokenOfLastProperty = sourceCode.getLastToken(children[children.length - 1])!
 
-          if (firstTokenOfFirstProperty.loc.end.line === lastTokenOfLastProperty.loc.start.line) {
+          if (isTokenOnSameLine(firstTokenOfFirstProperty, lastTokenOfLastProperty)) {
             // All keys and values are on the same line
             return
           }
@@ -59,7 +60,7 @@ export default createRule<RuleOptions, MessageIds>({
         const lastTokenOfPreviousProperty = sourceCode.getLastToken(children[i - 1])!
         const firstTokenOfCurrentProperty = sourceCode.getFirstToken(children[i])!
 
-        if (lastTokenOfPreviousProperty.loc.end.line === firstTokenOfCurrentProperty.loc.start.line) {
+        if (isTokenOnSameLine(lastTokenOfPreviousProperty, firstTokenOfCurrentProperty)) {
           context.report({
             node,
             loc: firstTokenOfCurrentProperty.loc,

--- a/packages/eslint-plugin/rules/one-var-declaration-per-line/one-var-declaration-per-line.ts
+++ b/packages/eslint-plugin/rules/one-var-declaration-per-line/one-var-declaration-per-line.ts
@@ -5,6 +5,7 @@
 
 import type { NodeTypes, RuleFixer, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
+import { isTokenOnSameLine } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 export default createRule<RuleOptions, MessageIds>({
@@ -57,7 +58,7 @@ export default createRule<RuleOptions, MessageIds>({
       let prev: Tree.LetOrConstOrVarDeclarator
 
       declarations.forEach((current) => {
-        if (prev && prev.loc.end.line === current.loc.start.line) {
+        if (prev && isTokenOnSameLine(prev, current)) {
           if (always || prev.init || current.init) {
             let fix = (fixer: RuleFixer) => fixer.insertTextBefore(current, '\n')
             const tokenBeforeDeclarator = sourceCode.getTokenBefore(current, { includeComments: false })

--- a/packages/eslint-plugin/rules/padded-blocks/padded-blocks.ts
+++ b/packages/eslint-plugin/rules/padded-blocks/padded-blocks.ts
@@ -127,7 +127,7 @@ export default createRule<RuleOptions, MessageIds>({
       do {
         prev = first
         first = sourceCode.getTokenAfter(first, { includeComments: true })!
-      } while (isComment(first) && first.loc.start.line === prev.loc.end.line)
+      } while (isComment(first) && isTokenOnSameLine(prev, first))
 
       return first
     }
@@ -144,7 +144,7 @@ export default createRule<RuleOptions, MessageIds>({
       do {
         next = last
         last = sourceCode.getTokenBefore(last, { includeComments: true })!
-      } while (isComment(last) && last.loc.end.line === next.loc.start.line)
+      } while (isComment(last) && isTokenOnSameLine(last, next))
 
       return last
     }

--- a/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements.ts
+++ b/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements.ts
@@ -328,8 +328,8 @@ function getActualLastToken(
       && nextToken
       && prevToken.range[0] >= node.range[0]
       && isSemicolonToken(semiToken)
-      && semiToken.loc.start.line !== prevToken.loc.end.line
-      && semiToken.loc.end.line === nextToken.loc.start.line
+      && !isTokenOnSameLine(prevToken, semiToken)
+      && isTokenOnSameLine(semiToken, nextToken)
 
   return isSemicolonLessStyle ? prevToken : semiToken
 }

--- a/packages/eslint-plugin/rules/semi/semi.ts
+++ b/packages/eslint-plugin/rules/semi/semi.ts
@@ -320,9 +320,9 @@ export default createRule<RuleOptions, MessageIds>({
         return parent.loc.start.line === parent.loc.end.line
 
       if (parent.type === 'StaticBlock') {
-        const openingBrace = sourceCode.getFirstToken(parent, { skip: 1 }) as Token
+        const openingBrace = sourceCode.getFirstToken(parent, { skip: 1 })!
 
-        return openingBrace.loc.start.line === parent.loc.end.line
+        return isTokenOnSameLine(parent, openingBrace)
       }
 
       return false

--- a/packages/shared/utils/ast/general.ts
+++ b/packages/shared/utils/ast/general.ts
@@ -1,6 +1,6 @@
 import type { ASTNode, SourceCode, Token, Tree } from '#types'
 import type { AST_NODE_TYPES } from '@typescript-eslint/utils'
-import { isClosingParenToken, isColonToken, isFunction, isOpeningParenToken, LINEBREAK_MATCHER } from '@typescript-eslint/utils/ast-utils'
+import { isClosingParenToken, isColonToken, isFunction, isOpeningParenToken, isTokenOnSameLine, LINEBREAK_MATCHER } from '@typescript-eslint/utils/ast-utils'
 import { KEYS as eslintVisitorKeys } from 'eslint-visitor-keys'
 // @ts-expect-error missing types
 import { latestEcmaVersion, tokenize } from 'espree'
@@ -757,9 +757,11 @@ export function getFirstNodeInLine(context: { sourceCode: SourceCode }, node: AS
  */
 export function isNodeFirstInLine(context: { sourceCode: SourceCode }, node: ASTNode) {
   const token = getFirstNodeInLine(context, node)
-  const startLine = node.loc!.start.line
-  const endLine = token ? token.loc.end.line : -1
-  return startLine !== endLine
+
+  if (!token)
+    return false
+
+  return !isTokenOnSameLine(token, node)
 }
 
 /**


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
