### PR TITLE
docs(no-extra-parens): fix default setting

### DIFF
--- a/packages/eslint-plugin/rules/no-extra-parens/README.md
+++ b/packages/eslint-plugin/rules/no-extra-parens/README.md
@@ -45,8 +45,8 @@ In this case, the rule will not try to remove the parentheses around `"use stric
 
 This rule has a string option:
 
-- `"all"` (default) disallows unnecessary parentheses around _any_ expression
-- `"functions"` disallows unnecessary parentheses _only_ around function expressions
+- `"all"` disallows unnecessary parentheses around _any_ expression
+- `"functions"` (default) disallows unnecessary parentheses _only_ around function expressions
 
 This rule has an object option for exceptions to the `"all"` option:
 


### PR DESCRIPTION
### Description

Any `shared configuration` sets `no-extra-parens` with default `['error', 'functions']`
