### PR TITLE
fix: disallow extra properties in rule options

### DIFF
--- a/packages/eslint-plugin/rules/jsx-curly-spacing/jsx-curly-spacing.ts
+++ b/packages/eslint-plugin/rules/jsx-curly-spacing/jsx-curly-spacing.ts
@@ -10,7 +10,7 @@
  */
 
 import type { ASTNode, JSONSchema, RuleFixer, Token } from '#types'
-import type { BasicConfig, MessageIds, RuleOptions } from './types'
+import type { MessageIds, RuleOptions } from './types'
 import { isTokenOnSameLine } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
@@ -54,10 +54,15 @@ const BASIC_CONFIG_SCHEMA = {
 } satisfies JSONSchema.JSONSchema4
 
 const BASIC_CONFIG_OR_BOOLEAN_SCHEMA = {
-  anyOf: [BASIC_CONFIG_SCHEMA, {
-    type: 'boolean',
-  }],
+  anyOf: [
+    BASIC_CONFIG_SCHEMA,
+    {
+      type: 'boolean',
+    },
+  ],
 } satisfies JSONSchema.JSONSchema4
+
+type BasicConfig = Pick<Extract<RuleOptions[0], { when?: any }>, 'when' | 'allowMultiline' | 'spacing'>
 
 interface NormalizedConfig extends BasicConfig {
   objectLiteralSpaces?: 'always' | 'never'

--- a/packages/eslint-plugin/rules/jsx-curly-spacing/jsx-curly-spacing.ts
+++ b/packages/eslint-plugin/rules/jsx-curly-spacing/jsx-curly-spacing.ts
@@ -50,8 +50,7 @@ const BASIC_CONFIG_SCHEMA = {
       additionalProperties: false,
     },
   },
-  additionalProperties: false,
-} satisfies JSONSchema.JSONSchema4
+} satisfies JSONSchema.JSONSchema4ObjectSchema
 
 const BASIC_CONFIG_OR_BOOLEAN_SCHEMA = {
   anyOf: [
@@ -60,7 +59,7 @@ const BASIC_CONFIG_OR_BOOLEAN_SCHEMA = {
       type: 'boolean',
     },
   ],
-} satisfies JSONSchema.JSONSchema4
+} satisfies JSONSchema.JSONSchema4AnyOfSchema
 
 type BasicConfig = Pick<Extract<RuleOptions[0], { when?: any }>, keyof typeof BASIC_CONFIG_SCHEMA['properties']>
 
