### PR TITLE
fix(indent): correct handling of return type annotations

### DIFF
--- a/packages/eslint-plugin/rules/indent/indent._ts_.test.ts
+++ b/packages/eslint-plugin/rules/indent/indent._ts_.test.ts
@@ -845,6 +845,50 @@ const map2 = Object.keys(map)
       `,
       options: [2, { VariableDeclarator: { using: 'first' } }],
     },
+    {
+      code: $`
+        async function foo(bar: number): Promise<
+          number
+        > {
+          return 2;
+        }
+      `,
+      options: [2],
+    },
+    {
+      code: $`
+        async function foo(
+          bar: number,
+        ): Promise<
+          number
+        > {
+          return 2;
+        }
+      `,
+      options: [2],
+    },
+    {
+      code: $`
+        function foo(bar: number): (
+          number
+        ) {
+          return 2;
+        }
+      `,
+      options: [2],
+    },
+    {
+      code: $`
+        function foo(
+          bar: number,
+        ): (
+          number
+        ) {
+          return 2;
+        }
+      `,
+      options: [2],
+    },
   ],
   invalid: [
     ...individualNodeTests.invalid!,

--- a/packages/eslint-plugin/rules/indent/indent._ts_.test.ts
+++ b/packages/eslint-plugin/rules/indent/indent._ts_.test.ts
@@ -889,6 +889,20 @@ const map2 = Object.keys(map)
       `,
       options: [2],
     },
+    {
+      code: $`
+        const a = (
+          param: 2 | 3,
+        ): Promise<
+          (
+            2 | 3
+          )
+        > => {
+          return Promise.resolve(param)
+        }
+      `,
+      options: [2],
+    },
   ],
   invalid: [
     ...individualNodeTests.invalid!,

--- a/packages/eslint-plugin/rules/indent/indent.ts
+++ b/packages/eslint-plugin/rules/indent/indent.ts
@@ -1497,20 +1497,25 @@ export default createRule<RuleOptions, MessageIds>({
       },
 
       'FunctionDeclaration, FunctionExpression': function (node: Tree.FunctionDeclaration | Tree.FunctionExpression) {
-        const closingParen = sourceCode.getTokenBefore(node.body)!
-        const openingParen = sourceCode.getTokenBefore(
-          node.params.length
-            ? node.params[0].decorators?.length
-              ? node.params[0].decorators[0]
-              : node.params[0] : closingParen,
-          {
-            filter: isOpeningParenToken,
-          },
-        )!
+        const paramsClosingParen = sourceCode.getTokenBefore(
+          node.returnType ?? node.body,
+          { filter: isClosingParenToken },
+        )
+        if (!paramsClosingParen)
+          throw new Error('Expected to find a closing parenthesis for function parameters.')
 
-        parameterParens.add(openingParen)
-        parameterParens.add(closingParen)
-        addElementListIndent(node.params, openingParen, closingParen, options[node.type].parameters)
+        const paramsOpeningParen = sourceCode.getTokenBefore(
+          node.params.length
+            ? (node.params[0].decorators?.[0] ?? node.params[0])
+            : paramsClosingParen,
+          { filter: isOpeningParenToken },
+        )
+        if (!paramsOpeningParen)
+          throw new Error('Expected to find an opening parenthesis for function parameters.')
+
+        parameterParens.add(paramsOpeningParen)
+        parameterParens.add(paramsClosingParen)
+        addElementListIndent(node.params, paramsOpeningParen, paramsClosingParen, options[node.type].parameters)
       },
 
       IfStatement(node) {

--- a/packages/eslint-plugin/rules/indent/indent.ts
+++ b/packages/eslint-plugin/rules/indent/indent.ts
@@ -1372,7 +1372,10 @@ export default createRule<RuleOptions, MessageIds>({
 
         if (isOpeningParenToken(maybeOpeningParen)) {
           const openingParen = maybeOpeningParen
-          const closingParen = sourceCode.getTokenBefore(node.body, isClosingParenToken)!
+          const closingParen = sourceCode.getTokenBefore(
+            node.returnType ?? node.body,
+            { filter: isClosingParenToken },
+          )!
 
           parameterParens.add(openingParen)
           parameterParens.add(closingParen)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

The `indent` rule has special handling for indenting the contents of a function definition’s parameters (in a FunctionDeclaration, FunctionExpression, or ArrowFunctionExpression). However, the method for identifying the closing parenthesis of a function definition’s parameters was incorrect:

https://github.com/eslint-stylistic/eslint-stylistic/blob/aa436b8415fa7fe627468ae1b1c75a5f41fe111d/packages/eslint-plugin/rules/indent/indent.ts#L1500

This is incorrect for functions that include return type annotations—since those come between the end of the parameter list and the start of the function body, the “token before the function body” would be the end of the return type annotation, **not** the end of the parameters as expected.

This too-wide range for the function parameters causes incorrect indentation within functions’ return type annotations, as noted in #851 and #846.


### Linked Issues

Fixes #851, closes #846 