### PR TITLE
Correct vscode setting value

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -35,7 +35,7 @@ Add the following settings to your `.vscode/settings.json`:
 
 ```jsonc
 {
-  "editor.formatOnSave": false,
+  "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },


### PR DESCRIPTION
`editor.formatOnSave` should be true to achieve auto format on save

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

I found an incorrect settting suggestion for vscode in the document. It was easy to fix to I did it anyway.

### Linked Issues

No big deal, not worth to open an issue

### Additional context

Somehow the explanation would even be longer the commit code :?
