### PR TITLE
feat(multiline-comment-style): add support for exclamation comments

### DIFF
--- a/packages/eslint-plugin/rules/multiline-comment-style/README.md
+++ b/packages/eslint-plugin/rules/multiline-comment-style/README.md
@@ -16,8 +16,8 @@ This rule aims to enforce a particular style for multiline comments.
 This rule has a string option, which can have one of the following values:
 
 - `"starred-block"` (default): Disallows consecutive line comments in favor of block comments. Additionally, requires block comments to have an aligned `*` character before each line.
-- `"bare-block"`: Disallows consecutive line comments in favor of block comments, and disallows block comments from having a `"*"` character before each line. This option ignores JSDoc comments.
-- `"separate-lines"`: Disallows block comments in favor of consecutive line comments. By default, this option ignores JSDoc comments. To also apply this rule to JSDoc comments, set the `checkJSDoc` option to `true`.
+- `"bare-block"`: Disallows consecutive line comments in favor of block comments, and disallows block comments from having a `"*"` character before each line. This option ignores JSDoc and Exclamation comments.
+- `"separate-lines"`: Disallows block comments in favor of consecutive line comments. By default, this option ignores JSDoc and Exclamation comments. To also apply this rule to JSDoc comments, set the `checkJSDoc` and or `checkExclamation` option to `true`.
 
 The rule always ignores directive comments such as `/* eslint-disable */`.
 
@@ -173,6 +173,24 @@ Examples of **correct** code for this rule with the `"separate-lines"` option an
 
 // I am a JSDoc comment
 // and I'm not allowed
+foo();
+
+```
+
+:::
+
+Examples of **incorrect** code for this rule with the `"separate-lines"` option and `checkExclamation` set to `true`:
+
+::: incorrect
+
+```js
+
+/* eslint @stylistic/multiline-comment-style: ["error", "separate-lines", { "checkExclamation": true }] */
+
+/*!
+ * I am an exclamation comment
+ * and I'm not allowed
+ */
 foo();
 
 ```

--- a/packages/eslint-plugin/rules/multiline-comment-style/README.md
+++ b/packages/eslint-plugin/rules/multiline-comment-style/README.md
@@ -11,15 +11,63 @@ Many style guides require a particular style for comments that span multiple lin
 
 This rule aims to enforce a particular style for multiline comments.
 
+Other than regular JavaScript comments, the following types of comments are recognized by this rule:
+
+1. **[JSDoc comments](https://jsdoc.app/)**
+
+   These are comments which start with a `/**` sequence. They are used to explain the functionality of functions, classes, methods, and other code elements, making the code self-documenting.
+
+   Example:
+
+   ```js
+   /**
+    * Represents a book.
+    * @constructor
+    * @param {string} title - The title of the book.
+    * @param {string} author - The author of the book.
+    */
+   ```
+
+2. **Exclamation comments**
+
+   These are comments which start with a `/*!` sequence. They are conventionally used in JavaScript to indicate a _preserved comment_ or _important comment_. An exclamation comment signals its consumer that the comment should be preserved during processing.
+
+   Exclamation comments are often used for including copyright information, attribution, or other important metadata that needs to remain in the code.
+
+   Example:
+
+   ```js
+   /*!
+    * My JavaScript Library
+    * Copyright (c) 2025 John Doe
+    *
+    * Licensed under the MIT license.
+    */
+   ```
+
+3. **Directive comments**
+
+   These are special comments that convey instructions or metadata to tools like linters, compilers (e.g., TypeScript), or build systems. They are not standard JavaScript comments meant for human readability, but rather specific syntax understood by particular tools to alter their behavior.
+
+   Example:
+
+   ```js
+   // @ts-ignore
+   or
+   /* eslint-disable */
+   ```
+
 ## Options
 
 This rule has a string option, which can have one of the following values:
 
 - `"starred-block"` (default): Disallows consecutive line comments in favor of block comments. Additionally, requires block comments to have an aligned `*` character before each line.
 - `"bare-block"`: Disallows consecutive line comments in favor of block comments, and disallows block comments from having a `"*"` character before each line. This option ignores JSDoc and Exclamation comments.
-- `"separate-lines"`: Disallows block comments in favor of consecutive line comments. By default, this option ignores JSDoc and Exclamation comments. To also apply this rule to JSDoc comments, set the `checkJSDoc` and or `checkExclamation` option to `true`.
+- `"separate-lines"`: Disallows block comments in favor of consecutive line comments. By default, this option ignores JSDoc and Exclamation comments. To also apply this rule to JSDoc comments and or Exclamation comments, set the `checkJSDoc` and or `checkExclamation` option to `true`.
 
 The rule always ignores directive comments such as `/* eslint-disable */`.
+
+## Examples
 
 Examples of **incorrect** code for this rule with the default `"starred-block"` option:
 

--- a/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style.test.ts
+++ b/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style.test.ts
@@ -23,6 +23,15 @@ run<RuleOptions, MessageIds>({
              */
         `,
     `
+            /*!
+             * this is
+             * an exclamation comment
+             */
+        `,
+    `
+            /*! this is a single line exclamation comment */
+        `,
+    `
             /* eslint semi: [
               "error"
             ] */
@@ -236,6 +245,33 @@ run<RuleOptions, MessageIds>({
     },
     {
       code: `
