### PR TITLE
fix(no-extra-parens): skip nested `TSUnionType/TSIntersectionType` when `nestedBinaryExpressions: false`

### DIFF
--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.test.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._ts_.test.ts
@@ -361,6 +361,10 @@ run<RuleOptions, MessageIds>({
 
     `type Foo = string & (number | 'bar')`,
     `type Foo = (a extends string ? 'bar' : number)[]`,
+    {
+      code: `type Foo = boolean | (Bar & Baz)`,
+      options: ['all', { nestedBinaryExpressions: false }],
+    },
   ],
 
   invalid: [
@@ -542,6 +546,37 @@ run<RuleOptions, MessageIds>({
     {
       code: `type Foo = ((import('x')))[]`,
       output: `type Foo = import('x')[]`,
+      recursive: Number.POSITIVE_INFINITY,
+      errors: [
+        { messageId: 'unexpected' },
+      ],
+    },
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/904
+    {
+      code: $`
+        type Foo = boolean | ((
+          & Bar
+          & Baz
+        ))
+      `,
+      output: $`
+        type Foo = boolean | (
+          & Bar
+          & Baz
+        )
+      `,
+      options: ['all', { nestedBinaryExpressions: false }],
+      errors: [
+        { messageId: 'unexpected' },
+      ],
+    },
+    {
+      code: $`
+        type Foo = boolean | ((Bar & Baz))
+      `,
+      output: $`
+        type Foo = boolean | Bar & Baz
+      `,
       recursive: Number.POSITIVE_INFINITY,
       errors: [
         { messageId: 'unexpected' },


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Fixes #904 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
