### PR TITLE
feat(type-generic-spacing): introduce `before` and `after`

### DIFF
--- a/docs/guide/upgrade.md
+++ b/docs/guide/upgrade.md
@@ -34,11 +34,24 @@ The following deprecated options or shorthands are no longer supported:
 
 ### Behavior Changes
 
+#### type-generic-spacing
+
+The rule now supports `before` and `after` options to control spacing before and after generic type parameters. Both default to `false`, preserving the previous behavior of disallowing spaces.
+
+```json
+{
+  "@stylistic/type-generic-spacing": [
+    "error",
+    { "before": false, "after": false }
+  ]
+}
+```
+
 #### type-generic-spacing / space-infix-ops
 
-Spacing around default values in type parameters is no longer handled by [type-generic-spacing](../rules/type-generic-spacing).
+Spacing around default values in type parameters (e.g., `type Foo<T = true>` instead of `type Foo<T=true>`) is no longer handled by [type-generic-spacing](../rules/type-generic-spacing).
 
-If you want to enforce `type Foo<T = true> = T` instead of `type Foo<T=true> = T`, make sure [space-infix-ops](../rules/space-infix-ops) is enabled.
+If you previously relied on this rule to enforce it, make sure [space-infix-ops](../rules/space-infix-ops) is enabled.
 
 #### keyword-spacing / space-before-blocks
 

