### PR TITLE
feat(no-trailing-spaces): add `ignoreMarkdownLineBreaks` option (#397)

### DIFF
--- a/packages/eslint-plugin/rules/no-trailing-spaces/README.md
+++ b/packages/eslint-plugin/rules/no-trailing-spaces/README.md
@@ -45,6 +45,9 @@ This rule has an object option:
 - `"skipBlankLines": true` allows trailing whitespace on empty lines
 - `"ignoreComments": false` (default) disallows trailing whitespace in comment blocks
 - `"ignoreComments": true` allows trailing whitespace in comment blocks
+- `"ignoreMarkdownLineBreaks": "never"` (default) disallows all trailing whitespace
+- `"ignoreMarkdownLineBreaks": "always"` allows exactly two trailing spaces when followed by a non-empty line (markdown line break syntax). Use this for `.md` files.
+- `"ignoreMarkdownLineBreaks": "comments"` allows exactly two trailing spaces only in comments when followed by a non-empty line. Use this for JSDoc and other documentation comments in `.js`/`.ts` files.
 
 ### skipBlankLines
 
@@ -80,6 +83,66 @@ Examples of **correct** code for this rule with the `{ "ignoreComments": true }`
  *   
  * bar   
  */
+```
+
+:::
+
+### ignoreMarkdownLineBreaks
+
+This option allows exactly two trailing spaces when followed by a non-empty line, which is the markdown syntax for a hard line break (`<br>`).
+
+- `"never"` (default): No markdown line breaks allowed
+- `"always"`: Allow everywhere (for `.md` files)
+- `"comments"`: Only allow in comments (for JSDoc in `.js`/`.ts` files)
+
+Examples of **correct** code for this rule with the `{ "ignoreMarkdownLineBreaks": "comments" }` option:
+
+::: correct
+
+```js
+/* eslint @stylistic/no-trailing-spaces: ["error", { "ignoreMarkdownLineBreaks": "comments" }] */
+
+/**
+ * First line of description  
+ * continues on second line  
+ * and third line
+ */
+function foo() {}
+```
+
+:::
+
+Examples of **incorrect** code for this rule with the `{ "ignoreMarkdownLineBreaks": "comments" }` option:
+
+::: incorrect
+
+```js
+/* eslint @stylistic/no-trailing-spaces: ["error", { "ignoreMarkdownLineBreaks": "comments" }] */
+
+// Two trailing spaces in code are still invalid:
+var x = 1;  
+
+/**
+ * Trailing spaces before empty line  
+ *
+ * Three spaces are invalid   
+ * Single space is invalid 
+ * Two spaces before end of comment  
+ */
+```
+
+:::
+
+Examples of **correct** code for this rule with the `{ "ignoreMarkdownLineBreaks": "always" }` option (for `.md` files):
+
+::: correct
+
+```md
+/* eslint @stylistic/no-trailing-spaces: ["error", { "ignoreMarkdownLineBreaks": "always" }] */
+
+First line of paragraph  
+continues on second line  
+and third line
 ```
 
 :::

--- a/packages/eslint-plugin/rules/no-trailing-spaces/no-trailing-spaces.test.ts
+++ b/packages/eslint-plugin/rules/no-trailing-spaces/no-trailing-spaces.test.ts
@@ -86,6 +86,47 @@ run<RuleOptions, MessageIds>({
       code: '/* \n */ /* \n */',
       options: [{ ignoreComments: true }],
     },
+
+    // Tests for ignoreMarkdownLineBreaks option - valid cases
+
+    // ignoreMarkdownLineBreaks: "comments" - only works in block/multiline comments
+    {
+      // Markdown line break in JSDoc block comment
+      code: '/**\n * first line  \n * second line\n */',
+      options: [{ ignoreMarkdownLineBreaks: 'comments' }],
+    },
+    {
+      // Multiple markdown line breaks in block comment
+      code: '/**\n * line one  \n * line two  \n * line three\n */',
+      options: [{ ignoreMarkdownLineBreaks: 'comments' }],
+    },
+    {
+      // Markdown line break in regular block comment
+      code: '/*\nfirst line  \nsecond line\n*/',
+      options: [{ ignoreMarkdownLineBreaks: 'comments' }],
+    },
+    {
+      // No trailing spaces is still valid
+      code: 'var a = 5;\nvar b = 3;',
+      options: [{ ignoreMarkdownLineBreaks: 'comments' }],
+    },
+
+    // ignoreMarkdownLineBreaks: "always" - works everywhere (for .md files)
+    {
+      // Markdown line break in block comment with "always" mode
+      code: '/*\nfirst line  \nsecond line\n*/',
+      options: [{ ignoreMarkdownLineBreaks: 'always' }],
+    },
+    {
+      // Multiple markdown line breaks in block comment
+      code: '/*\nline one  \nline two  \nline three\n*/',
+      options: [{ ignoreMarkdownLineBreaks: 'always' }],
+    },
+    {
+      // Markdown line break in comment with "always" mode
+      code: '/**\n * first line  \n * second line\n */',
+      options: [{ ignoreMarkdownLineBreaks: 'always' }],
+    },
   ],
 
   invalid: [
@@ -555,6 +596,246 @@ run<RuleOptions, MessageIds>({
           column: 34,
           endLine: 1,
           endColumn: 35,
+        },
+      ],
+    },
+
+    // Tests for ignoreMarkdownLineBreaks option - invalid cases
+
+    // ignoreMarkdownLineBreaks: "comments" - NOT allowed in regular code or single-line comments
+    {
+      // Two trailing spaces in regular code is still invalid with "comments" mode
+      code: 'var a = 5;  \nvar b = 3;',
+      output: 'var a = 5;\nvar b = 3;',
+      options: [{ ignoreMarkdownLineBreaks: 'comments' }],
+      errors: [
+        {
+          messageId: 'trailingSpace',
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 13,
+        },
+      ],
+    },
+    {
+      // Two trailing spaces in single-line comment is NOT allowed (only block comments)
+      code: '// first line  \n// second line',
+      output: '// first line\n// second line',
+      options: [{ ignoreMarkdownLineBreaks: 'comments' }],
+      errors: [
+        {
+          messageId: 'trailingSpace',
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 16,
+        },
+      ],
+    },
+    {
+      // One trailing space in comment is not valid markdown
+      code: '/**\n * first line \n * second line\n */',
+      output: '/**\n * first line\n * second line\n */',
+      options: [{ ignoreMarkdownLineBreaks: 'comments' }],
+      errors: [
+        {
+          messageId: 'trailingSpace',
+          line: 2,
+          column: 14,
+          endLine: 2,
+          endColumn: 15,
+        },
+      ],
+    },
+    {
+      // Three trailing spaces in comment is not valid markdown line break
+      code: '/**\n * first line   \n * second line\n */',
+      output: '/**\n * first line\n * second line\n */',
+      options: [{ ignoreMarkdownLineBreaks: 'comments' }],
+      errors: [
+        {
+          messageId: 'trailingSpace',
+          line: 2,
+          column: 14,
+          endLine: 2,
+          endColumn: 17,
+        },
+      ],
+    },
+    {
+      // Trailing tab in comment is not valid markdown
+      code: '/**\n * first line\t\n * second line\n */',
+      output: '/**\n * first line\n * second line\n */',
+      options: [{ ignoreMarkdownLineBreaks: 'comments' }],
+      errors: [
+        {
+          messageId: 'trailingSpace',
+          line: 2,
+          column: 14,
+          endLine: 2,
+          endColumn: 15,
+        },
+      ],
+    },
+    {
+      // Two spaces before empty line in comment is not valid markdown line break
+      code: '/**\n * first line  \n *\n * third line\n */',
+      output: '/**\n * first line\n *\n * third line\n */',
+      options: [{ ignoreMarkdownLineBreaks: 'comments' }],
+      errors: [
+        {
+          messageId: 'trailingSpace',
+          line: 2,
+          column: 14,
+          endLine: 2,
+          endColumn: 16,
+        },
+      ],
+    },
+    {
+      // Two spaces at end of comment (before closing) is not valid
+      code: '/**\n * last line  \n */',
+      output: '/**\n * last line\n */',
+      options: [{ ignoreMarkdownLineBreaks: 'comments' }],
+      errors: [
+        {
+          messageId: 'trailingSpace',
+          line: 2,
+          column: 13,
+          endLine: 2,
+          endColumn: 15,
+        },
+      ],
+    },
+    {
+      // Two spaces before line with only whitespace in comment is not valid
+      code: '/**\n * first  \n *   \n * third\n */',
+      output: '/**\n * first\n *\n * third\n */',
+      options: [{ ignoreMarkdownLineBreaks: 'comments' }],
+      errors: [
+        {
+          messageId: 'trailingSpace',
+          line: 2,
+          column: 9,
+          endLine: 2,
+          endColumn: 11,
+        },
+        {
+          messageId: 'trailingSpace',
+          line: 3,
+          column: 3,
+          endLine: 3,
+          endColumn: 6,
+        },
+      ],
+    },
+    {
+      // Mixed: valid markdown in comment + invalid trailing space in code
+      code: '/**\n * line one  \n * line two\n */\nvar x = 1;  ',
+      output: '/**\n * line one  \n * line two\n */\nvar x = 1;',
+      options: [{ ignoreMarkdownLineBreaks: 'comments' }],
+      errors: [
+        {
+          messageId: 'trailingSpace',
+          line: 5,
+          column: 11,
+          endLine: 5,
+          endColumn: 13,
+        },
+      ],
+    },
+    {
+      // String literal with trailing spaces - should still be flagged
+      code: 'var s = "hello";  \nvar t = "world";',
+      output: 'var s = "hello";\nvar t = "world";',
+      options: [{ ignoreMarkdownLineBreaks: 'comments' }],
+      errors: [
+        {
+          messageId: 'trailingSpace',
+          line: 1,
+          column: 17,
+          endLine: 1,
+          endColumn: 19,
+        },
+      ],
+    },
+
+    // ignoreMarkdownLineBreaks: "always" - still validates markdown format
+    {
+      // One trailing space is not valid markdown even with "always"
+      code: '/*\nfirst line \nsecond line\n*/',
+      output: '/*\nfirst line\nsecond line\n*/',
+      options: [{ ignoreMarkdownLineBreaks: 'always' }],
+      errors: [
+        {
+          messageId: 'trailingSpace',
+          line: 2,
+          column: 11,
+          endLine: 2,
+          endColumn: 12,
+        },
+      ],
+    },
+    {
+      // Three trailing spaces is not valid markdown
+      code: '/*\nfirst line   \nsecond line\n*/',
+      output: '/*\nfirst line\nsecond line\n*/',
+      options: [{ ignoreMarkdownLineBreaks: 'always' }],
+      errors: [
+        {
+          messageId: 'trailingSpace',
+          line: 2,
+          column: 11,
+          endLine: 2,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      // Two spaces before closing comment line is not valid markdown
+      code: '/*\nlast line  \n*/',
+      output: '/*\nlast line\n*/',
+      options: [{ ignoreMarkdownLineBreaks: 'always' }],
+      errors: [
+        {
+          messageId: 'trailingSpace',
+          line: 2,
+          column: 10,
+          endLine: 2,
+          endColumn: 12,
+        },
+      ],
+    },
+
+    // ignoreMarkdownLineBreaks: "never" - no markdown line breaks allowed (default behavior)
+    {
+      // Two trailing spaces flagged with "never"
+      code: '/*\nfirst line  \nsecond line\n*/',
+      output: '/*\nfirst line\nsecond line\n*/',
+      options: [{ ignoreMarkdownLineBreaks: 'never' }],
+      errors: [
+        {
+          messageId: 'trailingSpace',
+          line: 2,
+          column: 11,
+          endLine: 2,
+          endColumn: 13,
+        },
+      ],
+    },
+    {
+      // Two trailing spaces in comment flagged with "never"
+      code: '/**\n * first line  \n * second line\n */',
+      output: '/**\n * first line\n * second line\n */',
+      options: [{ ignoreMarkdownLineBreaks: 'never' }],
+      errors: [
+        {
+          messageId: 'trailingSpace',
+          line: 2,
+          column: 14,
+          endLine: 2,
+          endColumn: 16,
         },
       ],
     },

--- a/packages/eslint-plugin/rules/no-trailing-spaces/types.d.ts
+++ b/packages/eslint-plugin/rules/no-trailing-spaces/types.d.ts
@@ -1,10 +1,11 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: tu4oLOTfQp3sh6A5GvsAX8-37zHJAnW-0YUiwYZee5A */
+/* @checksum: _yej1_dltKFlLLR4oWVff-POw3Zb7QwZ6MMIBxsQUCM */
 
 export interface NoTrailingSpacesSchema0 {
   skipBlankLines?: boolean
   ignoreComments?: boolean
+  ignoreMarkdownLineBreaks?: 'never' | 'always' | 'comments'
 }
 
 export type NoTrailingSpacesRuleOptions = [


### PR DESCRIPTION
### Description

Add new `ignoreMarkdownLineBreaks` option to the `no-trailing-spaces` rule that allows exactly two trailing spaces (markdown line break syntax `<br>`) when followed by a non-empty line.

**New option values:**
- `"never"` (default): No markdown line breaks allowed - maintains existing behavior
- `"always"`: Allow markdown line breaks everywhere (for `.md` files)
- `"comments"`: Only allow markdown line breaks in block/multiline comments (for JSDoc in `.js`/`.ts` files)

**Validation rules:**
- Must be exactly two spaces (not one, three, or tabs)
- Next line must have actual content (not empty or whitespace-only)
- For block comments, correctly handles comment prefixes like ` *` when checking next line content

### Linked Issues

Closes #397

### Additional context

`·` = space, `⏎` = newline

**Valid with `{ "ignoreMarkdownLineBreaks": "comments" }`:**
```js
/**⏎
 * First line of description··⏎
 * continues on second line⏎
 */⏎
function foo() {}
```

**Invalid cases (still flagged):**
```js
/**⏎
 * one space is bad·⏎
 * three spaces are bad···⏎
 * tab is bad↹⏎
 * two spaces before empty line··⏎
 *⏎
 * two spaces before comment end··⏎
 */
```

**Example config:**
```js
// For .md files
{ "ignoreMarkdownLineBreaks": "always" }

// For JSDoc in .js/.ts files  
{ "ignoreMarkdownLineBreaks": "comments" }
```