### PR TITLE
feat(no-extra-parens): deprecate some options in favor of `ignoredNodes`

### DIFF
--- a/packages/eslint-plugin/rules/no-extra-parens/README.md
+++ b/packages/eslint-plugin/rules/no-extra-parens/README.md
@@ -52,13 +52,13 @@ This rule has an object option for exceptions to the `"all"` option:
 - [`"nestedBinaryExpressions": false`](#nestedbinaryexpressions) allows extra parentheses in nested binary expressions
 - [`"ternaryOperandBinaryExpressions": false`](#ternaryoperandbinaryexpressions) allows extra parentheses around binary expressions that are operands of ternary `?:`
 - [`"ignoreJSX": "none|all|multi-line|single-line"`](#ignorejsx) allows extra parentheses around no/all/multi-line/single-line JSX components. Defaults to `none`.
-- [`"enforceForArrowConditionals": false`](#enforceforarrowconditionals) allows extra parentheses around ternary expressions which are the body of an arrow function
+- [`"enforceForArrowConditionals": false`](#enforceforarrowconditionals-deprecated) **(deprecated)** allows extra parentheses around ternary expressions which are the body of an arrow function
 - [`"enforceForSequenceExpressions": false`](#enforceforsequenceexpressions) allows extra parentheses around sequence expressions
-- [`"enforceForNewInMemberExpressions": false`](#enforcefornewinmemberexpressions) allows extra parentheses around `new` expressions in member expressions
+- [`"enforceForNewInMemberExpressions": false`](#enforcefornewinmemberexpressions-deprecated) **(deprecated)** allows extra parentheses around `new` expressions in member expressions
 - [`"enforceForFunctionPrototypeMethods": false`](#enforceforfunctionprototypemethods) allows extra parentheses around immediate `.call` and `.apply` method calls on function expressions and around function expressions in the same context.
 - [`"allowParensAfterCommentPattern": "any-string-pattern"`](#allowparensaftercommentpattern) allows extra parentheses preceded by a comment that matches a regular expression.
 - [`"nestedConditionalExpressions": false`](#nestedconditionalexpressions) allows extra parentheses in nested conditional(ternary) expressions
-- [`"allowNodesInSpreadElement"`](#allownodesinspreadelement) object has properties whose names correspond to node types in the abstract syntax tree (AST) of JavaScript code. Allows extra parentheses to be added to these nodes within the spread syntax
+- [`"allowNodesInSpreadElement"`](#allownodesinspreadelement-deprecated) **(deprecated)** object has properties whose names correspond to node types in the abstract syntax tree (AST) of JavaScript code. Allows extra parentheses to be added to these nodes within the spread syntax
   - `"ConditionalExpression": true`
   - `"LogicalExpression": true`
   - `"AwaitExpression": true`
@@ -294,7 +294,9 @@ const ThatComponent = (<div><p /></div>)
 
 :::
 
-### enforceForArrowConditionals
+### enforceForArrowConditionals (deprecated)
+
+This option is deprecated, please use [`ignoredNodes`](#ignorednodes) instead.
 
 Examples of **correct** code for this rule with the `"all"` and `{ "enforceForArrowConditionals": false }` options:
 
@@ -327,7 +329,9 @@ while ((val = foo(), val < 10));
 
 :::
 
-### enforceForNewInMemberExpressions
+### enforceForNewInMemberExpressions (deprecated)
+
+This option is deprecated, please use [`ignoredNodes`](#ignorednodes) instead.
 
 Examples of **correct** code for this rule with the `"all"` and `{ "enforceForNewInMemberExpressions": false }` options:
 
@@ -408,7 +412,9 @@ a ? b : (c ? d : e);
 
 :::
 
-### allowNodesInSpreadElement
+### allowNodesInSpreadElement (deprecated)
+
+This option is deprecated, please use [`ignoredNodes`](#ignorednodes) instead.
 
 Examples of **correct** code for this rule with the `"all"` and `{ "allowNodesInSpreadElement": { LogicalExpression: true, ConditionalExpression: true } }` options:
 
@@ -435,6 +441,76 @@ const fruits = {
 :::
 
 ### ignoredNodes
+
+The following configuration ignores `ConditionalExpression` in `ArrowFunctionExpression` nodes like [`enforceForArrowConditionals`](#enforceforarrowconditionals-deprecated):
+
+Examples of **correct** code for this rule with the `"all", { "ignoredNodes": ["ArrowFunctionExpression[body.type=ConditionalExpression"] }` option:
+
+::: correct
+
+```js
+/* eslint @stylistic/no-extra-parens: ["error", "all", { "ignoredNodes": ["ArrowFunctionExpression[body.type=ConditionalExpression]"] }] */
+
+const b = a => 1 ? 2 : 3;
+const d = c => (1 ? 2 : 3);
+```
+
+:::
+
+The following configuration ignores `NewExpression` in `MemberExpression` nodes like [`enforceForNewInMemberExpressions`](#enforcefornewinmemberexpressions-deprecated):
+
+Examples of **correct** code for this rule with the `"all", { "ignoredNodes": ["MemberExpression[object.type=NewExpression"] }` option:
+
+::: correct
+
+```js
+/* eslint @stylistic/no-extra-parens: ["error", "all", { "ignoredNodes": ["MemberExpression[object.type=NewExpression]"] }] */
+
+const foo = (new Bar()).baz;
+
+const quux = (new Bar())[baz];
+
+(new Bar()).doSomething();
+```
+
+:::
+
+The following configuration ignores `LogicalExpression`, `ConditionalExpression` in `SpreadElement` nodes like [`allowNodesInSpreadElement`](#allownodesinspreadelement-deprecated):
+
+Examples of **correct** code for this rule with the `"all", { "ignoredNodes": ["SpreadElement[argument.type=ConditionalExpression]", "SpreadElement[argument.type=LogicalExpression]", "SpreadElement[argument.type=AwaitExpression]"] }` option:
+
+::: correct
+
+```js
+/* eslint @stylistic/no-extra-parens: [
+    "error",
+    "all",
+    {
+        "ignoredNodes": [
+            "SpreadElement[argument.type=ConditionalExpression]",
+            "SpreadElement[argument.type=LogicalExpression]",
+            "SpreadElement[argument.type=AwaitExpression]",
+        ]
+    }
+ ] */
+
+const x = [
+    ...a ? [1, 2, 3] : [],
+    ...(a ? [1, 2, 3] : []),
+]
+
+const fruits = {
+    ...isSummer && { watermelon: 30 },
+    ...(isSummer && { watermelon: 30 }),
+};
+
+async function example() {
+    const promiseArray = Promise.resolve([1, 2, 3]);
+    console.log(...(await promiseArray));
+}
+```
+
+:::
 
 The following configuration ignores init in `VariableDeclarator` nodes:
 

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.test.ts
@@ -573,6 +573,18 @@ run<RuleOptions, MessageIds>({
       code: 'var a = (b) => ((1 ? 2 : 3))',
       options: ['all', { enforceForArrowConditionals: false }],
     },
+    {
+      code: 'var a = b => (1 ? 2 : 3)',
+      options: ['all', { ignoredNodes: ['ArrowFunctionExpression[body.type=ConditionalExpression]'] }],
+    },
+    {
+      code: 'var a = (b) => (1 ? 2 : 3)',
+      options: ['all', { ignoredNodes: ['ArrowFunctionExpression[body.type=ConditionalExpression]'] }],
+    },
+    {
+      code: 'var a = (b) => ((1 ? 2 : 3))',
+      options: ['all', { ignoredNodes: ['ArrowFunctionExpression[body.type=ConditionalExpression]'] }],
+    },
 
     // ["all", { enforceForSequenceExpressions: false }]
     { code: '(a, b)', options: ['all', { enforceForSequenceExpressions: false }] },
@@ -582,6 +594,13 @@ run<RuleOptions, MessageIds>({
     { code: 'if((a, b)){}', options: ['all', { enforceForSequenceExpressions: false }] },
     { code: 'if(((a, b))){}', options: ['all', { enforceForSequenceExpressions: false }] },
     { code: 'while ((val = foo(), val < 10));', options: ['all', { enforceForSequenceExpressions: false }] },
+    { code: '(a, b)', options: ['all', { ignoredNodes: ['SequenceExpression'] }] },
+    // { code: '((a, b))', options: ['all', { ignoredNodes: ['SequenceExpression'] }] },
+    // { code: '(foo(), bar());', options: ['all', { ignoredNodes: ['SequenceExpression'] }] },
+    // { code: '((foo(), bar()));', options: ['all', { ignoredNodes: ['SequenceExpression'] }] },
+    // { code: 'if((a, b)){}', options: ['all', { ignoredNodes: ['SequenceExpression'] }] },
+    // { code: 'if(((a, b))){}', options: ['all', { ignoredNodes: ['SequenceExpression'] }] },
+    // { code: 'while ((val = foo(), val < 10));', options: ['all', { ignoredNodes: ['SequenceExpression'] }] },
 
     // ["all", { enforceForNewInMemberExpressions: false }]
     { code: '(new foo()).bar', options: ['all', { enforceForNewInMemberExpressions: false }] },
@@ -591,6 +610,13 @@ run<RuleOptions, MessageIds>({
     { code: '(new foo.bar()).baz', options: ['all', { enforceForNewInMemberExpressions: false }] },
     { code: '(new foo.bar()).baz()', options: ['all', { enforceForNewInMemberExpressions: false }] },
     { code: '((new foo.bar())).baz()', options: ['all', { enforceForNewInMemberExpressions: false }] },
+    { code: '(new foo()).bar', options: ['all', { ignoredNodes: ['MemberExpression[object.type=NewExpression]'] }] },
+    { code: '(new foo())[bar]', options: ['all', { ignoredNodes: ['MemberExpression[object.type=NewExpression]'] }] },
+    { code: '(new foo()).bar()', options: ['all', { ignoredNodes: ['MemberExpression[object.type=NewExpression]'] }] },
+    { code: '(new foo(bar)).baz', options: ['all', { ignoredNodes: ['MemberExpression[object.type=NewExpression]'] }] },
+    { code: '(new foo.bar()).baz', options: ['all', { ignoredNodes: ['MemberExpression[object.type=NewExpression]'] }] },
+    { code: '(new foo.bar()).baz()', options: ['all', { ignoredNodes: ['MemberExpression[object.type=NewExpression]'] }] },
+    { code: '((new foo.bar())).baz()', options: ['all', { ignoredNodes: ['MemberExpression[object.type=NewExpression]'] }] },
 
     // ["all", { enforceForFunctionPrototypeMethods: false }]
     { code: 'var foo = (function(){}).call()', options: ['all', { enforceForFunctionPrototypeMethods: false }] },
@@ -871,11 +897,29 @@ run<RuleOptions, MessageIds>({
     {
       code: $`
         const x = [
+          ...a ? [1, 2, 3] : [],
+          ...(a ? [1, 2, 3] : []),
+        ]
+      `,
+      options: ['all', { ignoredNodes: ['SpreadElement[argument.type=ConditionalExpression]'] }],
+    },
+    {
+      code: $`
+        const x = [
           ...b ?? c,
           ...(b ?? c),
         ]
       `,
       options: ['all', { allowNodesInSpreadElement: { LogicalExpression: true } }],
+    },
+    {
+      code: $`
+        const x = [
+          ...b ?? c,
+          ...(b ?? c),
+        ]
+      `,
+      options: ['all', { ignoredNodes: ['SpreadElement[argument.type=LogicalExpression]'] }],
     },
     {
       code: $`
@@ -888,12 +932,30 @@ run<RuleOptions, MessageIds>({
     },
     {
       code: $`
+        const fruits = {
+          ...isSummer && { watermelon: 30 },
+          ...(isSummer && { watermelon: 30 }),
+        };
+      `,
+      options: ['all', { ignoredNodes: ['SpreadElement[argument.type=LogicalExpression]'] }],
+    },
+    {
+      code: $`
         async function example() {
           const promiseArray = Promise.resolve([1, 2, 3]);
           console.log(...(await promiseArray));
         }
       `,
       options: ['all', { allowNodesInSpreadElement: { AwaitExpression: true } }],
+    },
+    {
+      code: $`
+        async function example() {
+          const promiseArray = Promise.resolve([1, 2, 3]);
+          console.log(...(await promiseArray));
+        }
+      `,
+      options: ['all', { ignoredNodes: ['SpreadElement[argument.type=AwaitExpression]'] }],
     },
     {
       code: $`
@@ -908,6 +970,20 @@ run<RuleOptions, MessageIds>({
         };
       `,
       options: ['all', { allowNodesInSpreadElement: { LogicalExpression: true, ConditionalExpression: true } }],
+    },
+    {
+      code: $`
+        const x = [
+          ...a ? [1, 2, 3] : [],
+          ...(a ? [1, 2, 3] : []),
+        ]
+        
+        const fruits = {
+          ...isSummer && { watermelon: 30 },
+          ...(isSummer && { watermelon: 30 }),
+        };
+      `,
+      options: ['all', { ignoredNodes: ['SpreadElement'] }],
     },
     // https://github.com/eslint-stylistic/eslint-stylistic/issues/872
     {

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.test.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens._js_.test.ts
@@ -594,13 +594,6 @@ run<RuleOptions, MessageIds>({
     { code: 'if((a, b)){}', options: ['all', { enforceForSequenceExpressions: false }] },
     { code: 'if(((a, b))){}', options: ['all', { enforceForSequenceExpressions: false }] },
     { code: 'while ((val = foo(), val < 10));', options: ['all', { enforceForSequenceExpressions: false }] },
-    { code: '(a, b)', options: ['all', { ignoredNodes: ['SequenceExpression'] }] },
-    // { code: '((a, b))', options: ['all', { ignoredNodes: ['SequenceExpression'] }] },
-    // { code: '(foo(), bar());', options: ['all', { ignoredNodes: ['SequenceExpression'] }] },
-    // { code: '((foo(), bar()));', options: ['all', { ignoredNodes: ['SequenceExpression'] }] },
-    // { code: 'if((a, b)){}', options: ['all', { ignoredNodes: ['SequenceExpression'] }] },
-    // { code: 'if(((a, b))){}', options: ['all', { ignoredNodes: ['SequenceExpression'] }] },
-    // { code: 'while ((val = foo(), val < 10));', options: ['all', { ignoredNodes: ['SequenceExpression'] }] },
 
     // ["all", { enforceForNewInMemberExpressions: false }]
     { code: '(new foo()).bar', options: ['all', { enforceForNewInMemberExpressions: false }] },

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens.ts
@@ -26,6 +26,7 @@ import {
   skipChainExpression,
 } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
+import { warnDeprecation } from '#utils/index'
 
 export default createRule<RuleOptions, MessageIds>({
   name: 'no-extra-parens',
@@ -63,13 +64,15 @@ export default createRule<RuleOptions, MessageIds>({
                 nestedBinaryExpressions: { type: 'boolean' },
                 returnAssign: { type: 'boolean' },
                 ignoreJSX: { type: 'string', enum: ['none', 'all', 'single-line', 'multi-line'] },
+                /** @deprected */
                 enforceForArrowConditionals: { type: 'boolean' },
                 enforceForSequenceExpressions: { type: 'boolean' },
+                /** @deprected */
                 enforceForNewInMemberExpressions: { type: 'boolean' },
                 enforceForFunctionPrototypeMethods: { type: 'boolean' },
                 allowParensAfterCommentPattern: { type: 'string' },
                 nestedConditionalExpressions: { type: 'boolean' },
-                // TODO: Deprecate options that can be simply defined using ignoredNodes.
+                /** @deprected */
                 allowNodesInSpreadElement: {
                   type: 'object',
                   properties: {
@@ -114,14 +117,24 @@ export default createRule<RuleOptions, MessageIds>({
     const IGNORE_NESTED_BINARY = ALL_NODES && options?.nestedBinaryExpressions === false
     const EXCEPT_RETURN_ASSIGN = ALL_NODES && options?.returnAssign === false
     const IGNORE_JSX = ALL_NODES && options?.ignoreJSX
+    /** @deprected */
     const IGNORE_ARROW_CONDITIONALS = ALL_NODES && options?.enforceForArrowConditionals === false
     const IGNORE_SEQUENCE_EXPRESSIONS = ALL_NODES && options?.enforceForSequenceExpressions === false
+    /** @deprected */
     const IGNORE_NEW_IN_MEMBER_EXPR = ALL_NODES && options?.enforceForNewInMemberExpressions === false
     const IGNORE_FUNCTION_PROTOTYPE_METHODS = ALL_NODES && options?.enforceForFunctionPrototypeMethods === false
     const ALLOW_PARENS_AFTER_COMMENT_PATTERN = ALL_NODES && options?.allowParensAfterCommentPattern
     const ALLOW_NESTED_TERNARY = ALL_NODES && options?.nestedConditionalExpressions === false
+    /** @deprected */
     const ALLOW_NODES_IN_SPREAD = ALL_NODES && context.options[1]
       && new Set(Object.entries(context.options[1].allowNodesInSpreadElement || {}).filter(([_, value]) => value).map(([key]) => key))
+
+    if (IGNORE_ARROW_CONDITIONALS)
+      warnDeprecation('option("enforceForArrowConditionals")', '"ignoreNodes"', 'no-extra-parens')
+    if (IGNORE_NEW_IN_MEMBER_EXPR)
+      warnDeprecation('option("enforceForNewInMemberExpressions")', '"ignoreNodes"', 'no-extra-parens')
+    if (ALLOW_NODES_IN_SPREAD)
+      warnDeprecation('option("allowNodesInSpreadElement")', '"ignoreNodes"', 'no-extra-parens')
 
     // @ts-expect-error other properties are not used
     const PRECEDENCE_OF_ASSIGNMENT_EXPR = precedence({ type: 'AssignmentExpression' })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

After #899, some options can simply use [`ignoredNodes`](https://eslint.style/rules/no-extra-parens#ignorednodes) instead; we can just add some examples in the docs.

Options are deprecated in this PR:

- `enforceForArrowConditionals`
- `enforceForNewInMemberExpressions`
- `allowNodesInSpreadElement`

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
