### PR TITLE
refactor: extract `safeReplaceTextBetween` to reuse common fix logic

### DIFF
--- a/packages/eslint-plugin/rules/function-paren-newline/function-paren-newline.ts
+++ b/packages/eslint-plugin/rules/function-paren-newline/function-paren-newline.ts
@@ -7,6 +7,7 @@ import type { Token, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
 import { isClosingParenToken, isFunction, isOpeningParenToken, isTokenOnSameLine } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
+import { safeReplaceTextBetween } from '#utils/fix'
 
 interface ParensPair {
   leftParen: Token
@@ -106,13 +107,7 @@ export default createRule<RuleOptions, MessageIds>({
         context.report({
           node: leftParen,
           messageId: 'unexpectedAfter',
-          fix(fixer) {
-            return sourceCode.getText().slice(leftParen.range[1], tokenAfterLeftParen.range[0]).trim()
-
-            // If there is a comment between the ( and the first element, don't do a fix.
-              ? null
-              : fixer.removeRange([leftParen.range[1], tokenAfterLeftParen.range[0]])
-          },
+          fix: safeReplaceTextBetween(sourceCode, leftParen, tokenAfterLeftParen, ''),
         })
       }
       else if (!hasLeftNewline && needsNewlines) {
@@ -127,13 +122,7 @@ export default createRule<RuleOptions, MessageIds>({
         context.report({
           node: rightParen,
           messageId: 'unexpectedBefore',
-          fix(fixer) {
-            return sourceCode.getText().slice(tokenBeforeRightParen.range[1], rightParen.range[0]).trim()
-
-            // If there is a comment between the last element and the ), don't do a fix.
-              ? null
-              : fixer.removeRange([tokenBeforeRightParen.range[1], rightParen.range[0]])
-          },
+          fix: safeReplaceTextBetween(sourceCode, tokenBeforeRightParen, rightParen, ''),
         })
       }
       else if (!hasRightNewline && needsNewlines) {

--- a/packages/eslint-plugin/rules/implicit-arrow-linebreak/implicit-arrow-linebreak.ts
+++ b/packages/eslint-plugin/rules/implicit-arrow-linebreak/implicit-arrow-linebreak.ts
@@ -7,6 +7,7 @@ import type { Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
 import { isNotOpeningParenToken, isTokenOnSameLine } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
+import { safeReplaceTextBetween } from '#utils/fix'
 
 export default createRule<RuleOptions, MessageIds>({
   name: 'implicit-arrow-linebreak',
@@ -59,12 +60,7 @@ export default createRule<RuleOptions, MessageIds>({
         context.report({
           node: firstTokenOfBody,
           messageId: 'unexpected',
-          fix(fixer) {
-            if (sourceCode.commentsExistBetween(arrowToken, firstTokenOfBody))
-              return null
-
-            return fixer.replaceTextRange([arrowToken.range[1], firstTokenOfBody.range[0]], ' ')
-          },
+          fix: safeReplaceTextBetween(sourceCode, arrowToken, firstTokenOfBody, ' '),
         })
       }
     }

--- a/packages/eslint-plugin/rules/list-style/list-style.ts
+++ b/packages/eslint-plugin/rules/list-style/list-style.ts
@@ -14,6 +14,7 @@ import {
   isTokenOnSameLine,
 } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
+import { safeReplaceTextBetween } from '#utils/fix'
 
 export default createRule<RuleOptions, MessageIds>({
   name: 'list-style',
@@ -262,15 +263,7 @@ export default createRule<RuleOptions, MessageIds>({
               prev: prev.value,
               next: next.value,
             },
-            fix(fixer) {
-              if (sourceCode.commentsExistBetween(prev, next))
-                return null
-
-              const range = [prev.range[1], next.range[0]] as const
-              const delimiter = items.length === 1 ? '' : getDelimiter(node, prev)
-
-              return fixer.replaceTextRange(range, delimiter ?? '')
-            },
+            fix: safeReplaceTextBetween(sourceCode, prev, next, () => items.length === 1 ? '' : getDelimiter(node, prev) ?? ''),
           })
         }
       }

--- a/packages/eslint-plugin/rules/no-whitespace-before-property/no-whitespace-before-property.ts
+++ b/packages/eslint-plugin/rules/no-whitespace-before-property/no-whitespace-before-property.ts
@@ -2,6 +2,7 @@ import type { ASTNode, Token, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
 import { isDecimalInteger, isOpeningBracketToken, isTokenOnSameLine } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
+import { safeReplaceTextBetween } from '#utils/fix'
 
 type SupportedNode = Tree.MemberExpression | Tree.TSIndexedAccessType | Tree.TSQualifiedName | Tree.TSImportType
 
@@ -48,16 +49,7 @@ export default createRule<RuleOptions, MessageIds>({
         data: {
           propName,
         },
-        fix(fixer) {
-          // Don't fix if comments exist.
-          if (sourceCode.commentsExistBetween(leftToken, rightToken))
-            return null
-
-          if (preventAutoFix?.())
-            return null
-
-          return fixer.replaceTextRange([leftToken.range[1], rightToken.range[0]], replacementText)
-        },
+        fix: preventAutoFix?.() ? null : safeReplaceTextBetween(sourceCode, leftToken, rightToken, replacementText),
       })
     }
 

--- a/packages/eslint-plugin/rules/nonblock-statement-body-position/nonblock-statement-body-position.ts
+++ b/packages/eslint-plugin/rules/nonblock-statement-body-position/nonblock-statement-body-position.ts
@@ -7,6 +7,7 @@ import type { JSONSchema, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
 import { isTokenOnSameLine } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
+import { safeReplaceTextBetween } from '#utils/fix'
 
 type KeywordName = keyof NonNullable<NonNullable<RuleOptions['1']>['overrides']>
 
@@ -93,12 +94,7 @@ export default createRule<RuleOptions, MessageIds>({
         context.report({
           node,
           messageId: 'expectNoLinebreak',
-          fix(fixer) {
-            if (sourceCode.getText().slice(tokenBefore.range[1], node.range[0]).trim())
-              return null
-
-            return fixer.replaceTextRange([tokenBefore.range[1], node.range[0]], ' ')
-          },
+          fix: safeReplaceTextBetween(sourceCode, tokenBefore, node, ' '),
         })
       }
     }

--- a/shared/utils/fix.ts
+++ b/shared/utils/fix.ts
@@ -1,0 +1,10 @@
+import type { ASTNode, ReportFixFunction, SourceCode, Token } from '#types'
+
+export function safeReplaceTextBetween(sourceCode: SourceCode, left: ASTNode | Token, right: ASTNode | Token, replacement: string | (() => string)): ReportFixFunction | null {
+  if (sourceCode.commentsExistBetween(left, right))
+    return null
+
+  const range = [left.range[1], right.range[0]] as const
+
+  return fixer => fixer.replaceTextRange(range, typeof replacement === 'function' ? replacement() : replacement)
+}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE! Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guide](https://eslint.style/contribute/guide).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
- [ ] If this PR changes documented rule default options, I've confirmed it is not addressing the intentional difference between rule defaults and preset values described in `#890`.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
