### PR TITLE
fix(deps): revert `eslint-visitor-keys` and `espree` to compatible versions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,11 +160,11 @@ catalogs:
       specifier: ^8.52.0
       version: 8.53.0
     eslint-visitor-keys:
-      specifier: ^5.0.0
-      version: 5.0.0
+      specifier: ^4.2.1
+      version: 4.2.1
     espree:
-      specifier: ^11.0.0
-      version: 11.0.0
+      specifier: ^10.4.0
+      version: 10.4.0
     estraverse:
       specifier: ^5.3.0
       version: 5.3.0
@@ -300,13 +300,13 @@ importers:
         version: 1.2.0(eslint@9.39.2(jiti@2.6.1))
       eslint-visitor-keys:
         specifier: catalog:prod
-        version: 5.0.0
+        version: 4.2.1
       eslint-vitest-rule-tester:
         specifier: catalog:test
         version: 3.0.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.16)
       espree:
         specifier: catalog:prod
-        version: 11.0.0
+        version: 10.4.0
       estraverse:
         specifier: catalog:prod
         version: 5.3.0
@@ -439,10 +439,10 @@ importers:
         version: 9.39.2(jiti@2.6.1)
       eslint-visitor-keys:
         specifier: catalog:prod
-        version: 5.0.0
+        version: 4.2.1
       espree:
         specifier: catalog:prod
-        version: 11.0.0
+        version: 10.4.0
       estraverse:
         specifier: catalog:prod
         version: 5.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,8 +64,8 @@ catalogs:
   prod:
     '@eslint-community/eslint-utils': ^4.9.1
     '@typescript-eslint/types': ^8.52.0
-    eslint-visitor-keys: ^5.0.0
-    espree: ^11.0.0
+    eslint-visitor-keys: ^4.2.1
+    espree: ^10.4.0
     estraverse: ^5.3.0
     picomatch: ^4.0.3
   test:


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE! Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guide](https://eslint.style/contribute/guide).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
- [ ] If this PR changes documented rule default options, I've confirmed it is not addressing the intentional difference between rule defaults and preset values described in `#890`.

### Description

Thanks to @matz3

https://github.com/eslint-stylistic/eslint-stylistic/pull/1095#discussion_r2719157735

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