@@ -82,18 +81,21 @@ export default createRule<RuleOptions, MessageIds>({
     schema: {
       type: 'array',
       items: [{
-        anyOf: [{
-          type: 'object',
-          additionalProperties: false,
-          properties: {
-            ...BASIC_CONFIG_SCHEMA.properties,
-            attributes: BASIC_CONFIG_OR_BOOLEAN_SCHEMA,
-            children: BASIC_CONFIG_OR_BOOLEAN_SCHEMA,
+        anyOf: [
+          {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              ...BASIC_CONFIG_SCHEMA.properties,
+              attributes: BASIC_CONFIG_OR_BOOLEAN_SCHEMA,
+              children: BASIC_CONFIG_OR_BOOLEAN_SCHEMA,
+            },
           },
-        }, {
-          type: 'string',
-          enum: SPACING_VALUES,
-        }],
+          {
+            type: 'string',
+            enum: SPACING_VALUES,
+          },
+        ],
       }, {
         type: 'object',
         properties: {

--- a/packages/eslint-plugin/rules/jsx-curly-spacing/jsx-curly-spacing.ts
+++ b/packages/eslint-plugin/rules/jsx-curly-spacing/jsx-curly-spacing.ts
@@ -62,7 +62,7 @@ const BASIC_CONFIG_OR_BOOLEAN_SCHEMA = {
   ],
 } satisfies JSONSchema.JSONSchema4
 
-type BasicConfig = Pick<Extract<RuleOptions[0], { when?: any }>, 'when' | 'allowMultiline' | 'spacing'>
+type BasicConfig = Pick<Extract<RuleOptions[0], { when?: any }>, keyof typeof BASIC_CONFIG_SCHEMA['properties']>
 
 interface NormalizedConfig extends BasicConfig {
   objectLiteralSpaces?: 'always' | 'never'

--- a/packages/eslint-plugin/rules/jsx-curly-spacing/jsx-curly-spacing.ts
+++ b/packages/eslint-plugin/rules/jsx-curly-spacing/jsx-curly-spacing.ts
@@ -50,6 +50,7 @@ const BASIC_CONFIG_SCHEMA = {
       additionalProperties: false,
     },
   },
+  additionalProperties: false,
 } satisfies JSONSchema.JSONSchema4ObjectSchema
 
 const BASIC_CONFIG_OR_BOOLEAN_SCHEMA = {

--- a/packages/eslint-plugin/rules/jsx-curly-spacing/jsx-curly-spacing.ts
+++ b/packages/eslint-plugin/rules/jsx-curly-spacing/jsx-curly-spacing.ts
@@ -60,8 +60,10 @@ export default createRule<RuleOptions, MessageIds>({
                   enum: SPACING_VALUES,
                 },
               },
+              additionalProperties: false,
             },
           },
+          additionalProperties: false,
         },
         basicConfigOrBoolean: {
           anyOf: [{
@@ -86,6 +88,7 @@ export default createRule<RuleOptions, MessageIds>({
                 $ref: '#/definitions/basicConfigOrBoolean',
               },
             },
+            additionalProperties: false,
           }],
         }, {
           type: 'string',
@@ -105,6 +108,7 @@ export default createRule<RuleOptions, MessageIds>({
                 enum: SPACING_VALUES,
               },
             },
+            additionalProperties: false,
           },
         },
         additionalProperties: false,

--- a/packages/eslint-plugin/rules/jsx-curly-spacing/jsx-curly-spacing.ts
+++ b/packages/eslint-plugin/rules/jsx-curly-spacing/jsx-curly-spacing.ts
@@ -9,8 +9,7 @@
  * @author Erik Wendel
  */
 
-import type { ASTNode, RuleFixer, Token } from '#types'
-import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
+import type { ASTNode, JSONSchema, RuleFixer, Token } from '#types'
 import type { BasicConfig, MessageIds, RuleOptions } from './types'
 import { isTokenOnSameLine } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
@@ -52,13 +51,17 @@ const BASIC_CONFIG_SCHEMA = {
     },
   },
   additionalProperties: false,
