### PR TITLE
refactor: replace `hasCommentsBetween` with `sourceCode.commentsExistBetween`

### DIFF
--- a/packages/eslint-plugin/rules/implicit-arrow-linebreak/implicit-arrow-linebreak.ts
+++ b/packages/eslint-plugin/rules/implicit-arrow-linebreak/implicit-arrow-linebreak.ts
@@ -5,7 +5,7 @@
 
 import type { Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
-import { hasCommentsBetween, isNotOpeningParenToken, isTokenOnSameLine } from '#utils/ast'
+import { isNotOpeningParenToken, isTokenOnSameLine } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 export default createRule<RuleOptions, MessageIds>({
@@ -60,7 +60,7 @@ export default createRule<RuleOptions, MessageIds>({
           node: firstTokenOfBody,
           messageId: 'unexpected',
           fix(fixer) {
-            if (hasCommentsBetween(sourceCode, arrowToken, firstTokenOfBody))
+            if (sourceCode.commentsExistBetween(arrowToken, firstTokenOfBody))
               return null
 
             return fixer.replaceTextRange([arrowToken.range[1], firstTokenOfBody.range[0]], ' ')

--- a/packages/eslint-plugin/rules/list-style/list-style.ts
+++ b/packages/eslint-plugin/rules/list-style/list-style.ts
@@ -2,7 +2,6 @@ import type { ASTNode, Token, Tree } from '#types'
 import type { BaseConfig, MessageIds, RuleOptions } from './types'
 import {
   AST_NODE_TYPES,
-  hasCommentsBetween,
   isClosingBraceToken,
   isClosingBracketToken,
   isClosingParenToken,
@@ -238,7 +237,7 @@ export default createRule<RuleOptions, MessageIds>({
               next: next.value,
             },
             fix(fixer) {
-              if (hasCommentsBetween(sourceCode, prev, next))
+              if (sourceCode.commentsExistBetween(prev, next))
                 return null
 
               return fixer.insertTextBefore(
@@ -264,7 +263,7 @@ export default createRule<RuleOptions, MessageIds>({
               next: next.value,
             },
             fix(fixer) {
-              if (hasCommentsBetween(sourceCode, prev, next))
+              if (sourceCode.commentsExistBetween(prev, next))
                 return null
 
               const range = [prev.range[1], next.range[0]] as const

--- a/packages/eslint-plugin/rules/switch-colon-spacing/switch-colon-spacing.ts
+++ b/packages/eslint-plugin/rules/switch-colon-spacing/switch-colon-spacing.ts
@@ -5,7 +5,7 @@
 
 import type { RuleFixer, Token } from '#types'
 import type { MessageIds, RuleOptions } from './types'
-import { getSwitchCaseColonToken, hasCommentsBetween, isClosingBraceToken, isTokenOnSameLine } from '#utils/ast'
+import { getSwitchCaseColonToken, isClosingBraceToken, isTokenOnSameLine } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 export default createRule<RuleOptions, MessageIds>({
@@ -66,7 +66,7 @@ export default createRule<RuleOptions, MessageIds>({
      * @returns The fix object.
      */
     function fix(fixer: RuleFixer, left: Token, right: Token, spacing: boolean) {
-      if (hasCommentsBetween(sourceCode, left, right))
+      if (sourceCode.commentsExistBetween(left, right))
         return null
 
       if (spacing)

--- a/shared/utils/ast/general.ts
+++ b/shared/utils/ast/general.ts
@@ -842,25 +842,6 @@ export function isSingleLine(node: ASTNode | Token) {
 }
 
 /**
- * Check whether comments exist between the given 2 tokens.
- * @param sourceCode The source code object to get tokens.
- * @param left The left token to check.
- * @param right The right token to check.
- * @param filter The callback function to filter tokens.
- * @returns `true` if comments exist between the given 2 tokens.
- */
-export function hasCommentsBetween(sourceCode: SourceCode, left: ASTNode | Token, right: ASTNode | Token, filter: (token: Tree.Comment) => boolean = () => true) {
-  return sourceCode.getFirstTokenBetween(
-    left,
-    right,
-    {
-      includeComments: true,
-      filter: token => isCommentToken(token) && filter(token),
-    },
-  ) !== null
-}
-
-/**
  * Get comments exist between the given 2 tokens.
  * @param sourceCode The source code object to get tokens.
  * @param left The left token to check.


### PR DESCRIPTION

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
