### PR TITLE
docs(no-extra-parens): add missing `]` in various examples.

### DIFF
--- a/packages/eslint-plugin/rules/no-extra-parens/README.md
+++ b/packages/eslint-plugin/rules/no-extra-parens/README.md
@@ -538,13 +538,13 @@ const foo = (
 
 The following configuration ignores parens around a `TSIntersectionType` as the typeAnnotation of a `TSTypeAliasDeclaration`.
 
-Examples of **correct** code for this rule with the `4, { "ignoredNodes": ['TSTypeAliasDeclaration[typeAnnotation.type='TSIntersectionType]'] }` option:
+Examples of **correct** code for this rule with the `"all", { "ignoredNodes": ["TSTypeAliasDeclaration[typeAnnotation.type=TSIntersectionType]"] }` option:
 
 ::: correct
 
 ```js
 /* eslint @stylistic/no-extra-parens: ["error", "all", {
-    "ignoredNodes": ["TSTypeAliasDeclaration[typeAnnotation.type='TSIntersectionType']"]
+    "ignoredNodes": ["TSTypeAliasDeclaration[typeAnnotation.type=TSIntersectionType]"]
 }] */
 
 type TBar = (


### PR DESCRIPTION
A few of the examples for the `no-extra-parens` rule involving the use of node selectors with `ignoredNodes` were missing a closing `]`.