### PR TITLE
fix: replace `context.getSourceCode()` with `context.sourceCode`

### DIFF
--- a/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements.ts
+++ b/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements.ts
@@ -360,7 +360,7 @@ function verifyForNever(
       const start = prevToken.range[1]
       const end = nextToken.range[0]
       const text = context
-        .getSourceCode()
+        .sourceCode
         .text
         .slice(start, end)
         .replace(PADDING_LINE_SEQUENCE, replacerToRemovePaddingLines)

--- a/packages/eslint-plugin/rules/type-named-tuple-spacing/type-named-tuple-spacing.ts
+++ b/packages/eslint-plugin/rules/type-named-tuple-spacing/type-named-tuple-spacing.ts
@@ -21,9 +21,10 @@ export default createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [],
   create: (context) => {
-    const sourceCode = context.getSourceCode()
+    const sourceCode = context.sourceCode
+
     return {
-      TSNamedTupleMember: (node: any) => {
+      TSNamedTupleMember(node) {
         const code = sourceCode.text.slice(node.range[0], node.range[1])
 
         const match = code.match(tupleRe)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

`context.getSourceCode()` has been deprecated since `ESLint v9.0.0` and will be remove in `ESLint v10`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

https://eslint.org/blog/2025/10/whats-coming-in-eslint-10.0.0/#removing-deprecated-rule-context-members

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