--- a/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements._js_.test.ts
+++ b/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements._js_.test.ts
@@ -4546,7 +4546,7 @@ run<RuleOptions, MessageIds>({
     // singleline-using
     // ----------------------------------------------------------------------
 
-    ...['using', 'await using'].flatMap <InvalidTestCase<RuleOptions, MessageIds>>(usingType => [
+    ...['using', 'await using'].flatMap<InvalidTestCase<RuleOptions, MessageIds>>(usingType => [
       {
         code: `${usingType} a=1\n\n${usingType} b=2`,
         output: `${usingType} a=1\n${usingType} b=2`,

--- a/packages/eslint-plugin/rules/type-generic-spacing/README.md
+++ b/packages/eslint-plugin/rules/type-generic-spacing/README.md
@@ -2,7 +2,7 @@
 related_rules:
   - type-annotation-spacing
   - space-infix-ops
-  - space-before-blocks
+  - space-before-function-paren
 ---
 
 # type-generic-spacing
@@ -28,10 +28,23 @@ Examples of **incorrect** code for this rule:
 ```ts
 /* eslint @stylistic/type-generic-spacing: ["error"] */
 
-type Foo<T=true> = T
+type Foo <T = true> = T
+
+const foo: Array <number> = []
+
+function foo <T> () {}
+
+const value = callback <string> ()
+
+const set = new Set <string> ()
+
+const tagged = tag <string> `value`
 
 interface Log {
-  foo <T>(name: T): void
+  new <T> (): Log
+  foo <T> (name: T): void
+  call: <T> () => void
+  construct: new <T> () => Log
 }
 ```
 
@@ -45,16 +58,23 @@ Examples of **correct** code for this rule:
 /* eslint @stylistic/type-generic-spacing: ["error"] */
 
 type Foo<T = true> = T
-//                ^
-// handled by `space-infix-ops`
+
+const foo: Array<number> = []
+
+function foo<T>() {}
+
+const value = callback<string>()
+
+const set = new Set<string>()
+
+const tagged = tag<string>`value`
 
 interface Log {
+  new <T>(): Log
   foo<T>(name: T): void
+  call: <T>() => void
+  construct: new <T>() => Log
 }
-
-const foo = class <T> {}
-//               ^   ^
-// handled by `keyword-spacing` and `space-before-blocks`
 ```
 
 :::

--- a/packages/eslint-plugin/rules/type-generic-spacing/README.md
+++ b/packages/eslint-plugin/rules/type-generic-spacing/README.md
@@ -1,3 +1,10 @@
+---
+related_rules:
+  - type-annotation-spacing
+  - space-infix-ops
+  - space-before-blocks
+---
+
 # type-generic-spacing
 
 Enforces consistent spacing inside TypeScript type generics.
@@ -8,7 +15,11 @@ This rule enforces consistent spacing inside TypeScript type generics.
 
 ## Options
 
-This rule has no options.
+This rule takes an object argument with `before` and `after` properties, each with a Boolean value.
+
+The default configuration is `{ "before": false, "after": false }`.
+
+`true` means there should be one or more spaces and false means no spaces.
 
 Examples of **incorrect** code for this rule:
 
@@ -16,6 +27,8 @@ Examples of **incorrect** code for this rule:
 
 ```ts
 /* eslint @stylistic/type-generic-spacing: ["error"] */
+
+type Foo<T=true> = T
 
 interface Log {
   foo <T>(name: T): void
@@ -31,9 +44,17 @@ Examples of **correct** code for this rule:
 ```ts
 /* eslint @stylistic/type-generic-spacing: ["error"] */
 
+type Foo<T = true> = T
+//                ^
+// handled by `space-infix-ops`
+
 interface Log {
   foo<T>(name: T): void
 }
+
+const foo = class <T> {}
+//               ^   ^
+// handled by `keyword-spacing` and `space-before-blocks`
 ```
 
 :::

--- a/packages/eslint-plugin/rules/type-generic-spacing/type-generic-spacing.test.ts
+++ b/packages/eslint-plugin/rules/type-generic-spacing/type-generic-spacing.test.ts
@@ -6,10 +6,15 @@ run<RuleOptions, MessageIds>({
   name: 'type-generic-spacing',
   rule,
   valid: [
+    // handled by `space-infix-ops`
     'const foo: Array<number> = []',
+    'const foo: Array<number>= []',
     'type Foo<T = true> = T',
+    'type Foo<T = true>= T',
     'type Foo<T extends true = true> = T',
+    // handled by `keyword-spacing`
     'type Foo = new <T>(name: T) => void',
+    'type Foo = new<T>(name: T) => void',
     $`
       type Foo<
         T = true,
@@ -18,14 +23,13 @@ run<RuleOptions, MessageIds>({
     `,
     $`
       function foo<
-            T
-          >() {}
+        T
+      >() {}
     `,
-    'const foo = <T>(name: T) => name',
     $`
       interface Log {
-            foo<T>(name: T): void
-          }
+        foo<T>(name: T): void
+      }
     `,
     $`
       interface Log {
@@ -38,8 +42,21 @@ run<RuleOptions, MessageIds>({
       }
     `,
     `const toSortedImplementation = Array.prototype.toSorted || function <T>(name: T): void {}`,
-    `class Foo<T> {}`,
-    `const foo = class<T> {}`,
+    `type Foo = import('foo')<T>['Foo']`,
+    `type Foo = import('foo')<T> ['Foo']`,
+    `const foo = class <T> { value: T; }`,
+    `const foo = class<T>{ value: T; }`,
+    `class Foo<T>{ value: T; }`,
+    `class Foo<T> { value: T; }`,
+    'const foo = <T>() => 1',
+    'const foo =<T>() => 1',
+    'const foo = function <T> () {}',
+    'const foo = function<T>() {}',
+    'function foo<T>() {}',
+    'declare function foo<T>(): void',
+    'declare function foo<T> (): void',
+    'interface Foo extends Bar<T> {}',
+    'interface Foo extends Bar<T>{}',
   ],
   invalid: ([
     ['const val: Set< string> = new Set()', 'const val: Set<string> = new Set()'],
@@ -55,15 +72,20 @@ run<RuleOptions, MessageIds>({
     ['function foo< T >() {}', 'function foo<T>() {}', 2],
     [
       $`
-        interface Log {
+        interface Log<T> {
           foo <T>(name: T): void
+          bar: <T> () => void
+          baz: new <T> () => void
         }
       `,
       $`
-        interface Log {
+        interface Log<T> {
           foo<T>(name: T): void
+          bar: <T>() => void
+          baz: new <T>() => void
         }
       `,
+      3,
     ],
     [
       $`
@@ -83,12 +105,71 @@ run<RuleOptions, MessageIds>({
       'const toSortedImplementation = Array.prototype.toSorted || function <T>(name: T): void {}',
       2,
     ],
-    ['class Foo <T> {}', 'class Foo<T> {}', 1],
-    ['const foo = class <T> {}', 'const foo = class<T> {}', 1],
-  ] as const)
-    .map(i => ({
-      code: i[0],
-      output: i[1],
-      errors: Array.from({ length: i[2] || 1 }, () => ({ messageId: 'genericSpacingMismatch' })),
-    })),
+  ] satisfies [string, string, number?][]).map(([code, output, errorLen = 1]) => ({
+    code,
+    output,
+    errors: Array.from({ length: errorLen }, () => ({ messageId: 'genericSpacingMismatch' })),
+  })),
+})
+
+run<RuleOptions, MessageIds>({
+  name: 'type-generic-spacing',
+  rule,
+  valid: [
+    { code: 'const foo = function bar<T>() {}' },
+    { code: 'function foo <T>() {}', options: [{ before: true }] },
+    { code: 'type Foo <T> = T', options: [{ before: true }] },
+    { code: 'const Foo = class Bar<T> {}' },
+    { code: 'class Foo <T> {}', options: [{ before: true }] },
+    { code: 'const val = callback<string> (() => \'foo\')', options: [{ after: true }] },
+    { code: 'interface Foo { foo<T> (name: T): void }', options: [{ after: true }] },
+  ],
+  invalid: [
+    {
+      code: 'const foo = function bar <T>() {}',
+      output: 'const foo = function bar<T>() {}',
+      errors: [{ messageId: 'genericSpacingMismatch' }],
+    },
+    {
+      code: 'function foo<T>() {}',
+      output: 'function foo <T>() {}',
+      options: [{ before: true }],
+      errors: [{ messageId: 'genericSpacingMismatch' }],
+    },
+    {
+      code: 'type Foo<T> = T',
+      output: 'type Foo <T> = T',
+      options: [{ before: true }],
+      errors: [{ messageId: 'genericSpacingMismatch' }],
+    },
+    {
+      code: 'const Foo = class Bar <T> {}',
+      output: 'const Foo = class Bar<T> {}',
+      errors: [{ messageId: 'genericSpacingMismatch' }],
+    },
+    {
+      code: 'class Foo<T> {}',
+      output: 'class Foo <T> {}',
+      options: [{ before: true }],
+      errors: [{ messageId: 'genericSpacingMismatch' }],
+    },
+    {
+      code: 'const val = foo<string>()',
+      output: 'const val = foo <string> ()',
+      options: [{ before: true, after: true }],
+      errors: [
+        { messageId: 'genericSpacingMismatch' },
+        { messageId: 'genericSpacingMismatch' },
+      ],
+    },
+    {
+      code: 'interface Foo { foo<T>(name: T): void }',
+      output: 'interface Foo { foo <T> (name: T): void }',
+      options: [{ before: true, after: true }],
+      errors: [
+        { messageId: 'genericSpacingMismatch' },
+        { messageId: 'genericSpacingMismatch' },
+      ],
+    },
+  ],
 })

--- a/packages/eslint-plugin/rules/type-generic-spacing/type-generic-spacing.test.ts
+++ b/packages/eslint-plugin/rules/type-generic-spacing/type-generic-spacing.test.ts
@@ -95,18 +95,6 @@ run<RuleOptions, MessageIds>({
     [
       $`
         interface Log {
-          new <T>(): Log
-        }
-      `,
-      $`
-        interface Log {
-          new<T>(): Log
-        }
-      `,
-    ],
-    [
-      $`
-        interface Log {
           foo<  T >(name: T): void
         }
       `,

--- a/packages/eslint-plugin/rules/type-generic-spacing/type-generic-spacing.test.ts
+++ b/packages/eslint-plugin/rules/type-generic-spacing/type-generic-spacing.test.ts
@@ -9,6 +9,7 @@ run<RuleOptions, MessageIds>({
     // handled by `space-infix-ops`
     'const foo: Array<number> = []',
     'const foo: Array<number>= []',
+    // handled by `space-infix-ops`
     'type Foo<T = true> = T',
     'type Foo<T = true>= T',
     'type Foo<T extends true = true> = T',
@@ -44,17 +45,21 @@ run<RuleOptions, MessageIds>({
     `const toSortedImplementation = Array.prototype.toSorted || function <T>(name: T): void {}`,
     `type Foo = import('foo')<T>['Foo']`,
     `type Foo = import('foo')<T> ['Foo']`,
+    // handled by `keyword-spacing` and `space-before-blocks`
     `const foo = class <T> { value: T; }`,
     `const foo = class<T>{ value: T; }`,
     `class Foo<T>{ value: T; }`,
     `class Foo<T> { value: T; }`,
+    // handled by `space-infix-ops`
     'const foo = <T>() => 1',
     'const foo =<T>() => 1',
+    // handled by `space-before-function-paren`
     'const foo = function <T> () {}',
     'const foo = function<T>() {}',
     'function foo<T>() {}',
     'declare function foo<T>(): void',
     'declare function foo<T> (): void',
+    // handled by `space-before-blocks`
     'interface Foo extends Bar<T> {}',
     'interface Foo extends Bar<T>{}',
   ],
@@ -86,6 +91,18 @@ run<RuleOptions, MessageIds>({
         }
       `,
       3,
+    ],
+    [
+      $`
+        interface Log {
+          new <T>(): Log
+        }
+      `,
+      $`
+        interface Log {
+          new<T>(): Log
+        }
+      `,
     ],
     [
       $`

--- a/packages/eslint-plugin/rules/type-generic-spacing/type-generic-spacing.ts
+++ b/packages/eslint-plugin/rules/type-generic-spacing/type-generic-spacing.ts
@@ -1,8 +1,8 @@
-import type { NodeTypes, Token } from '#types'
+import type { NodeTypes, Token, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
 import { createRule } from '#utils/create-rule'
 
-const PRESERVE_PREFIX_SPACE_BEFORE_GENERIC = new Set<NodeTypes>([
+const SKIP_BEFORE_CHECK = new Set<NodeTypes>([
   'TSCallSignatureDeclaration',
   // const foo = <T>(name: T) => name
   //            ^
@@ -16,8 +16,69 @@ const PRESERVE_PREFIX_SPACE_BEFORE_GENERIC = new Set<NodeTypes>([
   //               ^
   // handled by `space-unary-ops`
   'TSConstructorType',
-  'FunctionExpression',
 ])
+
+function shouldSkipBeforeCheck(node: SupportNodes) {
+  if (SKIP_BEFORE_CHECK.has(node.parent.type))
+    return true
+
+  // const foo = function <T>() {}
+  //                     ^
+  // handled by `space-before-function-paren`
+  //
+  // const foo = class <T> {}
+  //                  ^
+  // handled by `keyword-spacing`
+  if (node.parent.type === 'FunctionExpression' || node.parent.type === 'ClassExpression')
+    return node.parent.id == null
+
+  return false
+}
+
+const SKIP_AFTER_CHECK = new Set<NodeTypes>([
+  // const foo = class Foo<T> extends Bar<T> {}
+  //                                        ^
+  // handled by `space-before-blocks`
+  'ClassExpression',
+  // class foo<T> extends bar<T> {}
+  //             ^              ^
+  // handled by `keyword-spacing` and `space-before-blocks`
+  'ClassDeclaration',
+  // type Foo<T> = T
+  //            ^
+  // handled by `space-infix-ops`
+  'TSTypeAliasDeclaration',
+  // interface Foo<T> {}
+  //                 ^
+  // handled by `space-before-blocks`
+  'TSInterfaceDeclaration',
+  // interface Foo extends Bar<T> {}
+  //                             ^
+  // handled by `space-before-blocks`
+  'TSInterfaceHeritage',
+  // const x: Array<T> = []
+  //                  ^
+  // handled by `space-infix-ops`
+  'TSTypeReference',
+  // type Foo = import('foo')<T> ['Foo']
+  //                            ^
+  // handled by `no-whitespace-before-property`
+  'TSImportType',
+  // function foo<T> () {}
+  //                ^
+  // handled by `space-before-function-paren`
+  'FunctionDeclaration',
+  // const foo = function<T> () {}
+  //                        ^
+  // handled by `space-before-function-paren`
+  'FunctionExpression',
+  // declare function foo<T> (): void
+  //                        ^
+  // handled by `space-before-function-paren`
+  'TSDeclareFunction',
+])
+
+type SupportNodes = Tree.TSTypeParameterDeclaration | Tree.TSTypeParameterInstantiation
 
 export default createRule<RuleOptions, MessageIds>({
   name: 'type-generic-spacing',
@@ -27,13 +88,77 @@ export default createRule<RuleOptions, MessageIds>({
       description: 'Enforces consistent spacing inside TypeScript type generics',
     },
     fixable: 'whitespace',
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          before: {
+            type: 'boolean',
+          },
+          after: {
+            type: 'boolean',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    defaultOptions: [
+      {
+        before: false,
+        after: false,
+      },
+    ],
     messages: {
       genericSpacingMismatch: 'Generic spaces mismatch',
     },
   },
-  create: (context) => {
+  create: (context, [options]) => {
     const sourceCode = context.sourceCode
+    const { before, after } = options!
+
+    function checkBefore(node: SupportNodes) {
+      if (shouldSkipBeforeCheck(node))
+        return
+
+      const preToken = sourceCode.getTokenBefore(node, { includeComments: true })!
+      const hasSpace = sourceCode.isSpaceBetween(preToken, node)
+
+      if (before !== hasSpace) {
+        context.report({
+          node,
+          messageId: 'genericSpacingMismatch',
+          fix(fixer) {
+            return before
+              ? fixer.insertTextBefore(node, ' ')
+              : fixer.replaceTextRange([preToken.range[1], node.range[0]], '')
+          },
+        })
+      }
+    }
+
+    function checkAfter(node: SupportNodes) {
+      if (SKIP_AFTER_CHECK.has(node.parent.type))
+        return
+      const nextToken = sourceCode.getTokenAfter(node, { includeComments: true })!
+      const hasSpace = sourceCode.isSpaceBetween(node, nextToken)
+
+      if (after !== hasSpace) {
+        context.report({
+          node,
+          messageId: 'genericSpacingMismatch',
+          fix(fixer) {
+            return after
+              ? fixer.insertTextAfter(node, ' ')
+              : fixer.replaceTextRange([node.range[1], nextToken.range[0]], '')
+          },
+        })
+      }
+    }
+
+    function checkSpacing(node: SupportNodes) {
+      checkBefore(node)
+      checkAfter(node)
+    }
 
     function removeSpaceBetween(left: Token, right: Token) {
       const textBetween = sourceCode.text.slice(left.range[1], right.range[0])
@@ -73,41 +198,19 @@ export default createRule<RuleOptions, MessageIds>({
 
     return {
       TSTypeParameterInstantiation: (node) => {
-        const params = node.params
+        checkSpacing(node)
 
-        if (params.length === 0)
-          return
-
-        const openToken = sourceCode.getTokenBefore(params[0])
-        const closeToken = sourceCode.getTokenAfter(params[params.length - 1])
+        const openToken = sourceCode.getTokenBefore(node.params[0])
+        const closeToken = sourceCode.getTokenAfter(node.params.at(-1)!)
 
         checkBracketSpacing(openToken, closeToken)
       },
 
       TSTypeParameterDeclaration: (node) => {
-        if (!PRESERVE_PREFIX_SPACE_BEFORE_GENERIC.has(node.parent.type)) {
-          const pre = sourceCode.text.slice(0, node.range[0])
-          const preSpace = pre.match(/(\s+)$/)?.[0]
+        checkSpacing(node)
 
-          // strip space before <T>
-          if (preSpace && preSpace.length) {
-            context.report({
-              node,
-              messageId: 'genericSpacingMismatch',
-              * fix(fixer) {
-                yield fixer.replaceTextRange([node.range[0] - preSpace.length, node.range[0]], '')
-              },
-            })
-          }
-        }
-
-        const params = node.params
-
-        if (params.length === 0)
-          return
-
-        const openToken = sourceCode.getTokenBefore(params[0])
-        const closeToken = sourceCode.getTokenAfter(params[params.length - 1])
+        const openToken = sourceCode.getTokenBefore(node.params[0])
+        const closeToken = sourceCode.getTokenAfter(node.params.at(-1)!)
 
         checkBracketSpacing(openToken, closeToken)
       },

--- a/packages/eslint-plugin/rules/type-generic-spacing/type-generic-spacing.ts
+++ b/packages/eslint-plugin/rules/type-generic-spacing/type-generic-spacing.ts
@@ -3,7 +3,16 @@ import type { MessageIds, RuleOptions } from './types'
 import { createRule } from '#utils/create-rule'
 
 const SKIP_BEFORE_CHECK = new Set<NodeTypes>([
+  // interface A {
+  //   <T>(a: number): A
+  // }
   'TSCallSignatureDeclaration',
+  // interface A {
+  //   new <T>(a: number): A
+  //      ^
+  // handled by `space-unary-ops`
+  // }
+  'TSConstructSignatureDeclaration',
   // const foo = <T>(name: T) => name
   //            ^
   // handled by `space-infix-ops`
@@ -35,47 +44,37 @@ function shouldSkipBeforeCheck(node: SupportNodes) {
   return false
 }
 
-const SKIP_AFTER_CHECK = new Set<NodeTypes>([
-  // const foo = class Foo<T> extends Bar<T> {}
-  //                                        ^
-  // handled by `space-before-blocks`
-  'ClassExpression',
-  // class foo<T> extends bar<T> {}
-  //             ^              ^
-  // handled by `keyword-spacing` and `space-before-blocks`
-  'ClassDeclaration',
-  // type Foo<T> = T
-  //            ^
-  // handled by `space-infix-ops`
-  'TSTypeAliasDeclaration',
-  // interface Foo<T> {}
-  //                 ^
-  // handled by `space-before-blocks`
-  'TSInterfaceDeclaration',
-  // interface Foo extends Bar<T> {}
-  //                             ^
-  // handled by `space-before-blocks`
-  'TSInterfaceHeritage',
-  // const x: Array<T> = []
+const SHOULD_CHECK_AFTER = new Set<NodeTypes>([
+  // const foo = callback<T> ()
+  //                        ^
+  'CallExpression',
+  // const foo = new Foo<T> ()
+  //                        ^
+  'NewExpression',
+  // const foo = tag<T> `template`
+  //                   ^
+  'TaggedTemplateExpression',
+  // interface A {
+  //   <T> (): A
+  //      ^
+  // }
+  'TSCallSignatureDeclaration',
+  // interface A {
+  //   new<T> (): A
+  //         ^
+  // }
+  'TSConstructSignatureDeclaration',
+  // interface A {
+  //   foo<T> (): A
+  //        ^
+  // }
+  'TSMethodSignature',
+  // type Foo = <T> () => void
+  //              ^
+  'TSFunctionType',
+  // type Foo = new<T> () => void
   //                  ^
-  // handled by `space-infix-ops`
-  'TSTypeReference',
-  // type Foo = import('foo')<T> ['Foo']
-  //                            ^
-  // handled by `no-whitespace-before-property`
-  'TSImportType',
-  // function foo<T> () {}
-  //                ^
-  // handled by `space-before-function-paren`
-  'FunctionDeclaration',
-  // const foo = function<T> () {}
-  //                        ^
-  // handled by `space-before-function-paren`
-  'FunctionExpression',
-  // declare function foo<T> (): void
-  //                        ^
-  // handled by `space-before-function-paren`
-  'TSDeclareFunction',
+  'TSConstructorType',
 ])
 
 type SupportNodes = Tree.TSTypeParameterDeclaration | Tree.TSTypeParameterInstantiation
@@ -125,7 +124,10 @@ export default createRule<RuleOptions, MessageIds>({
 
       if (before !== hasSpace) {
         context.report({
-          node,
+          loc: {
+            start: preToken.loc.end,
+            end: node.loc.start,
+          },
           messageId: 'genericSpacingMismatch',
           fix(fixer) {
             return before
@@ -137,14 +139,17 @@ export default createRule<RuleOptions, MessageIds>({
     }
 
     function checkAfter(node: SupportNodes) {
-      if (SKIP_AFTER_CHECK.has(node.parent.type))
+      if (!SHOULD_CHECK_AFTER.has(node.parent.type))
         return
       const nextToken = sourceCode.getTokenAfter(node, { includeComments: true })!
       const hasSpace = sourceCode.isSpaceBetween(node, nextToken)
 
       if (after !== hasSpace) {
         context.report({
-          node,
+          loc: {
+            start: node.loc.end,
+            end: nextToken.loc.start,
+          },
           messageId: 'genericSpacingMismatch',
           fix(fixer) {
             return after

--- a/packages/eslint-plugin/rules/type-generic-spacing/types.d.ts
+++ b/packages/eslint-plugin/rules/type-generic-spacing/types.d.ts
@@ -1,8 +1,15 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: U7Qr2apF2YKrIKyL3cL-WlXDPID73rUMb8TVLH8uS_k */
+/* @checksum: Y1Dr3lFfoeRCkrJsfT7w90RsbMFbDf9VxwITBsjQ1fs */
 
-export type TypeGenericSpacingRuleOptions = []
+export interface TypeGenericSpacingSchema0 {
+  before?: boolean
+  after?: boolean
+}
+
+export type TypeGenericSpacingRuleOptions = [
+  TypeGenericSpacingSchema0?,
+]
 
 export type RuleOptions = TypeGenericSpacingRuleOptions
 export type MessageIds = 'genericSpacingMismatch'


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

#1025 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rule now accepts a single options object with configurable before/after spacing, applies checks and fixes consistently (including empty generics); exported option types updated.

* **Documentation**
  * Updated rule docs with examples, clarified defaults/meanings, added related-rule links, and upgraded guide notes about interactions with other spacing rules.

* **Tests**
  * Expanded and parameterized tests to cover many generic-spacing scenarios and option-driven behavior.

* **Bug Fixes**
  * Fixed test-generation spacing in single-line invalid test cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eslint-stylistic/eslint-stylistic/pull/1045?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->