### PR TITLE
Test: Add passing and failing tests that demonstrate an inconsistency of in…

### DIFF
--- a/packages/eslint-plugin/rules/indent-binary-ops/indent-binary-ops.test.ts
+++ b/packages/eslint-plugin/rules/indent-binary-ops/indent-binary-ops.test.ts
@@ -134,6 +134,123 @@ run<RuleOptions, MessageIds>({
         c()
       }
     `,
+    {
+      code: $`
+        1 + (
+          1
+        )
+      `,
+      options: [2],
+    },
+    {
+      code: $`
+        return 1 + (
+          1
+        )
+      `,
+      options: [2],
+    },
+    {
+      code: $`
+        const baz = foo && (
+          bar
+        )
+      `,
+      options: [2],
+    },
+    {
+      code: $`
+        const baz = foo && 
+          (
+            bar
+          )
+      `,
+      options: [2],
+    },
+    {
+      code: $`
+        const result = x 
+          + z * (
+            x ** 2
+            + y ** 3
+          );
+      `,
+      options: [2],
+    },
+    {
+      code: $`
+        const result = x +
+          z * (
+            x ** 2 +
+            y ** 3
+          );
+      `,
+      options: [2],
+    },
+    {
+      code: $`
+        const result = x +
+          z + (
+            x ** 2 +
+            y ** 3
+          );
+      `,
+      options: [2],
+    },
+    { // passes, drop start of paren-wrapped expression to newline. Perhaps not a preferred style.
+      code: $`
+        const result = x +
+          z + 
+          (
+            x ** 2
+            + y ** 3
+          );
+      `,
+      options: [2],
+    },
+    { // passes, wrap the whole expression in paran and offsets/indent are counted correctly.
+      code: $`
+        const result = (
+          x +
+          z + (
+            x ** 2
+            + y ** 3
+          )
+        )
+      `,
+      options: [2],
+    },
+    { // passes
+      code: $`
+        const condition1 = true;
+        const condition2 = false;
+        const condition3 = true;
+        const data = "foo"
+        if(
+          condition1 &&
+          condition2 && (
+            condition3 ||
+            typeof data === "string"
+          )
+        ) {
+          console.log("Something important happened");
+        }
+      `,
+      options: [2],
+    },
+    {
+      code: $`
+        function foo() {
+            return foo === bar ||
+                baz === qux && (
+                    foo === foo ||
+                    bar === bar ||
+                    baz === baz
+                )
+        }
+      `,
+      options: [4],
+    },
   ],
   invalid: [
     {
@@ -617,6 +734,111 @@ run<RuleOptions, MessageIds>({
           bbbbb &&
           ccccc }
       `,
+    },
+    {
+      code: $`
+        const x = 10;
+        const y = 4;
+        const z = 2;
+        const result = x +
+          z + (
+          x ** 2 +
+          y ** 3
+        );
+      `,
+      output: $`
+        const x = 10;
+        const y = 4;
+        const z = 2;
+        const result = x +
+          z + (
+            x ** 2 +
+            y ** 3
+          );
+      `,
+      errors: [
+        {
+          messageId: 'wrongIndentation',
+          data: {
+            expected: '4 spaces',
+            actual: 2,
+          },
+          line: 6,
+        },
+        {
+          messageId: 'wrongIndentation',
+          data: {
+            expected: '2 spaces',
+            actual: 0,
+          },
+          line: 8,
+        },
+      ],
+    },
+    {
+      code: $`
+        const x = 10;
+        const y = 4;
+        const z = 2;
+        const result = x +
+          z * (
+          x ** 2 +
+          y ** 3
+        );
+      `,
+      options: [2],
+      output: $`
+        const x = 10;
+        const y = 4;
+        const z = 2;
+        const result = x +
+          z * (
+            x ** 2 +
+            y ** 3
+          );
+      `,
+      errors: [
+        {
+          messageId: 'wrongIndentation',
+          data: {
+            expected: '4 spaces',
+            actual: 2,
+          },
+          line: 6,
+        },
+        {
+          messageId: 'wrongIndentation',
+          data: {
+            expected: '2 spaces',
+            actual: 0,
+          },
+          line: 8,
+        },
+      ],
+    },
+    {
+      code: $`
+        return 1 +
+          2 * (
+              3
+          )
+      `,
+      output: $`
+        return 1 +
+          2 * (
+            3
+          )
+      `,
+      options: [2],
+      errors: [
+        {
+          messageId: 'wrongIndentation',
+          data: {
+            expected: '4 spaces',
+            actual: 6,
+          },
+        },
+      ],
     },
   ],
 })

