### PR TITLE
test: add case showing fixed handling of ignoredNodes option

### DIFF
--- a/packages/eslint-plugin/rules/indent/indent._ts_.test.ts
+++ b/packages/eslint-plugin/rules/indent/indent._ts_.test.ts
@@ -2012,6 +2012,48 @@ class Foo {
         },
       ],
     },
+    // Type parameter is no longer mistaken for JSX opening element and ignored
+    // (failed in v4.4.1 in that no lint errors were reported, but now passes)
+    {
+      code: $`
+        async function foo(
+          a: string,
+          b: number,
+        ): Promise<{
+          prop1: string,
+          prop2: number,
+          prop3: boolean,
+          prop4: string[],
+        }> {
+          return {} as any;
+        }
+      `,
+      output: $`
+        async function foo(
+          a: string,
+          b: number,
+        ): Promise<{
+            prop1: string,
+            prop2: number,
+            prop3: boolean,
+            prop4: string[],
+          }> {
+          return {} as any;
+        }
+      `,
+      options: [2, {
+        ignoredNodes: [
+          'JSXOpeningElement',
+        ],
+      }],
+      errors: [
+        { messageId: 'wrongIndentation', data: { expected: '4 spaces', actual: 2 }, line: 5, column: 1 },
+        { messageId: 'wrongIndentation', data: { expected: '4 spaces', actual: 2 }, line: 6, column: 1 },
+        { messageId: 'wrongIndentation', data: { expected: '4 spaces', actual: 2 }, line: 7, column: 1 },
+        { messageId: 'wrongIndentation', data: { expected: '4 spaces', actual: 2 }, line: 8, column: 1 },
+        { messageId: 'wrongIndentation', data: { expected: '2 spaces', actual: 0 }, line: 9, column: 1 },
+      ],
+    },
     // https://github.com/eslint-stylistic/eslint-stylistic/issues/486
     {
       code: `


### PR DESCRIPTION
### Description

Add a test case reflecting fixed `ignoredNodes` handling in the `indent` rule.

This case fails when backported to v4.4.1 but passes in v5.0.0. So it serves as a regression test for (and illustration of) a bug fixed in 5.0.0.

I initially thought this was a regression, because my codebase saw no lint violations with v4.4.1 on a function like this:

```ts
async function foo(
  a: string,
  b: number,
): Promise<{
  prop1: string,
  prop2: number,
  prop3: boolean,
  prop4: string[],
}> {
  return {} as any;
}
```

but did get lint violations when I tried to update `@stylistic/eslint-plugin` to v5.0.0, and none of the breaking changes in the release notes seemed to explain this.

But really I think my code was just wrongly accepted by v4.4.1 because my configuration specified:

```
      '@stylistic/indent': [
        'error',
        2,
        {
          ignoredNodes: [
            // ...
            'JSXOpeningElement',
            // ...
          ],
        },
      ],
```

... and the type parameter in the return type was mistaken for a JSX element and thus wrongly ignored, and this was fixed in 5.0.0.

### Linked Issues

This seems likely related (though I'm just guessing!) to https://github.com/eslint-stylistic/eslint-stylistic/issues/754 and its fix in https://github.com/eslint-stylistic/eslint-stylistic/pull/785 — this seems like the opposite problem, wrongly ignoring nodes that should not be ignored, but for a similar reason (type parameters being treated like a JSX opening element)

### Additional context

I notice [this fudge][1] going away in #785 which seems likely to play a part in the fix being tested here:

```diff
-      TSTypeParameterInstantiation(node) {
-        if (!node.params.length)
-          return
-
-        const [name, ...attributes] = node.params
-
-        // JSX is about the closest we can get because the angle brackets
-        // it's not perfect but it works!
-        return rules.JSXOpeningElement({
```

[1]: https://github.com/eslint-stylistic/eslint-stylistic/pull/785/files#diff-2fbf78b49d54aae8589181cd750ea261b258f15e291fe3798e3cd6c39a008a01L2392-L2400