+                /*!
+                 * This is
+                 * an exclamation comment
+                 */
+            `,
+      options: ['separate-lines'],
+    },
+    {
+      code: `
+                /*!
+                 * This is
+                 * an exclamation comment
+                 */
+            `,
+      options: ['starred-block'],
+    },
+    {
+      code: `
+                /*!
+                 * This is
+                 * an exclamation comment
+                 */
+            `,
+      options: ['bare-block'],
+    },
+    {
+      code: `
                 /* This is
                    a comment */
             `,
@@ -311,6 +347,39 @@ run<RuleOptions, MessageIds>({
       code: `
                 /**
                  *    JSDoc blocks
+                 *  are
+                 *   ignored
+                 * !
+                 */
+            `,
+      options: ['separate-lines'],
+    },
+    {
+      code: `
+                /*!
+                 *    Exclamation blocks
+                 *  are
+                 *   ignored
+                 * !
+                 */
+            `,
+      options: ['bare-block'],
+    },
+    {
+      code: `
+                /*!
+                 *    Exclamation blocks
+                 *  are
+                 *   ignored
+                 * !
+                 */
+            `,
+      options: ['starred-block'],
+    },
+    {
+      code: `
+                /*!
+                 *    Exclamation blocks
                  *  are
                  *   ignored
                  * !
@@ -447,6 +516,34 @@ run<RuleOptions, MessageIds>({
                 /**
                  * this JSDoc comment
                  * is missing a newline at the start
+                 */
+            `,
+      errors: [{ messageId: 'startNewline', line: 2 }],
+    },
+    {
+      code: `
+                /*! this Exclamation comment
+                 * is missing a newline
+                 * at the start
+                 */
+            `,
+      output: `
+                /*!
+                 * this Exclamation comment
+                 * is missing a newline
+                 * at the start
+                 */
+            `,
+      errors: [{ messageId: 'startNewline', line: 2 }],
+    },
+    {
+      code: `
+                /*! this Exclamation comment is missing a newline at the start
+                 */
+            `,
+      output: `
+                /*!
+                 * this Exclamation comment is missing a newline at the start
                  */
             `,
       errors: [{ messageId: 'startNewline', line: 2 }],
@@ -630,6 +727,20 @@ run<RuleOptions, MessageIds>({
                 // Comment
             `,
       options: ['separate-lines', { checkJSDoc: true }],
