### PR TITLE
feat: remove `@typescript-eslint/types` dependency

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -88,7 +88,7 @@ export default antfu(
         patterns: [
           {
             allowTypeImports: true,
-            group: ['@typescript-eslint/utils', '@typescript-eslint/types'],
+            group: ['@typescript-eslint/utils'],
             importNames: ['AST_NODE_TYPES'],
           },
         ],
@@ -106,7 +106,7 @@ export default antfu(
       'ts/no-restricted-imports': ['error', {
         patterns: [
           {
-            group: ['@typescript-eslint/utils', '@typescript-eslint/utils/*', '@typescript-eslint/types'],
+            group: ['@typescript-eslint/utils', '@typescript-eslint/utils/*'],
             importNames: [
               'TSESTree',
               'TSESLint',
@@ -155,7 +155,7 @@ export default antfu(
       'ts/no-restricted-imports': ['error', {
         patterns: [
           {
-            group: ['@typescript-eslint/utils', '@typescript-eslint/types'],
+            group: ['@typescript-eslint/utils'],
             importNames: ['ASTUtils'],
             message: 'Import from "#utils/ast" instead',
           },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -89,7 +89,7 @@ export default antfu(
           {
             allowTypeImports: true,
             group: ['@typescript-eslint/utils'],
-            importNames: ['AST_NODE_TYPES'],
+            importNames: ['AST_NODE_TYPES', 'AST_TOKEN_TYPES'],
           },
         ],
       }],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,7 @@
 /* eslint perfectionist/sort-objects: "error" */
 // @ts-check
 
-import antfu from '@antfu/eslint-config'
+import antfu, { GLOB_TESTS, GLOB_TS } from '@antfu/eslint-config'
 import stylistic from './stub.mjs'
 
 const stylisticConfig = stylistic.configs.customize({
@@ -80,11 +80,27 @@ export default antfu(
     },
   },
   {
+    files: [GLOB_TS],
+    ignores: GLOB_TESTS,
+    name: 'local/restrict-imports',
+    rules: {
+      'ts/no-restricted-imports': ['error', {
+        patterns: [
+          {
+            allowTypeImports: true,
+            group: ['@typescript-eslint/utils', '@typescript-eslint/types'],
+            importNames: ['AST_NODE_TYPES'],
+          },
+        ],
+      }],
+    },
+  },
+  {
     files: [
       'packages/eslint-plugin/{rules,utils}/**/*.ts',
       'shared/utils/**/*.ts',
     ],
-    ignores: ['**/*.test.ts'],
+    ignores: GLOB_TESTS,
     name: 'local/restrict-types',
     rules: {
       'ts/no-restricted-imports': ['error', {
@@ -140,7 +156,7 @@ export default antfu(
         patterns: [
           {
             group: ['@typescript-eslint/utils', '@typescript-eslint/types'],
-            importNames: ['AST_NODE_TYPES', 'AST_TOKEN_TYPES', 'ASTUtils'],
+            importNames: ['ASTUtils'],
             message: 'Import from "#utils/ast" instead',
           },
           {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@types/picomatch": "catalog:dev",
     "@types/semver": "catalog:dev",
     "@typescript-eslint/parser": "catalog:dev",
-    "@typescript-eslint/types": "catalog:prod",
     "@typescript-eslint/utils": "catalog:dev",
     "@vitest/coverage-v8": "catalog:test",
     "@vitest/ui": "catalog:test",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -140,7 +140,6 @@
   },
   "dependencies": {
     "@eslint-community/eslint-utils": "catalog:prod",
-    "@typescript-eslint/types": "catalog:prod",
     "eslint-visitor-keys": "catalog:prod",
     "espree": "catalog:prod",
     "estraverse": "catalog:prod",

--- a/packages/eslint-plugin/rules/block-spacing/block-spacing.ts
+++ b/packages/eslint-plugin/rules/block-spacing/block-spacing.ts
@@ -1,6 +1,6 @@
 import type { Token, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
-import { AST_TOKEN_TYPES, isClosingBraceToken, isOpeningBraceToken, isTokenOnSameLine } from '#utils/ast'
+import { isClosingBraceToken, isOpeningBraceToken, isTokenOnSameLine } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 type SupportedNodes = Tree.BlockStatement | Tree.StaticBlock | Tree.SwitchStatement
@@ -82,7 +82,7 @@ export default createRule<RuleOptions, MessageIds>({
       }
 
       // Skip line comments for option never
-      if (!always && firstToken.type === AST_TOKEN_TYPES.Line)
+      if (!always && firstToken.type === 'Line')
         return
 
       if (!isValid(openBrace, firstToken)) {

--- a/packages/eslint-plugin/rules/comma-dangle/comma-dangle.ts
+++ b/packages/eslint-plugin/rules/comma-dangle/comma-dangle.ts
@@ -1,6 +1,6 @@
 import type { EcmaVersion, Tree } from '#types'
 import type { MessageIds, RuleOptions, ValueWithIgnore } from './types'
-import { AST_NODE_TYPES, getNextLocation, isCommaToken } from '#utils/ast'
+import { getNextLocation, isCommaToken } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 type Extract<T> = T extends Record<any, any> ? T : never
@@ -240,7 +240,7 @@ export default createRule<RuleOptions, MessageIds>({
        * https://github.com/microsoft/TypeScript/issues/15713#issuecomment-499474386
        * https://github.com/eslint-stylistic/eslint-stylistic/issues/35
        */
-      if (isTSX && info.node.type === AST_NODE_TYPES.TSTypeParameterDeclaration && info.node.params.length === 1)
+      if (isTSX && info.node.type === 'TSTypeParameterDeclaration' && info.node.params.length === 1)
         return
 
       const lastItem = info.lastItem

--- a/packages/eslint-plugin/rules/comma-spacing/comma-spacing.ts
+++ b/packages/eslint-plugin/rules/comma-spacing/comma-spacing.ts
@@ -1,7 +1,6 @@
 import type { Token, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
 import {
-  AST_TOKEN_TYPES,
   isClosingBraceToken,
   isClosingBracketToken,
   isClosingParenToken,
@@ -128,7 +127,7 @@ export default createRule<RuleOptions, MessageIds>({
         && !isClosingParenToken(nextToken) // controlled by space-in-parens
         && !isClosingBracketToken(nextToken) // controlled by array-bracket-spacing
         && !isClosingBraceToken(nextToken) // controlled by object-curly-spacing
-        && !(!spaceAfter && nextToken.type === AST_TOKEN_TYPES.Line)
+        && !(!spaceAfter && nextToken.type === 'Line')
         && spaceAfter !== sourceCode.isSpaceBetween(commaToken, nextToken)
       ) {
         context.report({

--- a/packages/eslint-plugin/rules/indent/indent._ts_.test.ts
+++ b/packages/eslint-plugin/rules/indent/indent._ts_.test.ts
@@ -1,7 +1,7 @@
 import type { InvalidTestCase, TestCaseError, TestCasesOptions, ValidTestCase } from '#test'
 import type { MessageIds, RuleOptions } from './types'
 import { $, run } from '#test'
-import { AST_NODE_TYPES } from '#utils/ast'
+import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import rule from './indent'
 
 // #region individualNodeTests

--- a/packages/eslint-plugin/rules/indent/indent.ts
+++ b/packages/eslint-plugin/rules/indent/indent.ts
@@ -10,7 +10,7 @@ import { createGlobalLinebreakMatcher, getCommentsBetween, isClosingBraceToken, 
 import { createRule } from '#utils/create-rule'
 import { warnDeprecatedOptions } from '#utils/index'
 
-const KNOWN_NODES = new Set([
+const KNOWN_NODES = new Set<NodeTypes>([
   'AssignmentExpression',
   'AssignmentPattern',
   'ArrayExpression',

--- a/packages/eslint-plugin/rules/indent/indent.ts
+++ b/packages/eslint-plugin/rules/indent/indent.ts
@@ -6,7 +6,7 @@
 
 import type { ASTNode, JSONSchema, NodeTypes, RuleFunction, RuleListener, SourceCode, Token, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
-import { AST_NODE_TYPES, createGlobalLinebreakMatcher, getCommentsBetween, isClosingBraceToken, isClosingBracketToken, isClosingParenToken, isColonToken, isCommentToken, isEqToken, isNotClosingParenToken, isNotOpeningParenToken, isNotSemicolonToken, isOpeningBraceToken, isOpeningBracketToken, isOpeningParenToken, isOptionalChainPunctuator, isQuestionToken, isSemicolonToken, isSingleLine, isTokenOnSameLine, skipChainExpression, STATEMENT_LIST_PARENTS } from '#utils/ast'
+import { createGlobalLinebreakMatcher, getCommentsBetween, isClosingBraceToken, isClosingBracketToken, isClosingParenToken, isColonToken, isCommentToken, isEqToken, isNotClosingParenToken, isNotOpeningParenToken, isNotSemicolonToken, isOpeningBraceToken, isOpeningBracketToken, isOpeningParenToken, isOptionalChainPunctuator, isQuestionToken, isSemicolonToken, isSingleLine, isTokenOnSameLine, skipChainExpression, STATEMENT_LIST_PARENTS } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 import { warnDeprecatedOptions } from '#utils/index'
 
@@ -52,7 +52,7 @@ const KNOWN_NODES = new Set([
   'Program',
   'Property',
   'PropertyDefinition',
-  AST_NODE_TYPES.AccessorProperty,
+  'AccessorProperty',
   'RestElement',
   'ReturnStatement',
   'SequenceExpression',
@@ -100,72 +100,72 @@ const KNOWN_NODES = new Set([
   'ImportAttribute',
 
   // ts keywords
-  AST_NODE_TYPES.TSAbstractKeyword,
-  AST_NODE_TYPES.TSAnyKeyword,
-  AST_NODE_TYPES.TSBooleanKeyword,
-  AST_NODE_TYPES.TSNeverKeyword,
-  AST_NODE_TYPES.TSNumberKeyword,
-  AST_NODE_TYPES.TSStringKeyword,
-  AST_NODE_TYPES.TSSymbolKeyword,
-  AST_NODE_TYPES.TSUndefinedKeyword,
-  AST_NODE_TYPES.TSUnknownKeyword,
-  AST_NODE_TYPES.TSVoidKeyword,
-  AST_NODE_TYPES.TSNullKeyword,
+  'TSAbstractKeyword',
+  'TSAnyKeyword',
+  'TSBooleanKeyword',
+  'TSNeverKeyword',
+  'TSNumberKeyword',
+  'TSStringKeyword',
+  'TSSymbolKeyword',
+  'TSUndefinedKeyword',
+  'TSUnknownKeyword',
+  'TSVoidKeyword',
+  'TSNullKeyword',
 
   // ts specific nodes we want to support
-  AST_NODE_TYPES.TSAbstractPropertyDefinition,
-  AST_NODE_TYPES.TSAbstractAccessorProperty,
-  AST_NODE_TYPES.TSAbstractMethodDefinition,
-  AST_NODE_TYPES.TSArrayType,
-  AST_NODE_TYPES.TSAsExpression,
-  AST_NODE_TYPES.TSCallSignatureDeclaration,
-  AST_NODE_TYPES.TSConditionalType,
-  AST_NODE_TYPES.TSConstructorType,
-  AST_NODE_TYPES.TSConstructSignatureDeclaration,
-  AST_NODE_TYPES.TSDeclareFunction,
-  AST_NODE_TYPES.TSEmptyBodyFunctionExpression,
-  AST_NODE_TYPES.TSEnumDeclaration,
-  AST_NODE_TYPES.TSEnumBody,
-  AST_NODE_TYPES.TSEnumMember,
-  AST_NODE_TYPES.TSExportAssignment,
-  AST_NODE_TYPES.TSExternalModuleReference,
-  AST_NODE_TYPES.TSFunctionType,
-  AST_NODE_TYPES.TSImportType,
-  AST_NODE_TYPES.TSIndexedAccessType,
-  AST_NODE_TYPES.TSIndexSignature,
-  AST_NODE_TYPES.TSInferType,
-  AST_NODE_TYPES.TSInterfaceBody,
-  AST_NODE_TYPES.TSInterfaceDeclaration,
-  AST_NODE_TYPES.TSInterfaceHeritage,
-  AST_NODE_TYPES.TSImportEqualsDeclaration,
-  AST_NODE_TYPES.TSLiteralType,
-  AST_NODE_TYPES.TSMappedType,
-  AST_NODE_TYPES.TSMethodSignature,
+  'TSAbstractPropertyDefinition',
+  'TSAbstractAccessorProperty',
+  'TSAbstractMethodDefinition',
+  'TSArrayType',
+  'TSAsExpression',
+  'TSCallSignatureDeclaration',
+  'TSConditionalType',
+  'TSConstructorType',
+  'TSConstructSignatureDeclaration',
+  'TSDeclareFunction',
+  'TSEmptyBodyFunctionExpression',
+  'TSEnumDeclaration',
+  'TSEnumBody',
+  'TSEnumMember',
+  'TSExportAssignment',
+  'TSExternalModuleReference',
+  'TSFunctionType',
+  'TSImportType',
+  'TSIndexedAccessType',
+  'TSIndexSignature',
+  'TSInferType',
+  'TSInterfaceBody',
+  'TSInterfaceDeclaration',
+  'TSInterfaceHeritage',
+  'TSImportEqualsDeclaration',
+  'TSLiteralType',
+  'TSMappedType',
+  'TSMethodSignature',
   'TSMinusToken',
-  AST_NODE_TYPES.TSModuleBlock,
-  AST_NODE_TYPES.TSModuleDeclaration,
-  AST_NODE_TYPES.TSNonNullExpression,
-  AST_NODE_TYPES.TSParameterProperty,
+  'TSModuleBlock',
+  'TSModuleDeclaration',
+  'TSNonNullExpression',
+  'TSParameterProperty',
   'TSPlusToken',
-  AST_NODE_TYPES.TSPropertySignature,
-  AST_NODE_TYPES.TSQualifiedName,
+  'TSPropertySignature',
+  'TSQualifiedName',
   'TSQuestionToken',
-  AST_NODE_TYPES.TSRestType,
-  AST_NODE_TYPES.TSThisType,
-  AST_NODE_TYPES.TSTupleType,
-  AST_NODE_TYPES.TSTypeAliasDeclaration,
-  AST_NODE_TYPES.TSTypeAnnotation,
-  AST_NODE_TYPES.TSTypeLiteral,
-  AST_NODE_TYPES.TSTypeOperator,
-  AST_NODE_TYPES.TSTypeParameter,
-  AST_NODE_TYPES.TSTypeParameterDeclaration,
-  AST_NODE_TYPES.TSTypeParameterInstantiation,
-  AST_NODE_TYPES.TSTypeReference,
-  AST_NODE_TYPES.Decorator,
+  'TSRestType',
+  'TSThisType',
+  'TSTupleType',
+  'TSTypeAliasDeclaration',
+  'TSTypeAnnotation',
+  'TSTypeLiteral',
+  'TSTypeOperator',
+  'TSTypeParameter',
+  'TSTypeParameterDeclaration',
+  'TSTypeParameterInstantiation',
+  'TSTypeReference',
+  'Decorator',
 
   // These are took care by `indent-binary-ops` rule
-  // AST_NODE_TYPES.TSIntersectionType,
-  // AST_NODE_TYPES.TSUnionType,
+  // 'TSIntersectionType',
+  // 'TSUnionType',
 ])
 
 type Offset = 'first' | 'off' | number
@@ -1194,7 +1194,7 @@ export default createRule<RuleOptions, MessageIds>({
     }
 
     function checkArrayLikeNode(node: Tree.ArrayExpression | Tree.ArrayPattern | Tree.TSTupleType) {
-      const elementList = node.type === AST_NODE_TYPES.TSTupleType ? node.elementTypes : node.elements
+      const elementList = node.type === 'TSTupleType' ? node.elementTypes : node.elements
       const openingBracket = sourceCode.getFirstToken(node)!
       const closingBracket = sourceCode.getTokenAfter([...elementList].reverse().find(_ => _) || openingBracket, isClosingBracketToken)!
 
@@ -1378,7 +1378,7 @@ export default createRule<RuleOptions, MessageIds>({
         offsets.setDesiredOffset(sourceCode.getFirstToken(node)!, sourceCode.getFirstToken(node.parent)!, 0)
 
       addElementListIndent(
-        node.type === AST_NODE_TYPES.TSEnumBody ? node.members : node.body,
+        node.type === 'TSEnumBody' ? node.members : node.body,
         sourceCode.getFirstToken(node)!,
         sourceCode.getLastToken(node)!,
         blockIndentLevel,
@@ -2039,7 +2039,7 @@ export default createRule<RuleOptions, MessageIds>({
         const properties: Tree.Property[] = [
           {
             parent: node as any,
-            type: AST_NODE_TYPES.Property,
+            type: 'Property',
             key: node.key || node.typeParameter,
             value: node.typeAnnotation as any,
 
@@ -2080,7 +2080,7 @@ export default createRule<RuleOptions, MessageIds>({
           node,
           {
             parent: node,
-            type: AST_NODE_TYPES.BinaryExpression,
+            type: 'BinaryExpression',
             operator: 'extends' as any,
             left: node.checkType as any,
             right: node.extendsType as any,

--- a/packages/eslint-plugin/rules/key-spacing/key-spacing.ts
+++ b/packages/eslint-plugin/rules/key-spacing/key-spacing.ts
@@ -1,7 +1,6 @@
-import type { ASTNode, ReportFixFunction, RuleListener, SourceCode, Tree } from '#types'
+import type { ASTNode, NodeTypes, ReportFixFunction, RuleListener, SourceCode, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
 import {
-  AST_NODE_TYPES,
   getStaticPropertyName,
   isClosingBraceToken,
   isClosingBracketToken,
@@ -24,7 +23,7 @@ const listeningNodes = [
   'TSTypeLiteral',
   'TSInterfaceBody',
   'ClassBody',
-] satisfies (keyof typeof Tree.AST_NODE_TYPES)[]
+] satisfies NodeTypes[]
 
 type UnionToIntersection<U>
   = (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
@@ -308,7 +307,7 @@ export default createRule<RuleOptions, MessageIds>({
     const multiLineOptions = ruleOptions.multiLine
     const singleLineOptions = ruleOptions.singleLine
     const alignmentOptions = ruleOptions.align || null
-    const ignoredNodes: Tree.AST_NODE_TYPES[] = ruleOptions.ignoredNodes
+    const ignoredNodes: NodeTypes[] = ruleOptions.ignoredNodes
 
     const sourceCode = context.sourceCode
 
@@ -754,9 +753,9 @@ export default createRule<RuleOptions, MessageIds>({
       node: ASTNode,
     ): node is KeyTypeNodeWithTypeAnnotation {
       return (
-        (node.type === AST_NODE_TYPES.TSPropertySignature
-          || node.type === AST_NODE_TYPES.TSIndexSignature
-          || node.type === AST_NODE_TYPES.PropertyDefinition)
+        (node.type === 'TSPropertySignature'
+          || node.type === 'TSIndexSignature'
+          || node.type === 'PropertyDefinition')
         && !!node.typeAnnotation
       )
     }
@@ -774,7 +773,7 @@ export default createRule<RuleOptions, MessageIds>({
      * To handle index signatures, to get the whole text for the parameters
      */
     function getKeyText(node: KeyTypeNodeWithTypeAnnotation): string {
-      if (node.type !== AST_NODE_TYPES.TSIndexSignature)
+      if (node.type !== 'TSIndexSignature')
         return sourceCode.getText(node.key)
 
       const code = sourceCode.getText(node)
@@ -794,7 +793,7 @@ export default createRule<RuleOptions, MessageIds>({
       node: KeyTypeNodeWithTypeAnnotation,
     ): Tree.Position {
       return getLastTokenBeforeColon(
-        node.type !== AST_NODE_TYPES.TSIndexSignature
+        node.type !== 'TSIndexSignature'
           ? node.key
           : node.parameters.at(-1)!,
       )!.loc.end
@@ -1053,7 +1052,7 @@ export default createRule<RuleOptions, MessageIds>({
       if (ignoredNodes.includes(body.type))
         return
 
-      const members = body.type === AST_NODE_TYPES.TSTypeLiteral
+      const members = body.type === 'TSTypeLiteral'
         ? body.members
         : body.body
 

--- a/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing.ts
@@ -1,6 +1,6 @@
 import type { ASTNode, JSONSchema, Token, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
-import { AST_NODE_TYPES, isKeywordToken, isNotOpeningParenToken, isTokenOnSameLine, isTypeKeyword, KEYWORDS } from '#utils/ast'
+import { isKeywordToken, isNotOpeningParenToken, isTokenOnSameLine, isTypeKeyword, KEYWORDS } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 const PREV_TOKEN = /^[)\]}>]$/u
@@ -416,13 +416,13 @@ export default createRule<RuleOptions, MessageIds>({
       let kind: undefined | string
 
       switch (node.type) {
-        case AST_NODE_TYPES.ImportDeclaration: {
+        case 'ImportDeclaration': {
           kind = node.importKind
           break
         }
 
-        case AST_NODE_TYPES.ExportAllDeclaration:
-        case AST_NODE_TYPES.ExportNamedDeclaration: {
+        case 'ExportAllDeclaration':
+        case 'ExportNamedDeclaration': {
           kind = node.exportKind
           break
         }
@@ -456,7 +456,7 @@ export default createRule<RuleOptions, MessageIds>({
           (('method' in node && node.method) || node.type === 'MethodDefinition')
           && 'async' in node.value && node.value.async
         )
-        || node.type === AST_NODE_TYPES.AccessorProperty
+        || node.type === 'AccessorProperty'
       ) {
         const token = sourceCode.getTokenBefore(
           node.key,

--- a/packages/eslint-plugin/rules/lines-around-comment/lines-around-comment.ts
+++ b/packages/eslint-plugin/rules/lines-around-comment/lines-around-comment.ts
@@ -1,6 +1,6 @@
-import type { ASTNode, Token, Tree } from '#types'
+import type { ASTNode, NodeTypes, Token, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
-import { AST_NODE_TYPES, AST_TOKEN_TYPES, COMMENTS_IGNORE_PATTERN, isCommentToken, isHashbangComment, isOpeningBraceToken, isTokenOnSameLine } from '#utils/ast'
+import { AST_TOKEN_TYPES, COMMENTS_IGNORE_PATTERN, isCommentToken, isHashbangComment, isOpeningBraceToken, isTokenOnSameLine } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 /**
@@ -178,7 +178,7 @@ export default createRule<RuleOptions, MessageIds>({
     /**
      * @returns whether comments are inside a node type.
      */
-    function isParentNodeType<T extends Tree.AST_NODE_TYPES>(
+    function isParentNodeType<T extends NodeTypes>(
       parent: ASTNode,
       nodeType: T,
     ): parent is Extract<ASTNode, { type: T }> {
@@ -226,7 +226,7 @@ export default createRule<RuleOptions, MessageIds>({
      */
     function isCommentAtParentStart(
       token: Token,
-      nodeType: AST_NODE_TYPES,
+      nodeType: NodeTypes,
     ): boolean {
       const parent = getParentNodeOfToken(token)
 
@@ -253,7 +253,7 @@ export default createRule<RuleOptions, MessageIds>({
      */
     function isCommentAtParentEnd(
       token: Token,
-      nodeType: Tree.AST_NODE_TYPES,
+      nodeType: NodeTypes,
     ): boolean {
       const parent = getParentNodeOfToken(token)
 
@@ -271,11 +271,11 @@ export default createRule<RuleOptions, MessageIds>({
      */
     function isCommentAtBlockStart(token: Token) {
       return (
-        isCommentAtParentStart(token, AST_NODE_TYPES.ClassBody)
-        || isCommentAtParentStart(token, AST_NODE_TYPES.BlockStatement)
-        || isCommentAtParentStart(token, AST_NODE_TYPES.StaticBlock)
-        || isCommentAtParentStart(token, AST_NODE_TYPES.SwitchCase)
-        || isCommentAtParentStart(token, AST_NODE_TYPES.SwitchStatement)
+        isCommentAtParentStart(token, 'ClassBody')
+        || isCommentAtParentStart(token, 'BlockStatement')
+        || isCommentAtParentStart(token, 'StaticBlock')
+        || isCommentAtParentStart(token, 'SwitchCase')
+        || isCommentAtParentStart(token, 'SwitchStatement')
       )
     }
 
@@ -286,11 +286,11 @@ export default createRule<RuleOptions, MessageIds>({
      */
     function isCommentAtBlockEnd(token: Token) {
       return (
-        isCommentAtParentEnd(token, AST_NODE_TYPES.ClassBody)
-        || isCommentAtParentEnd(token, AST_NODE_TYPES.BlockStatement)
-        || isCommentAtParentEnd(token, AST_NODE_TYPES.StaticBlock)
-        || isCommentAtParentEnd(token, AST_NODE_TYPES.SwitchCase)
-        || isCommentAtParentEnd(token, AST_NODE_TYPES.SwitchStatement)
+        isCommentAtParentEnd(token, 'ClassBody')
+        || isCommentAtParentEnd(token, 'BlockStatement')
+        || isCommentAtParentEnd(token, 'StaticBlock')
+        || isCommentAtParentEnd(token, 'SwitchCase')
+        || isCommentAtParentEnd(token, 'SwitchStatement')
       )
     }
 
@@ -300,7 +300,7 @@ export default createRule<RuleOptions, MessageIds>({
      * @returns True if the comment is at class start.
      */
     function isCommentAtClassStart(token: Token) {
-      return isCommentAtParentStart(token, AST_NODE_TYPES.ClassBody)
+      return isCommentAtParentStart(token, 'ClassBody')
     }
 
     /**
@@ -309,7 +309,7 @@ export default createRule<RuleOptions, MessageIds>({
      * @returns True if the comment is at class end.
      */
     function isCommentAtClassEnd(token: Token) {
-      return isCommentAtParentEnd(token, AST_NODE_TYPES.ClassBody)
+      return isCommentAtParentEnd(token, 'ClassBody')
     }
 
     /**
@@ -318,8 +318,8 @@ export default createRule<RuleOptions, MessageIds>({
      * @returns True if the comment is at object start.
      */
     function isCommentAtObjectStart(token: Token) {
-      return isCommentAtParentStart(token, AST_NODE_TYPES.ObjectExpression)
-        || isCommentAtParentStart(token, AST_NODE_TYPES.ObjectPattern)
+      return isCommentAtParentStart(token, 'ObjectExpression')
+        || isCommentAtParentStart(token, 'ObjectPattern')
     }
 
     /**
@@ -328,8 +328,8 @@ export default createRule<RuleOptions, MessageIds>({
      * @returns True if the comment is at object end.
      */
     function isCommentAtObjectEnd(token: Token) {
-      return isCommentAtParentEnd(token, AST_NODE_TYPES.ObjectExpression)
-        || isCommentAtParentEnd(token, AST_NODE_TYPES.ObjectPattern)
+      return isCommentAtParentEnd(token, 'ObjectExpression')
+        || isCommentAtParentEnd(token, 'ObjectPattern')
     }
 
     /**
@@ -338,8 +338,8 @@ export default createRule<RuleOptions, MessageIds>({
      * @returns True if the comment is at array start.
      */
     function isCommentAtArrayStart(token: Token) {
-      return isCommentAtParentStart(token, AST_NODE_TYPES.ArrayExpression)
-        || isCommentAtParentStart(token, AST_NODE_TYPES.ArrayPattern)
+      return isCommentAtParentStart(token, 'ArrayExpression')
+        || isCommentAtParentStart(token, 'ArrayPattern')
     }
 
     /**
@@ -348,40 +348,40 @@ export default createRule<RuleOptions, MessageIds>({
      * @returns True if the comment is at array end.
      */
     function isCommentAtArrayEnd(token: Token) {
-      return isCommentAtParentEnd(token, AST_NODE_TYPES.ArrayExpression)
-        || isCommentAtParentEnd(token, AST_NODE_TYPES.ArrayPattern)
+      return isCommentAtParentEnd(token, 'ArrayExpression')
+        || isCommentAtParentEnd(token, 'ArrayPattern')
     }
 
     function isCommentAtInterfaceStart(token: Tree.Comment): boolean {
-      return isCommentAtParentStart(token, AST_NODE_TYPES.TSInterfaceBody)
+      return isCommentAtParentStart(token, 'TSInterfaceBody')
     }
 
     function isCommentAtInterfaceEnd(token: Tree.Comment): boolean {
-      return isCommentAtParentEnd(token, AST_NODE_TYPES.TSInterfaceBody)
+      return isCommentAtParentEnd(token, 'TSInterfaceBody')
     }
 
     function isCommentAtTypeStart(token: Tree.Comment): boolean {
-      return isCommentAtParentStart(token, AST_NODE_TYPES.TSTypeLiteral)
+      return isCommentAtParentStart(token, 'TSTypeLiteral')
     }
 
     function isCommentAtTypeEnd(token: Tree.Comment): boolean {
-      return isCommentAtParentEnd(token, AST_NODE_TYPES.TSTypeLiteral)
+      return isCommentAtParentEnd(token, 'TSTypeLiteral')
     }
 
     function isCommentAtEnumStart(token: Tree.Comment): boolean {
-      return isCommentAtParentStart(token, AST_NODE_TYPES.TSEnumBody) || isCommentAtParentStart(token, AST_NODE_TYPES.TSEnumDeclaration)
+      return isCommentAtParentStart(token, 'TSEnumBody') || isCommentAtParentStart(token, 'TSEnumDeclaration')
     }
 
     function isCommentAtEnumEnd(token: Tree.Comment): boolean {
-      return isCommentAtParentEnd(token, AST_NODE_TYPES.TSEnumBody) || isCommentAtParentEnd(token, AST_NODE_TYPES.TSEnumDeclaration)
+      return isCommentAtParentEnd(token, 'TSEnumBody') || isCommentAtParentEnd(token, 'TSEnumDeclaration')
     }
 
     function isCommentAtModuleStart(token: Tree.Comment): boolean {
-      return isCommentAtParentStart(token, AST_NODE_TYPES.TSModuleBlock)
+      return isCommentAtParentStart(token, 'TSModuleBlock')
     }
 
     function isCommentAtModuleEnd(token: Tree.Comment): boolean {
-      return isCommentAtParentEnd(token, AST_NODE_TYPES.TSModuleBlock)
+      return isCommentAtParentEnd(token, 'TSModuleBlock')
     }
 
     function checkForEmptyLine(

--- a/packages/eslint-plugin/rules/lines-around-comment/lines-around-comment.ts
+++ b/packages/eslint-plugin/rules/lines-around-comment/lines-around-comment.ts
@@ -1,6 +1,6 @@
 import type { ASTNode, NodeTypes, Token, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
-import { AST_TOKEN_TYPES, COMMENTS_IGNORE_PATTERN, isCommentToken, isHashbangComment, isOpeningBraceToken, isTokenOnSameLine } from '#utils/ast'
+import { COMMENTS_IGNORE_PATTERN, isCommentToken, isHashbangComment, isOpeningBraceToken, isTokenOnSameLine } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 /**
@@ -530,7 +530,7 @@ export default createRule<RuleOptions, MessageIds>({
     return {
       Program() {
         comments.forEach((token) => {
-          if (token.type === AST_TOKEN_TYPES.Line) {
+          if (token.type === 'Line') {
             if (options.beforeLineComment || options.afterLineComment) {
               checkForEmptyLine(token, {
                 after: options.afterLineComment,
@@ -538,7 +538,7 @@ export default createRule<RuleOptions, MessageIds>({
               })
             }
           }
-          else if (token.type === AST_TOKEN_TYPES.Block) {
+          else if (token.type === 'Block') {
             if (options.beforeBlockComment || options.afterBlockComment) {
               checkForEmptyLine(token, {
                 after: options.afterBlockComment,

--- a/packages/eslint-plugin/rules/lines-between-class-members/lines-between-class-members.ts
+++ b/packages/eslint-plugin/rules/lines-between-class-members/lines-between-class-members.ts
@@ -1,6 +1,6 @@
 import type { ASTNode, Token } from '#types'
 import type { MessageIds, RuleOptions } from './types'
-import { AST_NODE_TYPES, isSemicolonToken, isTokenOnSameLine } from '#utils/ast'
+import { isSemicolonToken, isTokenOnSameLine } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 type NodeTest = (
@@ -224,9 +224,9 @@ export default createRule<RuleOptions, MessageIds>({
 
     function isOverload(node: ASTNode): boolean {
       return (
-        (node.type === AST_NODE_TYPES.TSAbstractMethodDefinition
-          || node.type === AST_NODE_TYPES.MethodDefinition)
-        && node.value.type === AST_NODE_TYPES.TSEmptyBodyFunctionExpression
+        (node.type === 'TSAbstractMethodDefinition'
+          || node.type === 'MethodDefinition')
+        && node.value.type === 'TSEmptyBodyFunctionExpression'
       )
     }
 

--- a/packages/eslint-plugin/rules/list-style/list-style.ts
+++ b/packages/eslint-plugin/rules/list-style/list-style.ts
@@ -1,7 +1,6 @@
 import type { ASTNode, Token, Tree } from '#types'
 import type { BaseConfig, MessageIds, RuleOptions } from './types'
 import {
-  AST_NODE_TYPES,
   hasCommentsBetween,
   isClosingBraceToken,
   isClosingBracketToken,
@@ -329,14 +328,14 @@ export default createRule<RuleOptions, MessageIds>({
       switch (node.type) {
         // fun<T>()
         // new Foo<T>()
-        case AST_NODE_TYPES.CallExpression:
-        case AST_NODE_TYPES.NewExpression:
+        case 'CallExpression':
+        case 'NewExpression':
           return sourceCode.getTokenAfter(node.typeArguments ?? node.callee)
 
         // const foo = [, a]
         // const [, a] = foo
-        case AST_NODE_TYPES.ArrayExpression:
-        case AST_NODE_TYPES.ArrayPattern:
+        case 'ArrayExpression':
+        case 'ArrayPattern':
           return sourceCode.getFirstToken(node)
 
         default: {
@@ -352,8 +351,8 @@ export default createRule<RuleOptions, MessageIds>({
       switch (node.type) {
         // const foo = [a, ]
         // const [a, ] = foo
-        case AST_NODE_TYPES.ArrayExpression:
-        case AST_NODE_TYPES.ArrayPattern:
+        case 'ArrayExpression':
+        case 'ArrayPattern':
           return sourceCode.getLastToken(node)
 
         default:{

--- a/packages/eslint-plugin/rules/member-delimiter-style/member-delimiter-style.ts
+++ b/packages/eslint-plugin/rules/member-delimiter-style/member-delimiter-style.ts
@@ -1,5 +1,5 @@
 import type { JSONSchema, ReportFixFunction, Token, Tree } from '#types'
-import { AST_NODE_TYPES, isSingleLine } from '#utils/ast'
+import { isSingleLine } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 import { deepMerge } from '#utils/merge'
 
@@ -308,7 +308,7 @@ export default createRule<Options, MessageIds>({
     function checkMemberSeparatorStyle(
       node: Tree.TSInterfaceBody | Tree.TSTypeLiteral,
     ): void {
-      const members = node.type === AST_NODE_TYPES.TSInterfaceBody ? node.body : node.members
+      const members = node.type === 'TSInterfaceBody' ? node.body : node.members
 
       let _isSingleLine = isSingleLine(node)
       if (
@@ -322,7 +322,7 @@ export default createRule<Options, MessageIds>({
       }
 
       const typeOpts
-        = node.type === AST_NODE_TYPES.TSInterfaceBody
+        = node.type === 'TSInterfaceBody'
           ? interfaceOptions
           : typeLiteralOptions
       const opts = _isSingleLine

--- a/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens.ts
+++ b/packages/eslint-plugin/rules/no-extra-parens/no-extra-parens.ts
@@ -3,7 +3,6 @@
 import type { ASTNode, RuleFunction, RuleListener, Token, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
 import {
-  AST_NODE_TYPES,
   canTokensBeAdjacent,
   getPrecedence,
   getStaticPropertyName,
@@ -40,10 +39,10 @@ import { warnDeprecatedOptions } from '#utils/index'
  * ```
  */
 const isTypeAssertion = isNodeOfTypes([
-  AST_NODE_TYPES.TSAsExpression,
-  AST_NODE_TYPES.TSNonNullExpression,
-  AST_NODE_TYPES.TSSatisfiesExpression,
-  AST_NODE_TYPES.TSTypeAssertion,
+  'TSAsExpression',
+  'TSNonNullExpression',
+  'TSSatisfiesExpression',
+  'TSTypeAssertion',
 ])
 
 export default createRule<RuleOptions, MessageIds>({
@@ -772,7 +771,7 @@ export default createRule<RuleOptions, MessageIds>({
           ...node,
           left: {
             ...node.left,
-            type: AST_NODE_TYPES.SequenceExpression as any,
+            type: 'SequenceExpression' as any,
           },
         })
       }
@@ -781,7 +780,7 @@ export default createRule<RuleOptions, MessageIds>({
           ...node,
           right: {
             ...node.right,
-            type: AST_NODE_TYPES.SequenceExpression as any,
+            type: 'SequenceExpression' as any,
           },
         })
       }
@@ -839,7 +838,7 @@ export default createRule<RuleOptions, MessageIds>({
           ...node,
           callee: {
             ...node.callee,
-            type: AST_NODE_TYPES.SequenceExpression as any,
+            type: 'SequenceExpression' as any,
           },
         })
       }
@@ -914,7 +913,7 @@ export default createRule<RuleOptions, MessageIds>({
           ...node,
           argument: {
             ...node.argument,
-            type: AST_NODE_TYPES.SequenceExpression as any,
+            type: 'SequenceExpression' as any,
           },
         })
       }
@@ -932,7 +931,7 @@ export default createRule<RuleOptions, MessageIds>({
 
     function checkTSBinaryType(node: Tree.TSUnionType | Tree.TSIntersectionType) {
       node.types.forEach((type) => {
-        const shouldReport = IGNORE_NESTED_BINARY && isNodeOfTypes([AST_NODE_TYPES.TSUnionType, AST_NODE_TYPES.TSIntersectionType])(type)
+        const shouldReport = IGNORE_NESTED_BINARY && isNodeOfTypes(['TSUnionType', 'TSIntersectionType'])(type)
           ? isParenthesisedTwice(type)
           : hasExcessParensWithPrecedence(type, precedence(node))
 
@@ -948,7 +947,7 @@ export default createRule<RuleOptions, MessageIds>({
           .map(
             element =>
               isTypeAssertion(element)
-                ? { ...element, type: AST_NODE_TYPES.FunctionExpression as any }
+                ? { ...element, type: 'FunctionExpression' as any }
                 : element,
           )
           .forEach((ele) => {
@@ -1013,7 +1012,7 @@ export default createRule<RuleOptions, MessageIds>({
             ...node,
             argument: {
               ...node.argument,
-              type: AST_NODE_TYPES.SequenceExpression as any,
+              type: 'SequenceExpression' as any,
             },
           })
         }
@@ -1027,24 +1026,24 @@ export default createRule<RuleOptions, MessageIds>({
       },
       'CallExpression': checkCallNew,
       ClassDeclaration(node) {
-        if (node.superClass?.type === AST_NODE_TYPES.TSAsExpression) {
+        if (node.superClass?.type === 'TSAsExpression') {
           return checkClass({
             ...node,
             superClass: {
               ...node.superClass,
-              type: AST_NODE_TYPES.SequenceExpression as any,
+              type: 'SequenceExpression' as any,
             },
           })
         }
         return checkClass(node)
       },
       ClassExpression(node) {
-        if (node.superClass?.type === AST_NODE_TYPES.TSAsExpression) {
+        if (node.superClass?.type === 'TSAsExpression') {
           return checkClass({
             ...node,
             superClass: {
               ...node.superClass,
-              type: AST_NODE_TYPES.SequenceExpression as any,
+              type: 'SequenceExpression' as any,
             },
           })
         }
@@ -1088,7 +1087,7 @@ export default createRule<RuleOptions, MessageIds>({
             ...node,
             test: {
               ...node.test,
-              type: AST_NODE_TYPES.SequenceExpression as any,
+              type: 'SequenceExpression' as any,
             },
           })
         }
@@ -1097,7 +1096,7 @@ export default createRule<RuleOptions, MessageIds>({
             ...node,
             consequent: {
               ...node.consequent,
-              type: AST_NODE_TYPES.SequenceExpression as any,
+              type: 'SequenceExpression' as any,
             },
           })
         }
@@ -1107,7 +1106,7 @@ export default createRule<RuleOptions, MessageIds>({
             ...node,
             alternate: {
               ...node.alternate,
-              type: AST_NODE_TYPES.SequenceExpression as any,
+              type: 'SequenceExpression' as any,
             },
           })
         }
@@ -1331,7 +1330,7 @@ export default createRule<RuleOptions, MessageIds>({
             ...node,
             object: {
               ...node.object,
-              type: AST_NODE_TYPES.SequenceExpression as any,
+              type: 'SequenceExpression' as any,
             },
           })
         }
@@ -1341,7 +1340,7 @@ export default createRule<RuleOptions, MessageIds>({
             ...node,
             property: ({
               ...node.property,
-              type: AST_NODE_TYPES.FunctionExpression as any,
+              type: 'FunctionExpression' as any,
             } as any),
           })
         }
@@ -1489,10 +1488,10 @@ export default createRule<RuleOptions, MessageIds>({
         if (isTypeAssertion(node.init)) {
           return rule({
             ...node,
-            type: AST_NODE_TYPES.VariableDeclarator,
+            type: 'VariableDeclarator',
             init: {
               ...(node.init as Tree.TSAsExpression),
-              type: AST_NODE_TYPES.FunctionExpression as any,
+              type: 'FunctionExpression' as any,
             },
           } as any)
         }

--- a/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing.ts
+++ b/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing.ts
@@ -1,7 +1,6 @@
 import type { ASTNode, Token, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
 import {
-  AST_TOKEN_TYPES,
   isClosingBraceToken,
   isClosingBracketToken,
   isOpeningBraceToken,
@@ -224,7 +223,7 @@ export default createRule<RuleOptions, MessageIds>({
         if (
           !openingCurlyBraceMustBeSpaced
           && firstSpaced
-          && tokenAfterOpening.type !== AST_TOKEN_TYPES.Line
+          && tokenAfterOpening.type !== 'Line'
         ) {
           reportNoBeginningSpace(node, openingToken)
         }

--- a/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing.ts
+++ b/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing.ts
@@ -1,7 +1,6 @@
 import type { ASTNode, Token, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
 import {
-  AST_NODE_TYPES,
   AST_TOKEN_TYPES,
   isClosingBraceToken,
   isClosingBracketToken,
@@ -213,8 +212,8 @@ export default createRule<RuleOptions, MessageIds>({
         const openingCurlyBraceMustBeSpaced
           = options.arraysInObjectsException
             && [
-              AST_NODE_TYPES.TSMappedType,
-              AST_NODE_TYPES.TSIndexSignature,
+              'TSMappedType',
+              'TSIndexSignature',
             ].includes(secondType)
             ? !spaced
             : spaced
@@ -247,18 +246,18 @@ export default createRule<RuleOptions, MessageIds>({
           = (
             options.arraysInObjectsException
             && [
-              AST_NODE_TYPES.ArrayExpression,
-              AST_NODE_TYPES.TSTupleType,
+              'ArrayExpression',
+              'TSTupleType',
             ].includes(penultimateType!)
           )
           || (
             options.objectsInObjectsException
             && penultimateType !== undefined
             && [
-              AST_NODE_TYPES.ObjectExpression,
-              AST_NODE_TYPES.ObjectPattern,
-              AST_NODE_TYPES.TSMappedType,
-              AST_NODE_TYPES.TSTypeLiteral,
+              'ObjectExpression',
+              'ObjectPattern',
+              'TSMappedType',
+              'TSTypeLiteral',
             ].includes(penultimateType)
           )
             ? !spaced

--- a/packages/eslint-plugin/rules/quotes/quotes.ts
+++ b/packages/eslint-plugin/rules/quotes/quotes.ts
@@ -1,7 +1,6 @@
 import type { ASTNode, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
 import {
-  AST_NODE_TYPES,
   hasOctalOrNonOctalDecimalEscapeSequence,
   isParenthesised,
   isSurroundedBy,
@@ -243,51 +242,51 @@ export default createRule<RuleOptions, MessageIds>({
 
       switch (parent.type) {
         // Directive Prologues.
-        case AST_NODE_TYPES.ExpressionStatement:
+        case 'ExpressionStatement':
           return !isParenthesised(sourceCode, node) && isExpressionInOrJustAfterDirectivePrologue(node)
 
           // LiteralPropertyName.
-        case AST_NODE_TYPES.Property:
-        case AST_NODE_TYPES.MethodDefinition:
+        case 'Property':
+        case 'MethodDefinition':
           return parent.key === node && !parent.computed
 
           // ModuleSpecifier.
-        case AST_NODE_TYPES.ImportDeclaration:
-        case AST_NODE_TYPES.ExportNamedDeclaration:
+        case 'ImportDeclaration':
+        case 'ExportNamedDeclaration':
           return parent.source === node
 
           // ModuleExportName or ModuleSpecifier.
-        case AST_NODE_TYPES.ExportAllDeclaration:
+        case 'ExportAllDeclaration':
           return parent.exported === node || parent.source === node
 
           // ModuleExportName.
-        case AST_NODE_TYPES.ImportSpecifier:
+        case 'ImportSpecifier':
           return parent.imported === node
 
           // ModuleExportName.
-        case AST_NODE_TYPES.ExportSpecifier:
+        case 'ExportSpecifier':
           return parent.local === node || parent.exported === node
 
-        case AST_NODE_TYPES.ImportAttribute:
+        case 'ImportAttribute':
           return parent.value === node
 
-        case AST_NODE_TYPES.TSAbstractMethodDefinition:
-        case AST_NODE_TYPES.TSMethodSignature:
-        case AST_NODE_TYPES.TSPropertySignature:
-        case AST_NODE_TYPES.TSModuleDeclaration:
-        case AST_NODE_TYPES.TSExternalModuleReference:
+        case 'TSAbstractMethodDefinition':
+        case 'TSMethodSignature':
+        case 'TSPropertySignature':
+        case 'TSModuleDeclaration':
+        case 'TSExternalModuleReference':
           return true
 
-        case AST_NODE_TYPES.TSEnumMember:
+        case 'TSEnumMember':
           return node === parent.id
 
-        case AST_NODE_TYPES.TSAbstractPropertyDefinition:
-        case AST_NODE_TYPES.PropertyDefinition:
-        case AST_NODE_TYPES.AccessorProperty:
+        case 'TSAbstractPropertyDefinition':
+        case 'PropertyDefinition':
+        case 'AccessorProperty':
           return parent.key === node && !parent.computed
 
-        case AST_NODE_TYPES.TSLiteralType:
-          return parent.parent?.type === AST_NODE_TYPES.TSImportType
+        case 'TSLiteralType':
+          return parent.parent?.type === 'TSImportType'
 
         // Others don't allow.
         default:

--- a/packages/eslint-plugin/rules/semi-spacing/semi-spacing.ts
+++ b/packages/eslint-plugin/rules/semi-spacing/semi-spacing.ts
@@ -1,7 +1,6 @@
 import type { ASTNode, Token, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
 import {
-  AST_NODE_TYPES,
   isClosingBraceToken,
   isClosingParenToken,
   isSemicolonToken,
@@ -232,7 +231,7 @@ export default createRule<RuleOptions, MessageIds>({
       TSTypeAliasDeclaration: checkNode,
       TSTypeAnnotation(node) {
         const excludeNodeTypes = new Set([
-          AST_NODE_TYPES.TSDeclareFunction,
+          'TSDeclareFunction',
         ])
         if (node.parent && !excludeNodeTypes.has(node.parent.type))
           checkNode!(node.parent as Tree.ExpressionStatement)

--- a/packages/eslint-plugin/rules/semi/semi.ts
+++ b/packages/eslint-plugin/rules/semi/semi.ts
@@ -1,7 +1,6 @@
 import type { ASTNode, RuleFixer, Token, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
 import {
-  AST_NODE_TYPES,
   getNextLocation,
   isClosingBraceToken,
   isSemicolonToken,
@@ -384,11 +383,11 @@ export default createRule<RuleOptions, MessageIds>({
     }
 
     // The following nodes are handled by the member-delimiter-style rule
-    // AST_NODE_TYPES.TSCallSignatureDeclaration,
-    // AST_NODE_TYPES.TSConstructSignatureDeclaration,
-    // AST_NODE_TYPES.TSIndexSignature,
-    // AST_NODE_TYPES.TSMethodSignature,
-    // AST_NODE_TYPES.TSPropertySignature,
+    // TSCallSignatureDeclaration,
+    // TSConstructSignatureDeclaration,
+    // TSIndexSignature,
+    // TSMethodSignature,
+    // TSPropertySignature,
     return {
       VariableDeclaration(node) {
         const parent = node.parent
@@ -413,7 +412,7 @@ export default createRule<RuleOptions, MessageIds>({
           checkForSemicolon(node)
       },
       ExportDefaultDeclaration(node) {
-        if (node.declaration.type === AST_NODE_TYPES.TSInterfaceDeclaration)
+        if (node.declaration.type === 'TSInterfaceDeclaration')
           return
 
         if (!/(?:Class|Function)Declaration/u.test(node.declaration.type))

--- a/packages/eslint-plugin/rules/space-before-function-paren/space-before-function-paren.ts
+++ b/packages/eslint-plugin/rules/space-before-function-paren/space-before-function-paren.ts
@@ -1,6 +1,6 @@
 import type { Token, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
-import { AST_NODE_TYPES, isOpeningParenToken } from '#utils/ast'
+import { isOpeningParenToken } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 type FuncOption = 'always' | 'never' | 'ignore'
@@ -76,10 +76,10 @@ export default createRule<RuleOptions, MessageIds>({
       const parent = node.parent
 
       return (
-        parent.type === AST_NODE_TYPES.MethodDefinition
-        || parent.type === AST_NODE_TYPES.TSAbstractMethodDefinition
+        parent.type === 'MethodDefinition'
+        || parent.type === 'TSAbstractMethodDefinition'
         || (
-          parent.type === AST_NODE_TYPES.Property
+          parent.type === 'Property'
           && (parent.kind === 'get' || parent.kind === 'set' || parent.method)
         )
       )
@@ -98,7 +98,7 @@ export default createRule<RuleOptions, MessageIds>({
         | Tree.TSDeclareFunction
         | Tree.TSEmptyBodyFunctionExpression,
     ): FuncOption {
-      if (node.type === AST_NODE_TYPES.ArrowFunctionExpression) {
+      if (node.type === 'ArrowFunctionExpression') {
         // Always ignore non-async functions and arrow functions without parens, e.g. async foo => bar
         if (
           node.async

--- a/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops.ts
+++ b/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops.ts
@@ -1,6 +1,6 @@
 import type { ASTNode, Token, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
-import { AST_NODE_TYPES, AST_TOKEN_TYPES, isNotOpeningParenToken } from '#utils/ast'
+import { AST_TOKEN_TYPES, isNotOpeningParenToken } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 const UNIONS = ['|', '&']
@@ -169,7 +169,7 @@ export default createRule<RuleOptions, MessageIds>({
 
       types.forEach((type) => {
         const skipFunctionParenthesis
-          = type.type === AST_NODE_TYPES.TSFunctionType
+          = type.type === 'TSFunctionType'
             ? isNotOpeningParenToken
             : 0
         const operator = sourceCode.getTokenBefore(

--- a/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops.ts
+++ b/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops.ts
@@ -1,6 +1,6 @@
 import type { ASTNode, Token, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
-import { AST_TOKEN_TYPES, isNotOpeningParenToken } from '#utils/ast'
+import { isNotOpeningParenToken } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 const UNIONS = ['|', '&']
@@ -115,7 +115,7 @@ export default createRule<RuleOptions, MessageIds>({
     }
 
     function isSpaceChar(token: Token): boolean {
-      return token.type === AST_TOKEN_TYPES.Punctuator && /^[=?:]$/.test(token.value)
+      return token.type === 'Punctuator' && /^[=?:]$/.test(token.value)
     }
 
     function checkAndReportAssignmentSpace(

--- a/patches/@typescript-eslint__utils.patch
+++ b/patches/@typescript-eslint__utils.patch
@@ -1,0 +1,156 @@
+diff --git a/dist/ast-utils/predicates.js b/dist/ast-utils/predicates.js
+index 7b867603cc1574049dfbcee0cee150bb86767c43..256c338fe6c1fc16ff1d6c399191e6c2e77f92b4 100644
+--- a/dist/ast-utils/predicates.js
++++ b/dist/ast-utils/predicates.js
+@@ -2,23 +2,22 @@
+ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.isLoop = exports.isImportKeyword = exports.isTypeKeyword = exports.isAwaitKeyword = exports.isAwaitExpression = exports.isIdentifier = exports.isConstructor = exports.isClassOrTypeElement = exports.isTSConstructorType = exports.isTSFunctionType = exports.isFunctionOrFunctionType = exports.isFunctionType = exports.isFunction = exports.isVariableDeclarator = exports.isTypeAssertion = exports.isLogicalOrOperator = exports.isOptionalCallExpression = exports.isNotNonNullAssertionPunctuator = exports.isNonNullAssertionPunctuator = exports.isNotOptionalChainPunctuator = exports.isOptionalChainPunctuator = void 0;
+ exports.isSetter = isSetter;
+-const ts_estree_1 = require("../ts-estree");
+ const helpers_1 = require("./helpers");
+-exports.isOptionalChainPunctuator = (0, helpers_1.isTokenOfTypeWithConditions)(ts_estree_1.AST_TOKEN_TYPES.Punctuator, { value: '?.' });
+-exports.isNotOptionalChainPunctuator = (0, helpers_1.isNotTokenOfTypeWithConditions)(ts_estree_1.AST_TOKEN_TYPES.Punctuator, { value: '?.' });
+-exports.isNonNullAssertionPunctuator = (0, helpers_1.isTokenOfTypeWithConditions)(ts_estree_1.AST_TOKEN_TYPES.Punctuator, { value: '!' });
+-exports.isNotNonNullAssertionPunctuator = (0, helpers_1.isNotTokenOfTypeWithConditions)(ts_estree_1.AST_TOKEN_TYPES.Punctuator, { value: '!' });
++exports.isOptionalChainPunctuator = (0, helpers_1.isTokenOfTypeWithConditions)('Punctuator', { value: '?.' });
++exports.isNotOptionalChainPunctuator = (0, helpers_1.isNotTokenOfTypeWithConditions)('Punctuator', { value: '?.' });
++exports.isNonNullAssertionPunctuator = (0, helpers_1.isTokenOfTypeWithConditions)('Punctuator', { value: '!' });
++exports.isNotNonNullAssertionPunctuator = (0, helpers_1.isNotTokenOfTypeWithConditions)('Punctuator', { value: '!' });
+ /**
+  * Returns true if and only if the node represents: foo?.() or foo.bar?.()
+  */
+-exports.isOptionalCallExpression = (0, helpers_1.isNodeOfTypeWithConditions)(ts_estree_1.AST_NODE_TYPES.CallExpression, 
++exports.isOptionalCallExpression = (0, helpers_1.isNodeOfTypeWithConditions)('CallExpression', 
+ // this flag means the call expression itself is option
+ // i.e. it is foo.bar?.() and not foo?.bar()
+ { optional: true });
+ /**
+  * Returns true if and only if the node represents logical OR
+  */
+-exports.isLogicalOrOperator = (0, helpers_1.isNodeOfTypeWithConditions)(ts_estree_1.AST_NODE_TYPES.LogicalExpression, { operator: '||' });
++exports.isLogicalOrOperator = (0, helpers_1.isNodeOfTypeWithConditions)('LogicalExpression', { operator: '||' });
+ /**
+  * Checks if a node is a type assertion:
+  * ```
+@@ -27,82 +26,82 @@ exports.isLogicalOrOperator = (0, helpers_1.isNodeOfTypeWithConditions)(ts_estre
+  * ```
+  */
+ exports.isTypeAssertion = (0, helpers_1.isNodeOfTypes)([
+-    ts_estree_1.AST_NODE_TYPES.TSAsExpression,
+-    ts_estree_1.AST_NODE_TYPES.TSTypeAssertion,
++    'TSAsExpression',
++    'TSTypeAssertion',
+ ]);
+-exports.isVariableDeclarator = (0, helpers_1.isNodeOfType)(ts_estree_1.AST_NODE_TYPES.VariableDeclarator);
++exports.isVariableDeclarator = (0, helpers_1.isNodeOfType)('VariableDeclarator');
+ const functionTypes = [
+-    ts_estree_1.AST_NODE_TYPES.ArrowFunctionExpression,
+-    ts_estree_1.AST_NODE_TYPES.FunctionDeclaration,
+-    ts_estree_1.AST_NODE_TYPES.FunctionExpression,
++    'ArrowFunctionExpression',
++    'FunctionDeclaration',
++    'FunctionExpression',
+ ];
+ exports.isFunction = (0, helpers_1.isNodeOfTypes)(functionTypes);
+ const functionTypeTypes = [
+-    ts_estree_1.AST_NODE_TYPES.TSCallSignatureDeclaration,
+-    ts_estree_1.AST_NODE_TYPES.TSConstructorType,
+-    ts_estree_1.AST_NODE_TYPES.TSConstructSignatureDeclaration,
+-    ts_estree_1.AST_NODE_TYPES.TSDeclareFunction,
+-    ts_estree_1.AST_NODE_TYPES.TSEmptyBodyFunctionExpression,
+-    ts_estree_1.AST_NODE_TYPES.TSFunctionType,
+-    ts_estree_1.AST_NODE_TYPES.TSMethodSignature,
++    'TSCallSignatureDeclaration',
++    'TSConstructorType',
++    'TSConstructSignatureDeclaration',
++    'TSDeclareFunction',
++    'TSEmptyBodyFunctionExpression',
++    'TSFunctionType',
++    'TSMethodSignature',
+ ];
+ exports.isFunctionType = (0, helpers_1.isNodeOfTypes)(functionTypeTypes);
+ exports.isFunctionOrFunctionType = (0, helpers_1.isNodeOfTypes)([
+     ...functionTypes,
+     ...functionTypeTypes,
+ ]);
+-exports.isTSFunctionType = (0, helpers_1.isNodeOfType)(ts_estree_1.AST_NODE_TYPES.TSFunctionType);
+-exports.isTSConstructorType = (0, helpers_1.isNodeOfType)(ts_estree_1.AST_NODE_TYPES.TSConstructorType);
++exports.isTSFunctionType = (0, helpers_1.isNodeOfType)('TSFunctionType');
++exports.isTSConstructorType = (0, helpers_1.isNodeOfType)('TSConstructorType');
+ exports.isClassOrTypeElement = (0, helpers_1.isNodeOfTypes)([
+     // ClassElement
+-    ts_estree_1.AST_NODE_TYPES.PropertyDefinition,
+-    ts_estree_1.AST_NODE_TYPES.FunctionExpression,
+-    ts_estree_1.AST_NODE_TYPES.MethodDefinition,
+-    ts_estree_1.AST_NODE_TYPES.TSAbstractPropertyDefinition,
+-    ts_estree_1.AST_NODE_TYPES.TSAbstractMethodDefinition,
+-    ts_estree_1.AST_NODE_TYPES.TSEmptyBodyFunctionExpression,
+-    ts_estree_1.AST_NODE_TYPES.TSIndexSignature,
++    'PropertyDefinition',
++    'FunctionExpression',
++    'MethodDefinition',
++    'TSAbstractPropertyDefinition',
++    'TSAbstractMethodDefinition',
++    'TSEmptyBodyFunctionExpression',
++    'TSIndexSignature',
+     // TypeElement
+-    ts_estree_1.AST_NODE_TYPES.TSCallSignatureDeclaration,
+-    ts_estree_1.AST_NODE_TYPES.TSConstructSignatureDeclaration,
++    'TSCallSignatureDeclaration',
++    'TSConstructSignatureDeclaration',
+     // AST_NODE_TYPES.TSIndexSignature,
+-    ts_estree_1.AST_NODE_TYPES.TSMethodSignature,
+-    ts_estree_1.AST_NODE_TYPES.TSPropertySignature,
++    'TSMethodSignature',
++    'TSPropertySignature',
+ ]);
+ /**
+  * Checks if a node is a constructor method.
+  */
+-exports.isConstructor = (0, helpers_1.isNodeOfTypeWithConditions)(ts_estree_1.AST_NODE_TYPES.MethodDefinition, { kind: 'constructor' });
++exports.isConstructor = (0, helpers_1.isNodeOfTypeWithConditions)('MethodDefinition', { kind: 'constructor' });
+ /**
+  * Checks if a node is a setter method.
+  */
+ function isSetter(node) {
+     return (!!node &&
+-        (node.type === ts_estree_1.AST_NODE_TYPES.MethodDefinition ||
+-            node.type === ts_estree_1.AST_NODE_TYPES.Property) &&
++        (node.type === 'MethodDefinition' ||
++            node.type === 'Property') &&
+         node.kind === 'set');
+ }
+-exports.isIdentifier = (0, helpers_1.isNodeOfType)(ts_estree_1.AST_NODE_TYPES.Identifier);
++exports.isIdentifier = (0, helpers_1.isNodeOfType)('Identifier');
+ /**
+  * Checks if a node represents an `await …` expression.
+  */
+-exports.isAwaitExpression = (0, helpers_1.isNodeOfType)(ts_estree_1.AST_NODE_TYPES.AwaitExpression);
++exports.isAwaitExpression = (0, helpers_1.isNodeOfType)('AwaitExpression');
+ /**
+  * Checks if a possible token is the `await` keyword.
+  */
+-exports.isAwaitKeyword = (0, helpers_1.isTokenOfTypeWithConditions)(ts_estree_1.AST_TOKEN_TYPES.Identifier, { value: 'await' });
++exports.isAwaitKeyword = (0, helpers_1.isTokenOfTypeWithConditions)('Identifier', { value: 'await' });
+ /**
+  * Checks if a possible token is the `type` keyword.
+  */
+-exports.isTypeKeyword = (0, helpers_1.isTokenOfTypeWithConditions)(ts_estree_1.AST_TOKEN_TYPES.Identifier, { value: 'type' });
++exports.isTypeKeyword = (0, helpers_1.isTokenOfTypeWithConditions)('Identifier', { value: 'type' });
+ /**
+  * Checks if a possible token is the `import` keyword.
+  */
+-exports.isImportKeyword = (0, helpers_1.isTokenOfTypeWithConditions)(ts_estree_1.AST_TOKEN_TYPES.Keyword, { value: 'import' });
++exports.isImportKeyword = (0, helpers_1.isTokenOfTypeWithConditions)('Keyword', { value: 'import' });
+ exports.isLoop = (0, helpers_1.isNodeOfTypes)([
+-    ts_estree_1.AST_NODE_TYPES.DoWhileStatement,
+-    ts_estree_1.AST_NODE_TYPES.ForStatement,
+-    ts_estree_1.AST_NODE_TYPES.ForInStatement,
+-    ts_estree_1.AST_NODE_TYPES.ForOfStatement,
+-    ts_estree_1.AST_NODE_TYPES.WhileStatement,
++    'DoWhileStatement',
++    'ForStatement',
++    'ForInStatement',
++    'ForOfStatement',
++    'WhileStatement',
+ ]);

--- a/patches/@typescript-eslint__utils.patch
+++ b/patches/@typescript-eslint__utils.patch
@@ -1,3 +1,33 @@
+diff --git a/dist/ast-utils/helpers.d.ts b/dist/ast-utils/helpers.d.ts
+index 9df9cdd86641e4a2c12d07fb2fe2f70416c57337..79de93796ddedad237b9e4e448f490f239c3f8ae 100644
+--- a/dist/ast-utils/helpers.d.ts
++++ b/dist/ast-utils/helpers.d.ts
+@@ -1,18 +1,20 @@
+ import type { AST_NODE_TYPES, AST_TOKEN_TYPES, TSESTree } from '../ts-estree';
+-export declare const isNodeOfType: <NodeType extends AST_NODE_TYPES>(nodeType: NodeType) => (node: TSESTree.Node | null | undefined) => node is Extract<TSESTree.Node, {
++type ASTNodeTypes = AST_NODE_TYPES | `${AST_NODE_TYPES}`
++type ASTTokenTypes = AST_TOKEN_TYPES | `${AST_TOKEN_TYPES}`
++export declare const isNodeOfType: <NodeType extends ASTNodeTypes>(nodeType: NodeType) => (node: TSESTree.Node | null | undefined) => node is Extract<TSESTree.Node, {
+     type: NodeType;
+ }>;
+-export declare const isNodeOfTypes: <NodeTypes extends readonly AST_NODE_TYPES[]>(nodeTypes: NodeTypes) => (node: TSESTree.Node | null | undefined) => node is Extract<TSESTree.Node, {
++export declare const isNodeOfTypes: <NodeTypes extends readonly ASTNodeTypes[]>(nodeTypes: NodeTypes) => (node: TSESTree.Node | null | undefined) => node is Extract<TSESTree.Node, {
+     type: NodeTypes[number];
+ }>;
+-export declare const isNodeOfTypeWithConditions: <NodeType extends AST_NODE_TYPES, ExtractedNode extends Extract<TSESTree.Node, {
++export declare const isNodeOfTypeWithConditions: <NodeType extends ASTNodeTypes, ExtractedNode extends Extract<TSESTree.Node, {
+     type: NodeType;
+ }>, Conditions extends Partial<ExtractedNode>>(nodeType: NodeType, conditions: Conditions) => ((node: TSESTree.Node | null | undefined) => node is Conditions & ExtractedNode);
+-export declare const isTokenOfTypeWithConditions: <TokenType extends AST_TOKEN_TYPES, ExtractedToken extends Extract<TSESTree.Token, {
++export declare const isTokenOfTypeWithConditions: <TokenType extends ASTTokenTypes, ExtractedToken extends Extract<TSESTree.Token, {
+     type: TokenType;
+ }>, Conditions extends Partial<{
+     type: TokenType;
+ } & TSESTree.Token>>(tokenType: TokenType, conditions: Conditions) => ((token: TSESTree.Token | null | undefined) => token is Conditions & ExtractedToken);
+-export declare const isNotTokenOfTypeWithConditions: <TokenType extends AST_TOKEN_TYPES, ExtractedToken extends Extract<TSESTree.Token, {
++export declare const isNotTokenOfTypeWithConditions: <TokenType extends ASTTokenTypes, ExtractedToken extends Extract<TSESTree.Token, {
+     type: TokenType;
+ }>, Conditions extends Partial<ExtractedToken>>(tokenType: TokenType, conditions: Conditions) => ((token: TSESTree.Token | null | undefined) => token is Exclude<TSESTree.Token, Conditions & ExtractedToken>);
 diff --git a/dist/ast-utils/predicates.js b/dist/ast-utils/predicates.js
 index 7b867603cc1574049dfbcee0cee150bb86767c43..256c338fe6c1fc16ff1d6c399191e6c2e77f92b4 100644
 --- a/dist/ast-utils/predicates.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,9 +153,6 @@ catalogs:
     '@eslint-community/eslint-utils':
       specifier: ^4.9.0
       version: 4.9.0
-    '@typescript-eslint/types':
-      specifier: ^8.47.0
-      version: 8.47.0
     eslint-visitor-keys:
       specifier: ^4.2.1
       version: 4.2.1
@@ -265,9 +262,6 @@ importers:
       '@typescript-eslint/parser':
         specifier: catalog:dev
         version: 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/types':
-        specifier: catalog:prod
-        version: 8.47.0
       '@typescript-eslint/utils':
         specifier: catalog:dev
         version: 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
@@ -422,9 +416,6 @@ importers:
       '@eslint-community/eslint-utils':
         specifier: catalog:prod
         version: 4.9.0(eslint@9.39.1(jiti@2.6.1))
-      '@typescript-eslint/types':
-        specifier: catalog:prod
-        version: 8.47.0
       eslint:
         specifier: '>=9.0.0'
         version: 9.39.1(jiti@2.6.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,7 +203,7 @@ overrides:
 
 patchedDependencies:
   '@typescript-eslint/utils':
-    hash: 63f1d5549d0455e595da2e06c7ba13f513ceddd82f6a08feba499e51a52b8c60
+    hash: bc30c563c84e382036d994c8168362208ad927edb312ced122c5f19d741db258
     path: patches/@typescript-eslint__utils.patch
 
 importers:
@@ -269,7 +269,7 @@ importers:
         version: 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/utils':
         specifier: catalog:dev
-        version: 8.47.0(patch_hash=63f1d5549d0455e595da2e06c7ba13f513ceddd82f6a08feba499e51a52b8c60)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.47.0(patch_hash=bc30c563c84e382036d994c8168362208ad927edb312ced122c5f19d741db258)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: catalog:test
         version: 4.0.10(vitest@4.0.10)
@@ -4909,7 +4909,7 @@ snapshots:
       '@typescript-eslint/parser': 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.47.0
       '@typescript-eslint/type-utils': 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.47.0(patch_hash=63f1d5549d0455e595da2e06c7ba13f513ceddd82f6a08feba499e51a52b8c60)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.47.0(patch_hash=bc30c563c84e382036d994c8168362208ad927edb312ced122c5f19d741db258)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.47.0
       eslint: 9.39.1(jiti@2.6.1)
       graphemer: 1.4.0
@@ -4954,7 +4954,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.47.0
       '@typescript-eslint/typescript-estree': 8.47.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.47.0(patch_hash=63f1d5549d0455e595da2e06c7ba13f513ceddd82f6a08feba499e51a52b8c60)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.47.0(patch_hash=bc30c563c84e382036d994c8168362208ad927edb312ced122c5f19d741db258)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       debug: 4.4.3
       eslint: 9.39.1(jiti@2.6.1)
       ts-api-utils: 2.1.0(typescript@5.9.3)
@@ -4980,7 +4980,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.47.0(patch_hash=63f1d5549d0455e595da2e06c7ba13f513ceddd82f6a08feba499e51a52b8c60)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.47.0(patch_hash=bc30c563c84e382036d994c8168362208ad927edb312ced122c5f19d741db258)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.47.0
@@ -5179,7 +5179,7 @@ snapshots:
   '@vitest/eslint-plugin@1.4.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.10)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.47.0
-      '@typescript-eslint/utils': 8.47.0(patch_hash=63f1d5549d0455e595da2e06c7ba13f513ceddd82f6a08feba499e51a52b8c60)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.47.0(patch_hash=bc30c563c84e382036d994c8168362208ad927edb312ced122c5f19d741db258)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
     optionalDependencies:
       typescript: 5.9.3
@@ -5792,7 +5792,7 @@ snapshots:
   eslint-plugin-perfectionist@4.15.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/types': 8.47.0
-      '@typescript-eslint/utils': 8.47.0(patch_hash=63f1d5549d0455e595da2e06c7ba13f513ceddd82f6a08feba499e51a52b8c60)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.47.0(patch_hash=bc30c563c84e382036d994c8168362208ad927edb312ced122c5f19d741db258)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
       natural-orderby: 5.0.0
     transitivePeerDependencies:
@@ -5907,7 +5907,7 @@ snapshots:
 
   eslint-vitest-rule-tester@3.0.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.10):
     dependencies:
-      '@typescript-eslint/utils': 8.47.0(patch_hash=63f1d5549d0455e595da2e06c7ba13f513ceddd82f6a08feba499e51a52b8c60)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.47.0(patch_hash=bc30c563c84e382036d994c8168362208ad927edb312ced122c5f19d741db258)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
       vitest: 4.0.10(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@4.0.10)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,11 @@ overrides:
   vue: ^3.5.24
   vue-tsc: ^3.1.4
 
+patchedDependencies:
+  '@typescript-eslint/utils':
+    hash: 63f1d5549d0455e595da2e06c7ba13f513ceddd82f6a08feba499e51a52b8c60
+    path: patches/@typescript-eslint__utils.patch
+
 importers:
 
   .:
@@ -264,7 +269,7 @@ importers:
         version: 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/utils':
         specifier: catalog:dev
-        version: 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.47.0(patch_hash=63f1d5549d0455e595da2e06c7ba13f513ceddd82f6a08feba499e51a52b8c60)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: catalog:test
         version: 4.0.10(vitest@4.0.10)
@@ -4904,7 +4909,7 @@ snapshots:
       '@typescript-eslint/parser': 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.47.0
       '@typescript-eslint/type-utils': 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.47.0(patch_hash=63f1d5549d0455e595da2e06c7ba13f513ceddd82f6a08feba499e51a52b8c60)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.47.0
       eslint: 9.39.1(jiti@2.6.1)
       graphemer: 1.4.0
@@ -4949,7 +4954,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.47.0
       '@typescript-eslint/typescript-estree': 8.47.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.47.0(patch_hash=63f1d5549d0455e595da2e06c7ba13f513ceddd82f6a08feba499e51a52b8c60)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       debug: 4.4.3
       eslint: 9.39.1(jiti@2.6.1)
       ts-api-utils: 2.1.0(typescript@5.9.3)
@@ -4975,7 +4980,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.47.0(patch_hash=63f1d5549d0455e595da2e06c7ba13f513ceddd82f6a08feba499e51a52b8c60)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.47.0
@@ -5174,7 +5179,7 @@ snapshots:
   '@vitest/eslint-plugin@1.4.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.10)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.47.0
-      '@typescript-eslint/utils': 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.47.0(patch_hash=63f1d5549d0455e595da2e06c7ba13f513ceddd82f6a08feba499e51a52b8c60)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
     optionalDependencies:
       typescript: 5.9.3
@@ -5787,7 +5792,7 @@ snapshots:
   eslint-plugin-perfectionist@4.15.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/types': 8.47.0
-      '@typescript-eslint/utils': 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.47.0(patch_hash=63f1d5549d0455e595da2e06c7ba13f513ceddd82f6a08feba499e51a52b8c60)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
       natural-orderby: 5.0.0
     transitivePeerDependencies:
@@ -5902,7 +5907,7 @@ snapshots:
 
   eslint-vitest-rule-tester@3.0.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.10):
     dependencies:
-      '@typescript-eslint/utils': 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.47.0(patch_hash=63f1d5549d0455e595da2e06c7ba13f513ceddd82f6a08feba499e51a52b8c60)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
       vitest: 4.0.10(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@4.0.10)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,7 +59,6 @@ catalogs:
     vue: ^3.5.24
   prod:
     '@eslint-community/eslint-utils': ^4.9.0
-    '@typescript-eslint/types': ^8.47.0
     eslint-visitor-keys: ^4.2.1
     espree: ^10.4.0
     estraverse: ^5.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,8 @@ packages:
   - docs
   - packages/*
   - shared
+patchedDependencies:
+  '@typescript-eslint/utils': patches/@typescript-eslint__utils.patch
 catalogs:
   build:
     '@codecov/rollup-plugin': ^1.9.1

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -1,5 +1,4 @@
-import type { AST_NODE_TYPES } from '#utils/ast'
-import type { TSESTree } from '@typescript-eslint/utils'
+import type { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils'
 import type { AST } from 'eslint'
 import type * as ESTree from 'estree'
 

--- a/shared/utils/ast.ts
+++ b/shared/utils/ast.ts
@@ -1,7 +1,6 @@
 export * from './ast/general'
 
 export {
-  AST_NODE_TYPES,
   AST_TOKEN_TYPES,
 } from '@typescript-eslint/types'
 

--- a/shared/utils/ast.ts
+++ b/shared/utils/ast.ts
@@ -1,8 +1,4 @@
 export * from './ast/general'
 
-export {
-  AST_TOKEN_TYPES,
-} from '@typescript-eslint/types'
-
 // eslint-disable-next-line ts/no-restricted-imports
 export * from '@typescript-eslint/utils/ast-utils'


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Since `AST_NODE_TYPES` and `AST_TOKEN_TYPES` are enums with strictly literal values, using string literals is entirely correct.  
The main reason we depend on `@typescript-eslint/types` is for these two enums, so we could remove this dependency entirely and switch to strings instead.

### Linked Issues

Wait #1073, #1075

https://github.com/typescript-eslint/typescript-eslint/pull/11860 has been closed, so I patch the `@typescript-eslint/utils` locally.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
