### PR TITLE
fix(list-style): replace text range with delimiter directly

### DIFF
--- a/packages/eslint-plugin/rules/list-style/list-style._json_.test.ts
+++ b/packages/eslint-plugin/rules/list-style/list-style._json_.test.ts
@@ -55,7 +55,7 @@ run<RuleOptions, MessageIds>({
       `,
       output: $`
         {
-          "foo": ["bar",  "baz"],
+          "foo": ["bar","baz"],
         }
       `,
       errors: [
@@ -91,7 +91,7 @@ run<RuleOptions, MessageIds>({
       `,
       output: $`
         {
-          "foo": {"a": "1",  "b": "2"}
+          "foo": {"a": "1","b": "2"}
         }
       `,
       errors: [
@@ -134,8 +134,8 @@ run<RuleOptions, MessageIds>({
         {
           "foo": { "a": "1",
             // comment
-            "b": "2"  },
-          "bar": ["1",  "2"]
+            "b": "2"},
+          "bar": ["1","2"]
         }
       `,
       errors: [

--- a/packages/eslint-plugin/rules/list-style/list-style.test.ts
+++ b/packages/eslint-plugin/rules/list-style/list-style.test.ts
@@ -196,7 +196,7 @@ run<RuleOptions, MessageIds>({
         }
       `,
       output: $`
-        const a = {foo: "bar", bar: 2}
+        const a = {foo: "bar",bar: 2}
       `,
       errors: [
         { messageId: 'shouldNotWrap', line: 1, column: 23 },
@@ -228,7 +228,7 @@ run<RuleOptions, MessageIds>({
         ]
       `,
       output: $`
-        const a = [1, 2, 3]
+        const a = [1,2, 3]
       `,
       errors: [
         { messageId: 'shouldNotWrap', line: 1, column: 14 },
@@ -257,7 +257,7 @@ run<RuleOptions, MessageIds>({
         bar } from "foo"
       `,
       output: $`
-        import { foo, bar } from "foo"
+        import { foo,bar } from "foo"
       `,
       errors: [
         { messageId: 'shouldNotWrap', line: 1, column: 14 },
@@ -415,7 +415,7 @@ run<RuleOptions, MessageIds>({
         }
       `,
       output: $`
-        export interface Foo {        a: 1,  b: Pick<Bar, 'baz'>,  c: 3,}
+        export interface Foo {        a: 1,b: Pick<Bar, 'baz'>,c: 3,}
       `,
       errors: [
         { messageId: 'shouldNotWrap', line: 1, column: 35 },
@@ -661,7 +661,7 @@ run<RuleOptions, MessageIds>({
     {
       description: 'CRLF',
       code: 'const a = {foo: "bar", \r\nbar: 2\r\n}',
-      output: 'const a = {foo: "bar", bar: 2}',
+      output: 'const a = {foo: "bar",bar: 2}',
       errors: [
         { messageId: 'shouldNotWrap', line: 1, column: 23 },
         { messageId: 'shouldNotWrap', line: 2, column: 7 },
@@ -897,8 +897,8 @@ run<RuleOptions, MessageIds>({
         };
       `,
       output: $`
-        const foo = [1, 2];
-        const bar = { a: 1, b: 2 };
+        const foo = [1,2];
+        const bar = {a: 1,b: 2};
       `,
       options: [{ multiLine: { minItems: 3 } }],
       errors: [
@@ -921,6 +921,15 @@ run<RuleOptions, MessageIds>({
       `,
       errors: [
         { messageId: 'shouldNotWrap', line: 1, column: 7 },
+      ],
+    },
+    {
+      description: 'indent by tab',
+      code: `const foo = [1,\n\t2,\n\t3];`,
+      output: `const foo = [1,2,3];`,
+      errors: [
+        { messageId: 'shouldNotWrap', line: 1, column: 16 },
+        { messageId: 'shouldNotWrap', line: 2, column: 4 },
       ],
     },
   ],

--- a/packages/eslint-plugin/rules/list-style/list-style.ts
+++ b/packages/eslint-plugin/rules/list-style/list-style.ts
@@ -13,7 +13,6 @@ import {
   isOpeningParenToken,
   isSingleLine,
   isTokenOnSameLine,
-  LINEBREAK_MATCHER,
 } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
@@ -269,10 +268,9 @@ export default createRule<RuleOptions, MessageIds>({
                 return null
 
               const range = [prev.range[1], next.range[0]] as const
-              const code = sourceCode.text.slice(...range)
               const delimiter = items.length === 1 ? '' : getDelimiter(node, prev)
 
-              return fixer.replaceTextRange(range, code.replaceAll(new RegExp(LINEBREAK_MATCHER, 'g'), delimiter ?? ''))
+              return fixer.replaceTextRange(range, delimiter ?? '')
             },
           })
         }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

```ts
const foo = [1,
    2,
	3
]
```
Now will be fixed to:
```ts
const foo = [1,2,3]
```

Before:

```ts
const foo = [1,    2,	3]
```

Spacing around `,` should be handled by [`comma-spacing`](https://eslint.style/rules/comma-spacing)

### Linked Issues

https://github.com/eslint-stylistic/eslint-stylistic/issues/1030#issuecomment-3499372205

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
