### PR TITLE
fix(no-whitespace-before-property): detect whitespace in `TSIndexedAccessType` with parens

### DIFF
--- a/packages/eslint-plugin/rules/no-whitespace-before-property/no-whitespace-before-property._ts_.test.ts
+++ b/packages/eslint-plugin/rules/no-whitespace-before-property/no-whitespace-before-property._ts_.test.ts
@@ -12,6 +12,8 @@ run<RuleOptions, MessageIds>({
     `type Foo = A['B']`,
     `type Foo = A.B`,
     `type Foo = import(A).B`,
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/1097
+    `type Test = ( typeof arr )[ number ];`,
   ],
 
   invalid: [
@@ -29,6 +31,12 @@ run<RuleOptions, MessageIds>({
       code: `type Foo = import(A) .B`,
       output: `type Foo = import(A).B`,
       errors: [{ messageId: 'unexpectedWhitespace', data: { propName: 'B' } }],
+    },
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/1097
+    {
+      code: `type Test = ( typeof arr ) [ number ];`,
+      output: `type Test = ( typeof arr )[ number ];`,
+      errors: [{ messageId: 'unexpectedWhitespace', data: { propName: 'number' } }],
     },
   ],
 })

--- a/packages/eslint-plugin/rules/no-whitespace-before-property/no-whitespace-before-property.ts
+++ b/packages/eslint-plugin/rules/no-whitespace-before-property/no-whitespace-before-property.ts
@@ -99,8 +99,8 @@ export default createRule<RuleOptions, MessageIds>({
         })
       },
       TSIndexedAccessType(node) {
-        const leftToken = node.objectType
-        const rightToken = sourceCode.getTokenBefore(node.indexType)!
+        const rightToken = sourceCode.getTokenBefore(node.indexType, isOpeningBracketToken)!
+        const leftToken = sourceCode.getTokenBefore(rightToken)!
 
         if (!sourceCode.isSpaceBetween(leftToken, rightToken))
           return


### PR DESCRIPTION

<!-- DO NOT IGNORE THE TEMPLATE! Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guide](https://eslint.style/contribute/guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [ ] If this PR changes documented rule default options, I've confirmed it is not addressing the intentional difference between rule defaults and preset values described in `#890`.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Fixes #1097

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
