### PR TITLE
fix(indent): correctly locate left paren in `CallExpression` with specific type arguments

### DIFF
--- a/packages/eslint-plugin/rules/indent/indent._ts_.test.ts
+++ b/packages/eslint-plugin/rules/indent/indent._ts_.test.ts
@@ -870,12 +870,19 @@ run<RuleOptions, MessageIds>({
     // https://github.com/eslint-stylistic/eslint-stylistic/issues/909
     $`
       genericFunction<
-        () => void
+          () => void
       >(
-        () => {
-          console.log("Test");
-        }
+          () => {
+              console.log("Test");
+          }
       );
+    `,
+    $`
+      genericFunction<() => void>(
+          () => {
+              console.log("Test");
+          }
+      )
     `,
   ],
   invalid: [

--- a/packages/eslint-plugin/rules/indent/indent._ts_.test.ts
+++ b/packages/eslint-plugin/rules/indent/indent._ts_.test.ts
@@ -867,6 +867,16 @@ run<RuleOptions, MessageIds>({
         | 'four'
       ;
     `,
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/909
+    $`
+      genericFunction<
+        () => void
+      >(
+        () => {
+          console.log("Test");
+        }
+      );
+    `,
   ],
   invalid: [
     ...individualNodeTests.invalid!,

--- a/packages/eslint-plugin/rules/indent/indent.ts
+++ b/packages/eslint-plugin/rules/indent/indent.ts
@@ -1002,7 +1002,7 @@ export default createRule<RuleOptions, MessageIds>({
       let openingParen
 
       if (node.arguments.length)
-        openingParen = sourceCode.getFirstTokenBetween(node.callee, node.arguments[0], isOpeningParenToken)!
+        openingParen = sourceCode.getTokenBefore(node.arguments[0], isOpeningParenToken)!
       else
         openingParen = sourceCode.getLastToken(node, 1)!
 

--- a/packages/eslint-plugin/rules/indent/indent.ts
+++ b/packages/eslint-plugin/rules/indent/indent.ts
@@ -1001,10 +1001,15 @@ export default createRule<RuleOptions, MessageIds>({
     function addFunctionCallIndent(node: Tree.CallExpression | Tree.NewExpression) {
       let openingParen
 
-      if (node.arguments.length)
-        openingParen = sourceCode.getTokenBefore(node.arguments[0], isOpeningParenToken)!
-      else
+      if (node.arguments.length) {
+        openingParen = sourceCode.getTokenAfter(
+          node.typeArguments ?? node.callee,
+          isOpeningParenToken,
+        )!
+      }
+      else {
         openingParen = sourceCode.getLastToken(node, 1)!
+      }
 
       const closingParen = sourceCode.getLastToken(node)!
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fix incorrect parenthesis positioning specifically when:
- CallExpression contains type arguments
- Type arguments include nested parentheses
- Only occurs in complex type structures like:
```ts
// parentheses inside type argument
func<{ prop: (Type) }>(...)
             ^
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Fix: #909

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
