### PR TITLE
fix(list-style): correctly get `(` for optional call expressions

### DIFF
--- a/packages/eslint-plugin/rules/list-style/list-style.test.ts
+++ b/packages/eslint-plugin/rules/list-style/list-style.test.ts
@@ -29,6 +29,7 @@ run<RuleOptions, MessageIds>({
     'a\n.filter(items => {\n\n})',
     'new Foo(a, b)',
     'new Foo(\na,\nb\n)',
+    'new (Foo())(a, b)',
     'function foo<T = {\na: 1,\nb: 2\n}>(a, b) {}',
     'foo(() =>\nbar())',
     `call<{\nfoo: 'bar'\n}>('')`,
@@ -142,6 +143,13 @@ run<RuleOptions, MessageIds>({
         (x),
         y,
         z
+      )
+    `,
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/1030#issuecomment-3797379905
+    $`
+      foo?.(
+        [],
+        {},
       )
     `,
     // https://github.com/antfu/eslint-plugin-antfu/issues/22

--- a/packages/eslint-plugin/rules/list-style/list-style.ts
+++ b/packages/eslint-plugin/rules/list-style/list-style.ts
@@ -319,11 +319,12 @@ export default createRule<RuleOptions, MessageIds>({
 
     function getLeftParen(node: ASTNode, items: (ASTNode | null)[], type: ParenType) {
       switch (node.type) {
+        // fun?.()
         // fun<T>()
         // new Foo<T>()
         case AST_NODE_TYPES.CallExpression:
         case AST_NODE_TYPES.NewExpression:
-          return sourceCode.getTokenAfter(node.typeArguments ?? node.callee)
+          return sourceCode.getTokenAfter(node.typeArguments ?? node.callee, isOpeningParenToken)
 
         // const foo = [, a]
         // const [, a] = foo


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE! Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guide](https://eslint.style/contribute/guide).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
- [ ] If this PR changes documented rule default options, I've confirmed it is not addressing the intentional difference between rule defaults and preset values described in `#890`.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

https://github.com/eslint-stylistic/eslint-stylistic/issues/1030#issuecomment-3797379905

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
