### PR TITLE
fix(vitepress): do not let (in)correct sign overlap with code fragment

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -24,3 +24,8 @@
   border-right: 3px solid transparent;
   border-bottom: 4px solid #d11;
 }
+
+/* A code fragment has 'incorrect' or 'correct' type */
+.vp-doc div[class*='language-']:has(~ div) {
+  margin-top: 3rem;
+}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When reading rule docs, I notice that the (in)correct has an overlap against the code fragment, which is not ideal in my opinion.

Before this PR:
<img width="737" height="315" alt="image" src="https://github.com/user-attachments/assets/65b01e6b-e254-4026-b710-effb68c0036a" />

After this PR:
<img width="711" height="441" alt="image" src="https://github.com/user-attachments/assets/84c94926-a1dc-4a90-8fd6-1b79b96868d2" />


### Linked Issues

No

### Additional context

Open to any suggestions
<!-- e.g. is there anything you'd like reviewers to focus on? -->
