### PR TITLE
feat(padding-line-between-statements): add declare statement type

### DIFF
--- a/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements._ts_.test.ts
+++ b/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements._ts_.test.ts
@@ -229,6 +229,130 @@ run<RuleOptions, MessageIds>({
         },
       ],
     },
+
+    // ----------------------------------------------------------------------
+    // declare (https://github.com/eslint-stylistic/eslint-stylistic/issues/1115)
+    // ----------------------------------------------------------------------
+
+    // declare function
+    {
+      code: $`
+        declare function foo(): void;
+        
+        foo();
+      `,
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'declare', next: '*' },
+      ],
+    },
+    // declare class
+    {
+      code: $`
+        declare class Foo {}
+        
+        const x = 1;
+      `,
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'declare', next: '*' },
+      ],
+    },
+    // declare const
+    {
+      code: $`
+        declare const x: number;
+        
+        foo();
+      `,
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'declare', next: '*' },
+      ],
+    },
+    // declare let
+    {
+      code: $`
+        declare let x: number;
+        
+        foo();
+      `,
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'declare', next: '*' },
+      ],
+    },
+    // declare var
+    {
+      code: $`
+        declare var x: number;
+        
+        foo();
+      `,
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'declare', next: '*' },
+      ],
+    },
+    // declare enum
+    {
+      code: $`
+        declare enum Foo { A, B }
+        
+        foo();
+      `,
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'declare', next: '*' },
+      ],
+    },
+    // declare module
+    {
+      code: $`
+        declare module "foo" {}
+        
+        foo();
+      `,
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'declare', next: '*' },
+      ],
+    },
+    // declare namespace
+    {
+      code: $`
+        declare namespace Foo {}
+        
+        foo();
+      `,
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'declare', next: '*' },
+      ],
+    },
+    // non-declare should not match
+    {
+      code: $`
+        function foo(): void {}
+        bar();
+      `,
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'declare', next: '*' },
+      ],
+    },
+    // declare before other statements (prev)
+    {
+      code: $`
+        foo();
+        
+        declare const x: number;
+      `,
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: '*', next: 'declare' },
+      ],
+    },
   ],
   invalid: [
     // ----------------------------------------------------------------------
@@ -454,6 +578,113 @@ run<RuleOptions, MessageIds>({
         }
       `,
       options: [{ blankLine: 'always', prev: '*', next: 'multiline-type' }],
+      errors: [{ messageId: 'expectedBlankLine' }],
+    },
+
+    // ----------------------------------------------------------------------
+    // declare (https://github.com/eslint-stylistic/eslint-stylistic/issues/1115)
+    // ----------------------------------------------------------------------
+
+    // declare function should require blank line
+    {
+      code: $`
+        declare function foo(): void;
+        bar();
+      `,
+      output: $`
+        declare function foo(): void;
+        
+        bar();
+      `,
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'declare', next: '*' },
+      ],
+      errors: [{ messageId: 'expectedBlankLine' }],
+    },
+    // declare class should require blank line
+    {
+      code: $`
+        declare class Foo {}
+        const x = 1;
+      `,
+      output: $`
+        declare class Foo {}
+        
+        const x = 1;
+      `,
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'declare', next: '*' },
+      ],
+      errors: [{ messageId: 'expectedBlankLine' }],
+    },
+    // declare const should require blank line
+    {
+      code: $`
+        declare const x: number;
+        foo();
+      `,
+      output: $`
+        declare const x: number;
+        
+        foo();
+      `,
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'declare', next: '*' },
+      ],
+      errors: [{ messageId: 'expectedBlankLine' }],
+    },
+    // declare module should require blank line
+    {
+      code: $`
+        declare module "foo" {}
+        bar();
+      `,
+      output: $`
+        declare module "foo" {}
+        
+        bar();
+      `,
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: 'declare', next: '*' },
+      ],
+      errors: [{ messageId: 'expectedBlankLine' }],
+    },
+    // blank line before declare should be removed when never
+    {
+      code: $`
+        foo();
+        
+        declare const x: number;
+      `,
+      output: $`
+        foo();
+        declare const x: number;
+      `,
+      options: [
+        { blankLine: 'always', prev: '*', next: '*' },
+        { blankLine: 'never', prev: '*', next: 'declare' },
+      ],
+      errors: [{ messageId: 'unexpectedBlankLine' }],
+    },
+    // blank line should be added before declare when always
+    {
+      code: $`
+        foo();
+        declare const x: number;
+      `,
+      output: $`
+        foo();
+        
+        declare const x: number;
+      `,
+      options: [
+        { blankLine: 'never', prev: '*', next: '*' },
+        { blankLine: 'always', prev: '*', next: 'declare' },
+      ],
       errors: [{ messageId: 'expectedBlankLine' }],
     },
   ],

--- a/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements.ts
+++ b/packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements.ts
@@ -549,6 +549,26 @@ const StatementTypes: Record<string, NodeTestObject> = {
     'interface',
   ),
   'function-overload': newNodeTypeTester(AST_NODE_TYPES.TSDeclareFunction),
+
+  'declare': {
+    test: (node, sourceCode): boolean => {
+      // Check if the first token is 'declare'
+      const firstToken = sourceCode.getFirstToken(node)
+      if (firstToken?.value !== 'declare')
+        return false
+
+      // Check if the node is a type that can have declare modifier
+      return [
+        AST_NODE_TYPES.TSDeclareFunction,
+        AST_NODE_TYPES.TSModuleDeclaration,
+        AST_NODE_TYPES.TSEnumDeclaration,
+        AST_NODE_TYPES.ClassDeclaration,
+        AST_NODE_TYPES.VariableDeclaration,
+        AST_NODE_TYPES.TSTypeAliasDeclaration,
+        AST_NODE_TYPES.TSInterfaceDeclaration,
+      ].includes(node.type)
+    },
+  },
   ...Object.fromEntries(
     Object.entries(MaybeMultilineStatementType)
       .flatMap(([key, value]) => [


### PR DESCRIPTION
Add support for TypeScript declare statements in padding-line-between-statements rule. This allows users to configure blank lines before/after declare statements (declare function, declare class, declare const/let/var, declare enum, declare module, declare namespace).

Closes #1115

<!-- DO NOT IGNORE THE TEMPLATE! Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guide](https://eslint.style/contribute/guide).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
- [ ] If this PR changes documented rule default options, I've confirmed it is not addressing the intentional difference between rule defaults and preset values described in `#890`.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
