### PR TITLE
Add missing ArrowFunctionExpression to config options

### DIFF
--- a/packages/eslint-plugin/rules/curly-newline/README.md
+++ b/packages/eslint-plugin/rules/curly-newline/README.md
@@ -45,6 +45,7 @@ You can specify different options for different kinds of blocks:
 - `"TryStatementHandler"` - A `try..catch..finally` statement handler body
 - `"TryStatementFinalizer"` - A `try..catch..finally` statement finalizer body
 - `"BlockStatement"` - A lone block
+- `"ArrowFunctionExpression"` - An arrow function expression body
 - `"FunctionDeclaration"` - A function declaration body
 - `"FunctionExpression"` - A function expression body
 - `"Property"` - An object method shorthand body


### PR DESCRIPTION
Add missing ArrowFunctionExpression config entry

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Added missing config option