+      errors: [{ messageId: 'expectedLines', line: 2 }],
+    },
+    {
+      code: `
+                /*!
+                 * Exclamation
+                 * Comment
+                 */
+            `,
+      output: `
+                // Exclamation
+                // Comment
+            `,
+      options: ['separate-lines', { checkExclamation: true }],
       errors: [{ messageId: 'expectedLines', line: 2 }],
     },
     {

--- a/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style.ts
+++ b/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style.ts
@@ -43,6 +43,9 @@ export default createRule<RuleOptions, MessageIds>({
                 checkJSDoc: {
                   type: 'boolean',
                 },
+                checkExclamation: {
+                  type: 'boolean',
+                },
               },
               additionalProperties: false,
             },
@@ -67,6 +70,7 @@ export default createRule<RuleOptions, MessageIds>({
     const option = context.options[0] || 'starred-block'
     const params = context.options[1] || {}
     const checkJSDoc = !!params.checkJSDoc
+    const checkExclamation = !!params.checkExclamation
 
     // ----------------------------------------------------------------------
     // Helpers
@@ -108,6 +112,22 @@ export default createRule<RuleOptions, MessageIds>({
       const lines = firstComment.value.split(LINEBREAK_MATCHER)
 
       return /^\*\s*$/u.test(lines[0])
+        && lines.slice(1, -1).every(line => /^\s* /u.test(line))
+        && isWhiteSpaces(lines.at(-1)!)
+    }
+
+    /**
+     * Checks if a comment group is in exclamation form.
+     * @param firstComment A group of comments, containing either multiple line comments or a single block comment.
+     * @returns Whether or not the comment group is in exclamation form.
+     */
+    function isExclamationComment([firstComment]: Token[]): boolean {
+      if (firstComment.type !== 'Block')
+        return false
+
+      const lines = firstComment.value.split(LINEBREAK_MATCHER)
+
+      return /^!\s*$/u.test(lines[0])
         && lines.slice(1, -1).every(line => /^\s* /u.test(line))
         && isWhiteSpaces(lines.at(-1)!)
     }
@@ -275,8 +295,8 @@ export default createRule<RuleOptions, MessageIds>({
           const expectedLeadingWhitespace = getInitialOffset(firstComment)
           const expectedLinePrefix = `${expectedLeadingWhitespace} *`
 
-          if (!/^\*?\s*$/u.test(lines[0])) {
-            const start = firstComment.value.startsWith('*') ? firstComment.range[0] + 1 : firstComment.range[0]
+          if (!/^[*!]?\s*$/u.test(lines[0])) {
+            const start = /^[*!]/.test(firstComment.value) ? firstComment.range[0] + 1 : firstComment.range[0]
 
             context.report({
               loc: {
@@ -352,13 +372,14 @@ export default createRule<RuleOptions, MessageIds>({
         const [firstComment] = commentGroup
 
         const isJSDoc = isJSDocComment(commentGroup)
+        const isExclamation = isExclamationComment(commentGroup)
 
-        if (firstComment.type !== 'Block' || (!checkJSDoc && isJSDoc))
+        if (firstComment.type !== 'Block' || (!checkJSDoc && isJSDoc) || (!checkExclamation && isExclamation))
           return
 
         let commentLines = getCommentLines(commentGroup)
 
-        if (isJSDoc)
+        if (isJSDoc || isExclamation)
           commentLines = commentLines.slice(1, commentLines.length - 1)
 
         const tokenAfter = sourceCode.getTokenAfter(firstComment, { includeComments: true })
@@ -378,7 +399,7 @@ export default createRule<RuleOptions, MessageIds>({
         })
       },
       'bare-block': function (commentGroup: Token[]) {
-        if (isJSDocComment(commentGroup))
+        if (isJSDocComment(commentGroup) || isExclamationComment(commentGroup))
           return
 
         const [firstComment] = commentGroup

--- a/packages/eslint-plugin/rules/multiline-comment-style/types.d.ts
+++ b/packages/eslint-plugin/rules/multiline-comment-style/types.d.ts
@@ -11,6 +11,7 @@ export type MultilineCommentStyleSchema0
       'separate-lines',
       {
         checkJSDoc?: boolean
+        checkExclamation?: boolean
       },
     ]
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR add the following changes to the `multiline-comment-style` rule:

#### 1. Add support for exclamation comments

_Exclamation comments_ are block comments which starts with an exclamation mark (`/*! ... */`).
   AS IS using `@stylistic/multiline-comment-style: ["error", "starred-block"]` rule with the    following code comment resulted in error: 
```js
Error: Expected a linebreak after '/*'

/*!
 * Copyright OpenJS Foundation and other contributors, <www.openjsf.org>
 * Copyright (c) 2023-PRESENT ESLint Stylistic contributors
 *
 * Licensed under the MIT license. See LICENSE file in the project root for details.
 */
```
This PR addresses the issue so that the above code is valid. 

#### 2. Add new `checkExclamation` option for the `separate-lines` option.

Like `JSDoc` comment, by default, all exclamation comments are also ignored when `bare-block` and `separate-lines` option is used. This PR add a new `checkExclamation` option to the `separate-lines` option to toggle the exclamation comments exclusion from the `separate-lines` option. 

With `@stylistic/multiline-comment-style: ["error", "separate-lines", { checkExclamation: true }]` the following code would result in error: 
     
```js
Error: Expected multiple line comments instead of a block comment

/*!
  Copyright OpenJS Foundation and other contributors, <www.openjsf.org>
  Copyright (c) 2023-PRESENT ESLint Stylistic contributors

  Licensed under the MIT license. See LICENSE file in the project root for details.
*/
```

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
