### PR TITLE
docs(max-len): clarify that ignorePattern needs to be a string

### DIFF
--- a/packages/eslint-plugin/rules/max-len/README.md
+++ b/packages/eslint-plugin/rules/max-len/README.md
@@ -26,7 +26,7 @@ This rule can have up to two numbers as positional arguments (for `code` and `ta
 - `"code"` (default `80`) enforces a maximum line length
 - `"tabWidth"` (default `4`) specifies the character width for tab characters
 - `"comments"` enforces a maximum line length for comments; defaults to value of `code`
-- `"ignorePattern"` ignores lines matching a regular expression; can only match a single line and need to be double escaped when written in YAML or JSON
+- `"ignorePattern"` ignores lines matching a pattern; can only match a single line, needs to be double escaped when written in YAML or JSON and should not be a `RegExp` object but a string that can be passed to its constructor.
 - `"ignoreComments": true` ignores all trailing comments and comments on their own line
 - `"ignoreTrailingComments": true` ignores only trailing comments
 - `"ignoreUrls": true` ignores lines that contain a URL
@@ -196,6 +196,12 @@ var longRegExpLiteral = /this is a really really really really really long regul
 :::
 
 ### ignorePattern
+
+::: warning
+
+This option needs to be a string that can be passed to the `RegExp` constructor; passing a `RegExp` object will not work.
+
+:::
 
 Examples of **correct** code for this rule with the `ignorePattern` option:
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guide](https://eslint.style/contribute/guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR clarifies the docs of max-len to explicitly point out that the `ìgnorePattern` option should not be a `RegExp` object but a string that can be passed to its constructor.

### Linked Issues

fixes #868

### Additional context

First time contributing to this project, feel free to tell me if you prefer to not use warning/tip containers or if it's not clear enough.