-} satisfies JSONSchema4
+} satisfies JSONSchema.JSONSchema4
 
 const BASIC_CONFIG_OR_BOOLEAN_SCHEMA = {
   anyOf: [BASIC_CONFIG_SCHEMA, {
     type: 'boolean',
   }],
-} satisfies JSONSchema4
+} satisfies JSONSchema.JSONSchema4
+
+interface NormalizedConfig extends BasicConfig {
+  objectLiteralSpaces?: 'always' | 'never'
+}
 
 export default createRule<RuleOptions, MessageIds>({
   name: 'jsx-curly-spacing',
@@ -109,11 +112,11 @@ export default createRule<RuleOptions, MessageIds>({
   },
 
   create(context) {
-    function normalizeConfig(configOrTrue: RuleOptions[0] | true, defaults: BasicConfig, lastPass: boolean = false) {
+    function normalizeConfig(configOrTrue: RuleOptions[0] | true, defaults: NormalizedConfig, lastPass: boolean = false): NormalizedConfig {
       const config = configOrTrue === true ? {} : configOrTrue as NonStringConfig
-      const when = (config as BasicConfig).when || defaults.when
+      const when = config.when || defaults.when
       const allowMultiline = 'allowMultiline' in config ? config.allowMultiline : defaults.allowMultiline
-      const spacing = (config as BasicConfig).spacing || {}
+      const spacing = config.spacing || {}
       let objectLiteralSpaces = spacing.objectLiterals || defaults.objectLiteralSpaces
       if (lastPass) {
         // On the final pass assign the values that should be derived from others if they are still undefined

--- a/packages/eslint-plugin/rules/jsx-curly-spacing/types.d.ts
+++ b/packages/eslint-plugin/rules/jsx-curly-spacing/types.d.ts
@@ -1,22 +1,64 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: rmsGs7ZFrVG4SO4GoAoakEXhdq9TICtKptLvUpZNPRI */
+/* @checksum: _pSba4lVI8bSVjFb0Xmp0h46hFdDbMk9iLr41NY4nwY */
 
 export type JsxCurlySpacingSchema0
   = | []
     | [
-      | (BasicConfig & {
-        attributes?: BasicConfigOrBoolean
-        children?: BasicConfigOrBoolean
-      })
+      | {
+        when?: 'always' | 'never'
+        allowMultiline?: boolean
+        spacing?: {
+          objectLiterals?: 'always' | 'never'
+        }
+        attributes?:
+          | {
+            when?: 'always' | 'never'
+            allowMultiline?: boolean
+            spacing?: {
+              objectLiterals?: 'always' | 'never'
+            }
+          }
+          | boolean
+        children?:
+          | {
+            when?: 'always' | 'never'
+            allowMultiline?: boolean
+            spacing?: {
+              objectLiterals?: 'always' | 'never'
+            }
+          }
+          | boolean
+      }
       | ('always' | 'never'),
     ]
     | [
       (
-        | (BasicConfig & {
-          attributes?: BasicConfigOrBoolean
-          children?: BasicConfigOrBoolean
-        })
+        | {
+          when?: 'always' | 'never'
+          allowMultiline?: boolean
+          spacing?: {
+            objectLiterals?: 'always' | 'never'
+          }
+          attributes?:
+            | {
+              when?: 'always' | 'never'
+              allowMultiline?: boolean
+              spacing?: {
+                objectLiterals?: 'always' | 'never'
+              }
+            }
+            | boolean
+          children?:
+            | {
+              when?: 'always' | 'never'
+              allowMultiline?: boolean
+              spacing?: {
+                objectLiterals?: 'always' | 'never'
+              }
+            }
+            | boolean
+        }
         | ('always' | 'never')
       ),
       {
@@ -26,15 +68,6 @@ export type JsxCurlySpacingSchema0
         }
       },
     ]
-export type BasicConfigOrBoolean = BasicConfig | boolean
-
-export interface BasicConfig {
-  when?: 'always' | 'never'
-  allowMultiline?: boolean
-  spacing?: {
-    objectLiterals?: 'always' | 'never'
-  }
-}
 
 export type JsxCurlySpacingRuleOptions
   = JsxCurlySpacingSchema0

--- a/packages/eslint-plugin/rules/jsx-curly-spacing/types.d.ts
+++ b/packages/eslint-plugin/rules/jsx-curly-spacing/types.d.ts
@@ -1,6 +1,6 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: 6np7FJPRpiFgbrMsnDL-PC4zMTYMNJoW_bCYp5XgxUg */
+/* @checksum: rmsGs7ZFrVG4SO4GoAoakEXhdq9TICtKptLvUpZNPRI */
 
 export type JsxCurlySpacingSchema0
   = | []
@@ -8,7 +8,6 @@ export type JsxCurlySpacingSchema0
       | (BasicConfig & {
         attributes?: BasicConfigOrBoolean
         children?: BasicConfigOrBoolean
-        [k: string]: unknown
       })
       | ('always' | 'never'),
     ]
@@ -17,7 +16,6 @@ export type JsxCurlySpacingSchema0
         | (BasicConfig & {
           attributes?: BasicConfigOrBoolean
           children?: BasicConfigOrBoolean
-          [k: string]: unknown
         })
         | ('always' | 'never')
       ),
@@ -25,7 +23,6 @@ export type JsxCurlySpacingSchema0
         allowMultiline?: boolean
         spacing?: {
           objectLiterals?: 'always' | 'never'
-          [k: string]: unknown
         }
       },
     ]
@@ -36,9 +33,7 @@ export interface BasicConfig {
   allowMultiline?: boolean
   spacing?: {
     objectLiterals?: 'always' | 'never'
-    [k: string]: unknown
   }
-  [k: string]: unknown
 }
 
 export type JsxCurlySpacingRuleOptions

--- a/packages/eslint-plugin/rules/jsx-indent-props/jsx-indent-props.ts
+++ b/packages/eslint-plugin/rules/jsx-indent-props/jsx-indent-props.ts
@@ -78,6 +78,7 @@ export default createRule<RuleOptions, MessageIds>({
               type: 'boolean',
             },
           },
+          additionalProperties: false,
         },
       ],
     }],

