### PR TITLE
feat(jsx-one-expression-per-line): enhance the fix result when `allow` is `single-line`

### DIFF
--- a/packages/eslint-plugin/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.test.ts
+++ b/packages/eslint-plugin/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.test.ts
@@ -1738,6 +1738,7 @@ Go to page 2
         },
       ],
     },
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/869
     {
       code: $`
         <App

--- a/packages/eslint-plugin/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.test.ts
+++ b/packages/eslint-plugin/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.test.ts
@@ -1721,14 +1721,14 @@ Go to page 2
       options: [{ allow: 'single-line' }],
     },
     {
-      code: `
-<div><span>foo</span>
-</div>
+      code: $`
+        <div><span>foo</span>
+        </div>
       `,
-      output: `
-<div>
-<span>foo</span>
-</div>
+      output: $`
+        <div>
+        <span>foo</span>
+        </div>
       `,
       options: [{ allow: 'single-line' }],
       errors: [
@@ -1750,6 +1750,25 @@ Go to page 2
           foo
         >
         Up to {percent}% Off
+        </App>
+      `,
+      options: [{ allow: 'single-line' }],
+      errors: [
+        { messageId: 'moveToNewLine' },
+      ],
+    },
+    {
+      code: $`
+        <App
+          foo
+        >
+          Up to {percent}% Off</App>
+      `,
+      output: $`
+        <App
+          foo
+        >
+          Up to {percent}% Off
         </App>
       `,
       options: [{ allow: 'single-line' }],

--- a/packages/eslint-plugin/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.test.ts
+++ b/packages/eslint-plugin/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.test.ts
@@ -4,7 +4,7 @@
  */
 
 import type { MessageIds, RuleOptions } from './types'
-import { run } from '#test'
+import { $, run } from '#test'
 import { invalids, valids } from '#test/parsers-jsx'
 import rule from './jsx-one-expression-per-line'
 
@@ -336,6 +336,24 @@ foo
           messageId: 'moveToNewLine',
           data: { descriptor: 'foo' },
         },
+      ],
+    },
+    {
+      code: $`
+        <App
+          foo
+        >bar
+        </App>
+      `,
+      output: $`
+        <App
+          foo
+        >
+        bar
+        </App>
+      `,
+      errors: [
+        { messageId: 'moveToNewLine' },
       ],
     },
     {
@@ -1718,6 +1736,25 @@ Go to page 2
           messageId: 'moveToNewLine',
           data: { descriptor: 'span' },
         },
+      ],
+    },
+    {
+      code: $`
+        <App
+          foo
+        >Up to {percent}% Off
+        </App>
+      `,
+      output: $`
+        <App
+          foo
+        >
+        Up to {percent}% Off
+        </App>
+      `,
+      options: [{ allow: 'single-line' }],
+      errors: [
+        { messageId: 'moveToNewLine' },
       ],
     },
   ),