--- a/packages/eslint-plugin/rules/indent/indent._ts_.test.ts
+++ b/packages/eslint-plugin/rules/indent/indent._ts_.test.ts
@@ -891,23 +891,7 @@ run<RuleOptions, MessageIds>({
           =
               require('source')
     `,
-    { // passes
-      code: $`
-        1 + (
-          1
-        )
-      `,
-      options: [2],
-    },
-    { // passes
-      code: $`
-        return 1 + (
-          1
-        )
-      `,
-      options: [2],
-    },
-    { // fails
+    { // fails, `indent` should probably ignore checks in this example and leave it to indent-binary-ops
       code: $`
         return 1 +
           2 + (
@@ -927,23 +911,6 @@ run<RuleOptions, MessageIds>({
     },
     { // passes
       code: $`
-        const baz = foo && (
-          bar
-        )
-      `,
-      options: [2],
-    },
-    { // passes
-      code: $`
-        const baz = foo && 
-          (
-            bar
-          )
-      `,
-      options: [2],
-    },
-    { // passes with operators on line-start
-      code: $`
         const result = x 
           + z * (
             x ** 2
@@ -962,7 +929,7 @@ run<RuleOptions, MessageIds>({
       `,
       options: [2],
     },
-    { // fails, contracts previous test, swap * to +
+    { // fails, `indent` should probably ignore checks in this example and leave it to indent-binary-ops
       code: $`
         const result = x +
           z + (
@@ -972,121 +939,33 @@ run<RuleOptions, MessageIds>({
       `,
       options: [2],
     },
-    { // passes, drop start of paren-wrapped expression to newline. Perhaps not a preferred style.
-      code: $`
-        const result = x +
-          z + 
-          (
-            x ** 2
-            + y ** 3
-          );
-      `,
-      options: [2],
-    },
-    { // passes, wrap the whole expression in paran and offsets/indent are counted correctly.
-      code: $`
-        const result = (
-          x +
-          z + (
-            x ** 2
-            + y ** 3
-          )
-        )
-      `,
-      options: [2],
-    },
-    { // passes
-      code: $`
-        const condition1 = true;
-        const condition2 = false;
-        const condition3 = true;
-        const data = "foo"
-        if(
-          condition1 &&
-          condition2 && (
-            condition3 ||
-            typeof data === "string"
-          )
-        ) {
-          console.log("Something important happened");
-        }
-      `,
-      options: [2],
-    },
-    { // fails
+    { // fails, `indent` should probably ignore checks in this example and leave it to indent-binary-ops
       code: $`
         const condition1 = true;
         const condition2 = false;
         const condition3 = true;
         const data = "foo"
         
-        const collapsedCondition = condition1 &&
+        const consolidated = condition1 &&
           condition2 && (
             condition3 ||
             typeof data === "string"
           )
-        
-        if(collapsedCondition) {
-          console.log("Something important happened");
-        }
       `,
       options: [2],
     },
-    { // passes, change && for || which changes order of operations?
+    { // passes, change && for || which changes the order of operations?
       code: $`
         const condition1 = true;
         const condition2 = false;
         const condition3 = true;
         const data = "foo"
         
-        const collapsedCondition = condition1 ||
+        const consolidated = condition1 ||
           condition2 && (
             condition3 ||
             typeof data === "string"
           )
-        
-        if(collapsedCondition) {
-          console.log("Something important happened");
-        }
-      `,
-      options: [2],
-    },
-    {
-      code: $`
-        function foo() {
-            return foo === bar ||
-                baz === qux && (
-                    foo === foo ||
-                    bar === bar ||
-                    baz === baz
-                )
-        }
-      `,
-      options: [4],
-    },
-    {
-      code: $`
-        interface RequestType {
-          requestId: string | null;
-          success: boolean | object;
-          message?: string;
-        }
-        
-        class genericService {
-          public goodFormatMethod = (data: RequestType) => {
-            if(
-              typeof data.requestId === "string" &&
-              typeof data.success === "boolean" && (
-                typeof data.message === "string" ||
-                typeof data.message === "undefined"
-              )
-            ) {
-              console.log("Something important happened");
-            }
-        
-            console.log("Something unimportant happened");
-          };
-        }
       `,
       options: [2],
     },
@@ -2511,40 +2390,27 @@ declare function h(x: number): number;
         const x = 10;
         const y = 4;
         const z = 2;
+        
         const result = x +
-          z + (
-          x ** 2 +
-          y ** 3
-        );
+            z * (
+                  x ** 2 +
+                y ** 3
+            );
       `,
-      // The 'correct' output looks strange as 'indent/binary-ops' is responsible for outside and in, but not across, parenthesis.
       output: $`
         const x = 10;
         const y = 4;
         const z = 2;
+        
         const result = x +
-          z + (
-            x ** 2 +
-          y ** 3
-          );
+            z * (
+                x ** 2 +
+                y ** 3
+            );
       `,
+      options: [4],
       errors: [
-        {
-          messageId: 'wrongIndentation',
-          data: {
-            expected: '4 spaces',
-            actual: 2,
-          },
-          line: 6,
-        },
-        {
-          messageId: 'wrongIndentation',
-          data: {
-            expected: '2 spaces',
-            actual: 0,
-          },
-          line: 8,
-        },
+        { messageId: 'wrongIndentation', data: { expected: '8 spaces', actual: 10 } },
       ],
     },
     {
@@ -2552,41 +2418,27 @@ declare function h(x: number): number;
         const x = 10;
         const y = 4;
         const z = 2;
+        
         const result = x +
-          z * (
-          x ** 2 +
-          y ** 3
-        );
+            z + (
+                  x ** 2 +
+                y ** 3
+            );
       `,
-      options: [2],
-      // The 'correct' output looks strange as 'indent/binary-ops' is responsible for outside and in, but not across, parenthesis.
       output: $`
         const x = 10;
         const y = 4;
         const z = 2;
+        
         const result = x +
-          z * (
-            x ** 2 +
-          y ** 3
-          );
+            z + (
+                x ** 2 +
+                y ** 3
+            );
       `,
+      options: [4],
       errors: [
-        {
-          messageId: 'wrongIndentation',
-          data: {
-            expected: '4 spaces',
-            actual: 2,
-          },
-          line: 6,
-        },
-        {
-          messageId: 'wrongIndentation',
-          data: {
-            expected: '2 spaces',
-            actual: 0,
-          },
-          line: 8,
-        },
+        { messageId: 'wrongIndentation', data: { expected: '8 spaces', actual: 10 } },
       ],
     },
   ],


### PR DESCRIPTION
…dent or indent-binary-ops.

### Description

Depending on the operator being used the combination of binary operators and parenthesis will result in incorrect warnings.

The example below and in this PR can produce warnings in both indent or indent-binary-ops
I believe the problem spans both indent and binary indent ops, the ignoring of binary expression nodes may need to be heavier handed so that indent-binary-ops may take over.

As an example the below code produces warnings.
```
const x = 10;
const y = 4;
const z = 2;

return x +
    z + (
        x ** 2 +
        y ** 3
    );
```

Where as this will not.
```
const x = 10;
const y = 4;
const z = 2;

return x +
    z * (
        x ** 2 +
        y ** 3
    );
```

There is also an example in this PR of swapping `&&` for `||` to produce valid code.

### Linked Issues

https://github.com/eslint-stylistic/eslint-stylistic/issues/1009

### Additional context

I may be able to contribute more to this issue/PR, however I think I need some insight/advice from those more experienced for the direction to take this. It is not clear if the indentation within parenthesis within a binary expression should be handled by indent-binary-ops, or if there is a bug to fix in `indent`.

The tests cases I have added were for me to try and explore this issue, they will need to be reworked into the correct rule if a solution is found.
