### PR TITLE
fix(multiline-comment-style): add proper spacing on each comment line with autofix

### DIFF
--- a/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style.test.ts
+++ b/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style.test.ts
@@ -1109,12 +1109,12 @@ run<RuleOptions, MessageIds>({
                  */
             `,
       output: `
-                //
+                //${' '}
                 // {
                 //     "foo": 1,
                 //     "bar": 2
                 // }
-                //
+                //${' '}
             `,
       options: ['separate-lines'],
       errors: [
@@ -1259,12 +1259,12 @@ run<RuleOptions, MessageIds>({
                 */
             `,
       output: `
-                //
+                //${' '}
                 // {
                 //     "foo": 1,
                 //     "bar": 2
                 // }
-                //
+                //${' '}
             `,
       options: ['separate-lines'],
       errors: [
@@ -1282,7 +1282,7 @@ run<RuleOptions, MessageIds>({
                 // {
                 //     "foo": 1,
                 //     "bar": 2
-                // }
+                // }${' '}
             `,
       options: ['separate-lines'],
       errors: [
@@ -1299,7 +1299,7 @@ run<RuleOptions, MessageIds>({
             `,
       output: `
                 // foo
-                //
+                //${' '}
                 // bar
             `,
       options: ['separate-lines'],
@@ -1315,7 +1315,7 @@ run<RuleOptions, MessageIds>({
             `,
       output: `
                 // foo
-                //
+                //${' '}
                 // bar
             `,
       options: ['separate-lines'],
@@ -1413,8 +1413,8 @@ ${'                   '}
             `,
       output: `
                 // foo
-                //
-                // bar
+                //${' '}
+                // bar${' '}
             `,
       options: ['separate-lines'],
       errors: [{ messageId: 'expectedLines', line: 2 }],
@@ -1427,8 +1427,8 @@ ${'                   '}
             `,
       output: `
                 // foo
-                //
-                // bar
+                //${' '}
+                // bar${' '}
             `,
       options: ['separate-lines'],
       errors: [{ messageId: 'expectedLines', line: 2 }],

--- a/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style.ts
+++ b/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style.ts
@@ -248,7 +248,7 @@ export default createRule<RuleOptions, MessageIds>({
      * @returns A representation of the comment value in separate-line form
      */
     function convertToSeparateLines(firstComment: Token, commentLinesList: string[]): string {
-      return commentLinesList.map(line => `// ${line}`.trimEnd()).join(`\n${getInitialOffset(firstComment)}`)
+      return commentLinesList.map(line => `// ${line}`).join(`\n${getInitialOffset(firstComment)}`)
     }
 
     /**
@@ -258,7 +258,12 @@ export default createRule<RuleOptions, MessageIds>({
      * @returns A representation of the comment value in bare-block form
      */
     function convertToBlock(firstComment: Token, commentLinesList: string[]): string {
-      return `${commentLinesList.reduce((s, c, i, a) => `${s}${c}\n${getInitialOffset(firstComment)}${i < a.length - 1 ? '   ' : ' '}`, '/*')}*/`
+      // Indent the lines by their initial offset + additional 3 spaces;
+      // If its the last line, just add it with one additional space to account for the closing token ('*/');
+      const len = commentLinesList.length - 1
+      const indented = commentLinesList.map((c, i) => `${c}\n${getInitialOffset(firstComment)}${(i < len ? '   ' : ' ')}`)
+
+      return `/*${indented.join('')}*/`
     }
 
     /**


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR changes to the `multiline-comment-style` rule autofix behavior by adding proper spacing to the comment lines

AS IS, running the autofixer for `@stylistic/multiline-comment-style` rule with the following code comment:
  
```js
/*
  Copyright OpenJS Foundation and other contributors, <www.openjsf.org>
  Copyright (c) 2023-PRESENT ESLint Stylistic contributors

  Licensed under the MIT license. See LICENSE file in the project root for details.
*/
```

would generate comment texts without proper spacing:
   
```js
/*
 *Copyright OpenJS Foundation and other contributors, <www.openjsf.org>
 *Copyright (c) 2023-PRESENT ESLint Stylistic contributors
 *
 *Licensed under the MIT license. See LICENSE file in the project root for details.
 */
```

With this PR, when auto-fixing, the above code would instead generate the following code:

```js
/*
 * Copyright OpenJS Foundation and other contributors, <www.openjsf.org>
 * Copyright (c) 2023-PRESENT ESLint Stylistic contributors
 *
 * Licensed under the MIT license. See LICENSE file in the project root for details.
 */
```

### Linked Issues

#757: Not exactly related with JSDoc; But [comments](https://github.com/eslint-stylistic/eslint-stylistic/issues/757#issuecomment-2784122622) on the thread about spacing issues are addressed in this PR

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
