### PR TITLE
fix(indent): prevent crashes during `JSXFragment` handling

### DIFF
--- a/packages/eslint-plugin/rules/indent/indent.ts
+++ b/packages/eslint-plugin/rules/indent/indent.ts
@@ -482,13 +482,14 @@ class OffsetStorage {
       }
       else if (this._lockedFirstTokens.has(token)) {
         const firstToken = this._lockedFirstTokens.get(token)!
+        const firstTokenOfLine = this._tokenInfo.getFirstTokenOfLine(firstToken)!
 
         this._desiredIndentCache.set(
           token,
           // (indentation for the first element's line)
-          this.getDesiredIndent(this._tokenInfo.getFirstTokenOfLine(firstToken)!)
+          this.getDesiredIndent(firstTokenOfLine)
           // (space between the start of the first element's line and the first element)
-          + this._indentType.repeat(firstToken.loc.start.column - this._tokenInfo.getFirstTokenOfLine(firstToken)!.loc.start.column),
+          + this._indentType.repeat(firstToken.loc.start.column - firstTokenOfLine.loc.start.column),
         )
       }
       else {
@@ -1947,12 +1948,16 @@ export default createRule<RuleOptions, MessageIds>({
 
       JSXClosingFragment(node) {
         const firstToken = sourceCode.getFirstToken(node)!
-        const slashToken = sourceCode.getLastToken(node, { skip: 1 })!
         const closingToken = sourceCode.getLastToken(node)!
-        const tokenToMatch = isTokenOnSameLine(slashToken, closingToken) ? slashToken : closingToken
 
         offsets.setDesiredOffsets(node.range, firstToken, 1)
-        offsets.matchOffsetOf(firstToken, tokenToMatch)
+
+        const slashToken = sourceCode.getLastToken(node, token => token.value === '/')
+        if (slashToken) {
+          const tokenToMatch = isTokenOnSameLine(slashToken, closingToken) ? slashToken : closingToken
+
+          offsets.matchOffsetOf(firstToken, tokenToMatch)
+        }
       },
 
       JSXExpressionContainer(node) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This change is independent of upstream parser decisions.
I'm implementing a conservative fix here to prevent crashes.

We may revisit this implementation for alignment once the parser's approach finalizes.

### Linked Issues

#915
https://github.com/typescript-eslint/typescript-eslint/issues/11455
https://github.com/microsoft/TypeScript/issues/62188

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
