### PR TITLE
feat(no-extra-parens): support part of TS Nodes

### DIFF
--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.test.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.test.ts
@@ -479,5 +479,13 @@ run<RuleOptions, MessageIds>({
         },
       ],
     },
+    {
+      code: 'function foo(x: (number)): (boolean) {}',
+      output: 'function foo(x: number): boolean {}',
+      errors: [
+        { messageId: 'unexpected' },
+        { messageId: 'unexpected' },
+      ],
+    },
   ],
 })

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.test.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.test.ts
@@ -358,6 +358,9 @@ run<RuleOptions, MessageIds>({
     {
       code: 'const x = (1 satisfies number).toFixed();',
     },
+
+    `type Foo = string & (number | 'bar')`,
+    `type Foo = (a extends string ? 'bar' : number)[]`,
   ],
 
   invalid: [
@@ -513,6 +516,28 @@ run<RuleOptions, MessageIds>({
           B = "x",
         }
       `,
+      errors: [
+        { messageId: 'unexpected' },
+      ],
+    },
+    {
+      code: `type Foo = (string & number) | 'bar'`,
+      output: `type Foo = string & number | 'bar'`,
+      errors: [
+        { messageId: 'unexpected' },
+      ],
+    },
+    {
+      code: 'type Foo = ((string | number))[]',
+      output: 'type Foo = (string | number)[]',
+      errors: [
+        { messageId: 'unexpected' },
+      ],
+    },
+    {
+      code: `type Foo = ((import('x')))[]`,
+      output: `type Foo = import('x')[]`,
+      recursive: Number.POSITIVE_INFINITY,
       errors: [
         { messageId: 'unexpected' },
       ],

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.test.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.test.ts
@@ -502,19 +502,18 @@ run<RuleOptions, MessageIds>({
     },
     {
       code: $`
-        enum Foo = {
-          A = (1),
+        enum Foo {
+          A,
           B = ("x"),
         }
       `,
       output: $`
-        enum Foo = {
-          A = 1,
+        enum Foo {
+          A,
           B = "x",
         }
       `,
       errors: [
-        { messageId: 'unexpected' },
         { messageId: 'unexpected' },
       ],
     },

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.test.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.test.ts
@@ -487,5 +487,36 @@ run<RuleOptions, MessageIds>({
         { messageId: 'unexpected' },
       ],
     },
+    {
+      code: $`
+        type Foo = ({
+          a: <T>(x: T) => any
+        })
+      `,
+      output: $`
+        type Foo = {
+          a: <T>(x: T) => any
+        }
+      `,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: $`
+        enum Foo = {
+          A = (1),
+          B = ("x"),
+        }
+      `,
+      output: $`
+        enum Foo = {
+          A = 1,
+          B = "x",
+        }
+      `,
+      errors: [
+        { messageId: 'unexpected' },
+        { messageId: 'unexpected' },
+      ],
+    },
   ],
 })

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens.ts
@@ -1479,10 +1479,19 @@ export default createRule<RuleOptions, MessageIds>({
       },
       TSTypeAnnotation(node) {
         if (hasExcessParens(node.typeAnnotation)) {
-          report({
-            ...node.typeAnnotation,
-            type: AST_NODE_TYPES.FunctionExpression as any,
-          })
+          report(node.typeAnnotation)
+        }
+      },
+      TSTypeAliasDeclaration(node) {
+        if (hasExcessParens(node.typeAnnotation)) {
+          report(node.typeAnnotation)
+        }
+      },
+      TSEnumMember(node) {
+        if (!node.initializer)
+          return
+        if (hasExcessParens(node.initializer)) {
+          report(node.initializer)
         }
       },
     }

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens.ts
@@ -1477,6 +1477,22 @@ export default createRule<RuleOptions, MessageIds>({
           report(node.argument)
         }
       },
+      TSArrayType(node) {
+        if (hasExcessParensWithPrecedence(node.elementType, precedence(node)))
+          report(node.elementType)
+      },
+      TSIntersectionType(node) {
+        node.types.forEach((type) => {
+          if (hasExcessParensWithPrecedence(type, precedence(node)))
+            report(type)
+        })
+      },
+      TSUnionType(node) {
+        node.types.forEach((type) => {
+          if (hasExcessParensWithPrecedence(type, precedence(node)))
+            report(type)
+        })
+      },
       TSTypeAnnotation(node) {
         if (hasExcessParens(node.typeAnnotation)) {
           report(node.typeAnnotation)

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens.ts
@@ -1477,10 +1477,10 @@ export default createRule<RuleOptions, MessageIds>({
           report(node.argument)
         }
       },
-      TSStringKeyword(node) {
-        if (hasExcessParens(node)) {
+      TSTypeAnnotation(node) {
+        if (hasExcessParens(node.typeAnnotation)) {
           report({
-            ...node,
+            ...node.typeAnnotation,
             type: AST_NODE_TYPES.FunctionExpression as any,
           })
         }

--- a/packages/shared/utils/ast/general.ts
+++ b/packages/shared/utils/ast/general.ts
@@ -424,6 +424,7 @@ export function getPrecedence(node: ASTNode) {
       return 1
 
     case 'ConditionalExpression':
+    case 'TSConditionalType':
       return 3
 
     case 'LogicalExpression':
@@ -478,6 +479,11 @@ export function getPrecedence(node: ASTNode) {
 
       /* falls through */
 
+    case 'TSUnionType':
+      return 6
+    case 'TSIntersectionType':
+      return 8
+
     case 'UnaryExpression':
     case 'AwaitExpression':
       return 16
@@ -492,6 +498,10 @@ export function getPrecedence(node: ASTNode) {
 
     case 'NewExpression':
       return 19
+
+    case 'TSImportType':
+    case 'TSArrayType':
+      return 20
 
     default:
       if (node.type in eslintVisitorKeys)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

`TSStringKeyword` only checks the `string` keyword, it's not enough obviously.

This PR adds support for:
- [x] `TSTypeAnnotation`
	``` ts
	const x: number = 1;
	//     ^^^^^^^^
	
	function foo(x: number): number { return x; }
	//            ^^^^^^^^ ^^^^^^^^
	```
- [x] `TSTypeAliasDeclaration`
- [x] `TSEnumMember`
- [x] `TSArrayType`
- [x] `TSIntersectionType`
- [x] `TSUnionType`

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