--- a/packages/eslint-plugin/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.ts
+++ b/packages/eslint-plugin/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.ts
@@ -193,8 +193,8 @@ export default createRule<RuleOptions, MessageIds>({
           const lastIndex = childrenGroupedByLine[line].length - 1
 
           childrenGroupedByLine[line].forEach((child, i) => {
-            let prevChild: Child | Tree.JSXOpeningElement | Tree.JSXClosingElement | Tree.JSXClosingFragment | undefined
-            let nextChild: Child | Tree.JSXOpeningElement | Tree.JSXClosingElement | Tree.JSXClosingFragment | undefined
+            let prevChild: Child | Tree.JSXOpeningElement | Tree.JSXOpeningFragment | undefined
+            let nextChild: Child | Tree.JSXClosingElement | Tree.JSXClosingFragment | undefined
 
             if (i === firstIndex) {
               if (line === openingElementEndLine)

--- a/packages/eslint-plugin/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.ts
+++ b/packages/eslint-plugin/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.ts
@@ -159,7 +159,42 @@ export default createRule<RuleOptions, MessageIds>({
         }
       })
 
-      Object.keys(childrenGroupedByLine).forEach((_line) => {
+      const lines = Object.keys(childrenGroupedByLine)
+
+      if (lines.length === 1 && options.allow === 'single-line') {
+        const line = parseInt(lines[0])
+        const children = childrenGroupedByLine[line]
+        const firstChild = children[0]
+        if (line === openingElementEndLine) {
+          context.report({
+            messageId: 'moveToNewLine',
+            node: firstChild,
+            data: {
+              descriptor: nodeDescriptor(firstChild),
+            },
+            fix(fixer) {
+              return fixer.insertTextBefore(firstChild, '\n')
+            },
+          })
+        }
+
+        const lastChild = children.at(-1)!
+        if (line === closingElementStartLine) {
+          context.report({
+            messageId: 'moveToNewLine',
+            node: lastChild,
+            data: {
+              descriptor: nodeDescriptor(lastChild),
+            },
+            fix(fixer) {
+              return fixer.insertTextAfter(lastChild, '\n')
+            },
+          })
+        }
+        return
+      }
+
+      lines.forEach((_line) => {
         const line = parseInt(_line, 10)
         const firstIndex = 0
         const lastIndex = childrenGroupedByLine[line].length - 1

--- a/packages/eslint-plugin/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.ts
+++ b/packages/eslint-plugin/rules/jsx-one-expression-per-line/jsx-one-expression-per-line.ts
@@ -3,7 +3,7 @@
  * @author Mark Ivan Allen <Vydia.com>
  */
 
-import type { ASTNode, Tree } from '#types'
+import type { ASTNode, ReportFixFunction, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
 import { isWhiteSpaces } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
@@ -59,6 +59,17 @@ export default createRule<RuleOptions, MessageIds>({
         : context.sourceCode.getText(n).replace(/\n/g, '')
     }
 
+    function report(node: Child, fix: ReportFixFunction) {
+      context.report({
+        messageId: 'moveToNewLine',
+        node,
+        data: {
+          descriptor: nodeDescriptor(node),
+        },
+        fix,
+      })
+    }
+
     function handleJSX(node: Tree.JSXElement | Tree.JSXFragment) {
       const children = node.children as Child[]
 
@@ -72,8 +83,9 @@ export default createRule<RuleOptions, MessageIds>({
         return
       }
 
-      const openingElement = (<Tree.JSXElement>node).openingElement || (<Tree.JSXFragment>node).openingFragment
-      const closingElement = (<Tree.JSXElement>node).closingElement || (<Tree.JSXFragment>node).closingFragment
+      const isFragment = node.type === 'JSXFragment'
+      const openingElement = isFragment ? node.openingFragment : node.openingElement
+      const closingElement = isFragment ? node.closingFragment : node.closingElement!
       const openingElementStartLine = openingElement.loc.start.line
       const openingElementEndLine = openingElement.loc.end.line
       const closingElementStartLine = closingElement.loc.start.line
@@ -117,9 +129,8 @@ export default createRule<RuleOptions, MessageIds>({
 
       const childrenGroupedByLine: Record<number, Child[]> = {}
       const fixDetailsByNode: Record<string, {
-        node: Child | Tree.JSXOpeningElement | Tree.JSXClosingElement | Tree.JSXClosingFragment
+        node: Child
         source: string
-        descriptor: string
         leadingSpace?: boolean
         trailingSpace?: boolean
         leadingNewLine?: boolean
@@ -164,136 +175,109 @@ export default createRule<RuleOptions, MessageIds>({
       if (lines.length === 1 && options.allow === 'single-line') {
         const line = parseInt(lines[0])
         const children = childrenGroupedByLine[line]
+
         const firstChild = children[0]
         if (line === openingElementEndLine) {
-          context.report({
-            messageId: 'moveToNewLine',
-            node: firstChild,
-            data: {
-              descriptor: nodeDescriptor(firstChild),
-            },
-            fix(fixer) {
-              return fixer.insertTextBefore(firstChild, '\n')
-            },
-          })
+          report(firstChild, fixer => fixer.insertTextBefore(firstChild, '\n'))
         }
 
         const lastChild = children.at(-1)!
         if (line === closingElementStartLine) {
-          context.report({
-            messageId: 'moveToNewLine',
-            node: lastChild,
-            data: {
-              descriptor: nodeDescriptor(lastChild),
-            },
-            fix(fixer) {
-              return fixer.insertTextAfter(lastChild, '\n')
-            },
-          })
+          report(lastChild, fixer => fixer.insertTextAfter(lastChild, '\n'))
         }
-        return
       }
+      else {
+        lines.forEach((_line) => {
+          const line = parseInt(_line, 10)
+          const firstIndex = 0
+          const lastIndex = childrenGroupedByLine[line].length - 1
 
-      lines.forEach((_line) => {
-        const line = parseInt(_line, 10)
-        const firstIndex = 0
-        const lastIndex = childrenGroupedByLine[line].length - 1
+          childrenGroupedByLine[line].forEach((child, i) => {
+            let prevChild: Child | Tree.JSXOpeningElement | Tree.JSXClosingElement | Tree.JSXClosingFragment | undefined
+            let nextChild: Child | Tree.JSXOpeningElement | Tree.JSXClosingElement | Tree.JSXClosingFragment | undefined
 
-        childrenGroupedByLine[line].forEach((child, i) => {
-          let prevChild: Child | Tree.JSXOpeningElement | Tree.JSXClosingElement | Tree.JSXClosingFragment | undefined
-          let nextChild: Child | Tree.JSXOpeningElement | Tree.JSXClosingElement | Tree.JSXClosingFragment | undefined
-
-          if (i === firstIndex) {
-            if (line === openingElementEndLine)
-              prevChild = openingElement
-          }
-          else {
-            prevChild = childrenGroupedByLine[line][i - 1]
-          }
-
-          if (i === lastIndex) {
-            if (line === closingElementStartLine)
-              nextChild = closingElement
-          }
-          else {
-            // We don't need to append a trailing because the next child will prepend a leading.
-            // nextChild = childrenGroupedByLine[line][i + 1];
-          }
-
-          if (!prevChild && !nextChild)
-            return
-
-          const spaceBetweenPrev = () => {
-            // There must only be one token at most
-            const tokenBetweenNodes = context.sourceCode.getTokensBetween(prevChild!, child)[0]
-            return ((prevChild!.type === 'Literal' || prevChild!.type === 'JSXText') && prevChild!.raw.endsWith(' '))
-              || ((child.type === 'Literal' || child.type === 'JSXText') && child.raw.startsWith(' '))
-              || isWhiteSpaces(tokenBetweenNodes?.value)
-          }
-
-          const spaceBetweenNext = () => {
-            // There must only be one token at most
-            const tokenBetweenNodes = context.sourceCode.getTokensBetween(child, nextChild!)[0]
-            return ((nextChild!.type === 'Literal' || nextChild!.type === 'JSXText') && nextChild!.raw.startsWith(' '))
-              || ((child.type === 'Literal' || child.type === 'JSXText') && child.raw.endsWith(' '))
-              || isWhiteSpaces(tokenBetweenNodes?.value)
-          }
-
-          const source = context.sourceCode.getText(child)
-          const leadingSpace = !!(prevChild && spaceBetweenPrev())
-          const trailingSpace = !!(nextChild && spaceBetweenNext())
-          const leadingNewLine = !!prevChild
-          const trailingNewLine = !!nextChild
-
-          const key = nodeKey(child)
-
-          if (!fixDetailsByNode[key]) {
-            fixDetailsByNode[key] = {
-              node: child,
-              source,
-              descriptor: nodeDescriptor(child),
+            if (i === firstIndex) {
+              if (line === openingElementEndLine)
+                prevChild = openingElement
             }
-          }
+            else {
+              prevChild = childrenGroupedByLine[line][i - 1]
+            }
 
-          if (leadingSpace)
-            fixDetailsByNode[key].leadingSpace = true
+            if (i === lastIndex) {
+              if (line === closingElementStartLine)
+                nextChild = closingElement
+            }
+            else {
+              // We don't need to append a trailing because the next child will prepend a leading.
+              // nextChild = childrenGroupedByLine[line][i + 1];
+            }
 
-          if (leadingNewLine)
-            fixDetailsByNode[key].leadingNewLine = true
+            if (!prevChild && !nextChild)
+              return
 
-          if (trailingNewLine)
-            fixDetailsByNode[key].trailingNewLine = true
+            const spaceBetweenPrev = () => {
+              // There must only be one token at most
+              const tokenBetweenNodes = context.sourceCode.getTokensBetween(prevChild!, child)[0]
+              return ((prevChild!.type === 'Literal' || prevChild!.type === 'JSXText') && prevChild!.raw.endsWith(' '))
+                || ((child.type === 'Literal' || child.type === 'JSXText') && child.raw.startsWith(' '))
+                || isWhiteSpaces(tokenBetweenNodes?.value)
+            }
 
-          if (trailingSpace)
-            fixDetailsByNode[key].trailingSpace = true
+            const spaceBetweenNext = () => {
+              // There must only be one token at most
+              const tokenBetweenNodes = context.sourceCode.getTokensBetween(child, nextChild!)[0]
+              return ((nextChild!.type === 'Literal' || nextChild!.type === 'JSXText') && nextChild!.raw.startsWith(' '))
+                || ((child.type === 'Literal' || child.type === 'JSXText') && child.raw.endsWith(' '))
+                || isWhiteSpaces(tokenBetweenNodes?.value)
+            }
+
+            const source = context.sourceCode.getText(child)
+            const leadingSpace = !!(prevChild && spaceBetweenPrev())
+            const trailingSpace = !!(nextChild && spaceBetweenNext())
+            const leadingNewLine = !!prevChild
+            const trailingNewLine = !!nextChild
+
+            const key = nodeKey(child)
+
+            if (!fixDetailsByNode[key]) {
+              fixDetailsByNode[key] = {
+                node: child,
+                source,
+              }
+            }
+
+            if (leadingSpace)
+              fixDetailsByNode[key].leadingSpace = true
+
+            if (leadingNewLine)
+              fixDetailsByNode[key].leadingNewLine = true
+
+            if (trailingNewLine)
+              fixDetailsByNode[key].trailingNewLine = true
+
+            if (trailingSpace)
+              fixDetailsByNode[key].trailingSpace = true
+          })
         })
-      })
 
-      Object.keys(fixDetailsByNode).forEach((key) => {
-        const details = fixDetailsByNode[key]
+        Object.keys(fixDetailsByNode).forEach((key) => {
+          const details = fixDetailsByNode[key]
 
-        const nodeToReport = details.node
-        const descriptor = details.descriptor
-        const source = details.source.replace(/(^ +| +$)/g, '')
+          const nodeToReport = details.node
+          const source = details.source.replace(/(^ +| +$)/g, '')
 
-        const leadingSpaceString = details.leadingSpace ? '\n{\' \'}' : ''
-        const trailingSpaceString = details.trailingSpace ? '{\' \'}\n' : ''
-        const leadingNewLineString = details.leadingNewLine ? '\n' : ''
-        const trailingNewLineString = details.trailingNewLine ? '\n' : ''
+          const leadingSpaceString = details.leadingSpace ? '\n{\' \'}' : ''
+          const trailingSpaceString = details.trailingSpace ? '{\' \'}\n' : ''
+          const leadingNewLineString = details.leadingNewLine ? '\n' : ''
+          const trailingNewLineString = details.trailingNewLine ? '\n' : ''
 
-        const replaceText = `${leadingSpaceString}${leadingNewLineString}${source}${trailingNewLineString}${trailingSpaceString}`
+          const replaceText = `${leadingSpaceString}${leadingNewLineString}${source}${trailingNewLineString}${trailingSpaceString}`
 
-        context.report({
-          messageId: 'moveToNewLine',
-          node: nodeToReport,
-          data: {
-            descriptor,
-          },
-          fix(fixer) {
-            return fixer.replaceText(nodeToReport, replaceText)
-          },
+          report(nodeToReport, fixer => fixer.replaceText(nodeToReport, replaceText),
+          )
         })
-      })
+      }
     }
 
     return {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Enhance the auto-fix result.

Input:
```tsx
<div
  className='fs-6 col-12 text-danger fw-bold'
>Up to {percent}% Off
</div>
```

Before:
```tsx
<div
  className='fs-6 col-12 text-danger fw-bold'
>
Up
to
{percent}
% Off
</div>
```

After:
```tsx
<div
  className='fs-6 col-12 text-danger fw-bold'
>
Up to {percent}% Off
</div>
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Resolves #869 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
