### PR TITLE
fix(disable-legacy): disable `multiline-comment-style`

### DIFF
--- a/packages/eslint-plugin/configs/disable-legacy.ts
+++ b/packages/eslint-plugin/configs/disable-legacy.ts
@@ -30,6 +30,7 @@ const config: Linter.Config = {
     'max-len': 0,
     'max-statements-per-line': 0,
     'multiline-ternary': 0,
+    'multiline-comment-style': 0,
     'new-parens': 0,
     'newline-per-chained-call': 0,
     'no-confusing-arrow': 0,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE! Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guide](https://eslint.style/contribute/guide).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
- [ ] If this PR changes documented rule default options, I've confirmed it is not addressing the intentional difference between rule defaults and preset values described in `#890`.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

fixes #396

### Additional context

https://eslint.org/docs/latest/rules/multiline-comment-style
<!-- e.g. is there anything you'd like reviewers to focus on? -->
