### PR TITLE
fix(customize): remove specific nodes in `ignoreNodes` of the `indent` rule

### DIFF
--- a/packages/eslint-plugin/configs/customize.ts
+++ b/packages/eslint-plugin/configs/customize.ts
@@ -50,9 +50,6 @@ export function customize(options: StylisticCustomizeOptions = {}): Linter.Confi
       ignoredNodes: [
         'TSUnionType',
         'TSIntersectionType',
-        'TSTypeParameterInstantiation',
-        'FunctionExpression > .params[decorators.length > 0]',
-        'FunctionExpression > .params > :matches(Decorator, :not(:first-child))',
       ],
       ImportDeclaration: 1,
       MemberExpression: 1,


### PR DESCRIPTION

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

These nodes are now handled correctly, so there is no need to ignore them.

- `TSTypeParameterInstantiation`: https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin/rules/indent/indent.ts#L2115
- `FunctionExpression`: https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin/rules/indent/indent.ts#L1538
	Also, `Decorator` can now only be used in a class, more info:
	- https://www.typescriptlang.org/docs/handbook/decorators.html
	- https://mirone.me/a-complete-guide-to-typescript-decorator/

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
