### PR TITLE
fix(object-curly-spacing): prevent crash when encountering multiple non-ImportSpecifier nodes

### DIFF
--- a/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing._js_.test.ts
@@ -168,6 +168,8 @@ run<RuleOptions, MessageIds>({
       options: ['never'],
       languageOptions: languageOptionsForBabelFlow,
     },
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/906
+    `import ActionManagementApi, * as ActionManagementModule from '@lcep/action-management-api';`,
   ],
 
   invalid: [

--- a/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing._js_.test.ts
@@ -169,7 +169,7 @@ run<RuleOptions, MessageIds>({
       languageOptions: languageOptionsForBabelFlow,
     },
     // https://github.com/eslint-stylistic/eslint-stylistic/issues/906
-    `import ActionManagementApi, * as ActionManagementModule from '@lcep/action-management-api';`,
+    `import foo, * as bar from 'mod'`,
   ],
 
   invalid: [

--- a/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing.ts
+++ b/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing.ts
@@ -272,14 +272,12 @@ export default createRule<RuleOptions, MessageIds>({
         if (node.attributes)
           checkForObjectLike(node, node.attributes)
 
-        if (node.specifiers.length === 0)
+        const firstSpecifierIndex = node.specifiers.findIndex(specifier => specifier.type === 'ImportSpecifier')
+
+        if (firstSpecifierIndex === -1)
           return
 
-        const specifiers = node.specifiers[0].type !== 'ImportSpecifier'
-          ? node.specifiers.slice(1)
-          : node.specifiers
-
-        checkForObjectLike(node, specifiers)
+        checkForObjectLike(node, node.specifiers.slice(firstSpecifierIndex))
       },
       // export {name} from 'yo';
       ExportNamedDeclaration(node) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Resolves: #906

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
