### PR TITLE
ci: cache build dist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,36 @@ jobs:
       - name: Typecheck
         run: nr typecheck
 
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v5
+        with:
+          node-version: lts/*
+          cache: pnpm
+
+      - name: Setup
+        run: npm i -g @antfu/ni
+
+      - name: Install
+        run: nci
+
+      - name: Build
+        run: nr build
+
+      - name: Cache dist
+        uses: actions/upload-artifact@v4
+        with:
+          retention-days: 3
+          name: dist
+          path: packages/*/dist
+
   test:
     runs-on: ${{ matrix.os }}
-
+    needs:
+      - build
     strategy:
       matrix:
         node: [lts/*]
@@ -51,10 +78,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
+      - uses: pnpm/action-setup@v4
       - name: Set node ${{ matrix.node }}
         uses: actions/setup-node@v5
         with:
@@ -67,8 +91,11 @@ jobs:
       - name: Install
         run: nci
 
-      - name: Build
-        run: nr build
+      - name: Restore dist cache
+        uses: actions/download-artifact@v5
+        with:
+          name: dist
+          path: packages
 
       - name: Test
         run: nr test


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Rolldown requires node >= 20.19 since [v1.0.0-beta.36](https://github.com/rolldown/rolldown/releases/tag/v1.0.0-beta.36), so build is failed in CI with node18, see: https://github.com/eslint-stylistic/eslint-stylistic/actions/runs/18553529006/job/52885612760?pr=1011.

Related: #1011

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