--- a/packages/eslint-plugin/rules/jsx-indent-props/types.d.ts
+++ b/packages/eslint-plugin/rules/jsx-indent-props/types.d.ts
@@ -1,6 +1,6 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: yoq47ZFhtyO96ComOIYTmw3_4sqKrrg0Nv2kSf7dBYo */
+/* @checksum: 30G_ZrWyAGlBb_DWlLb43wDD7IXoSKVHzxArM3d3ta0 */
 
 export type JsxIndentPropsSchema0
   = | ('tab' | 'first')
@@ -8,7 +8,6 @@ export type JsxIndentPropsSchema0
     | {
       indentMode?: ('tab' | 'first') | number
       ignoreTernaryOperator?: boolean
-      [k: string]: unknown
     }
 
 export type JsxIndentPropsRuleOptions = [

--- a/packages/eslint-plugin/rules/jsx-max-props-per-line/jsx-max-props-per-line.ts
+++ b/packages/eslint-plugin/rules/jsx-max-props-per-line/jsx-max-props-per-line.ts
@@ -46,6 +46,7 @@ export default createRule<RuleOptions, MessageIds>({
                 minimum: 1,
               },
             },
+            additionalProperties: false,
           },
         },
         additionalProperties: false,

--- a/packages/eslint-plugin/rules/jsx-max-props-per-line/types.d.ts
+++ b/packages/eslint-plugin/rules/jsx-max-props-per-line/types.d.ts
@@ -1,13 +1,12 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: KOe_wU0r0lsPla5JCuUUOQFmBSnDNOIm5DXIMsRs3g4 */
+/* @checksum: Cw90UTKsHhPLRv0dTeRqkUFq1z8xJdtpn3CUONfizj4 */
 
 export type JsxMaxPropsPerLineSchema0
   = | {
     maximum?: {
       single?: number
       multi?: number
-      [k: string]: unknown
     }
   }
   | {

--- a/packages/eslint-plugin/rules/multiline-ternary/multiline-ternary.ts
+++ b/packages/eslint-plugin/rules/multiline-ternary/multiline-ternary.ts
@@ -29,6 +29,7 @@ export default createRule<RuleOptions, MessageIds>({
             default: false,
           },
         },
+        additionalProperties: false,
       },
     ],
 

--- a/packages/eslint-plugin/rules/multiline-ternary/types.d.ts
+++ b/packages/eslint-plugin/rules/multiline-ternary/types.d.ts
@@ -1,6 +1,6 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: F-2EEbab-hKzmU-DEbejw9951edJ-x4z3ngYponoEZI */
+/* @checksum: B9Xuzw8xZiK_fneqs8jInWdZlTCYrLuG3DJ0naQrxnY */
 
 export type MultilineTernarySchema0
   = | 'always'
@@ -9,7 +9,6 @@ export type MultilineTernarySchema0
 
 export interface MultilineTernarySchema1 {
   ignoreJSX?: boolean
-  [k: string]: unknown
 }
 
 export type MultilineTernaryRuleOptions = [


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Some rules, for example [jsx-curly-spacing](https://github.com/eslint-stylistic/eslint-stylistic/blob/4a5fe59f528021fa2e6e8f787d2f21a69739391b/packages/eslint-plugin/rules/jsx-curly-spacing/jsx-curly-spacing.ts#L45) allow extra properties to be passed in options object, which should not be allowed. This makes it easier for typos in rule options to go unnoticed.

This PR simply disallows extra properties in rules' schemas which currently allow them.

### Linked Issues

### Additional context

Touched rules:
- jsx-curly-spacing
- jsx-indent-props
- jsx-max-props-per-line
- multiline-ternary

<!-- e.g. is there anything you'd like reviewers to focus on? -->
