### PR TITLE
fix(object-curly-spacing): correctly handle object patterns with type annotations

### DIFF
--- a/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing._ts_.test.ts
@@ -733,5 +733,14 @@ run<RuleOptions, MessageIds>({
         },
       ],
     },
+    {
+      code: 'const foo = ({str}: { str: string }) => null',
+      output: 'const foo = ({ str }: { str: string }) => null',
+      options: ['always'],
+      errors: [
+        { messageId: 'requireSpaceAfter' },
+        { messageId: 'requireSpaceBefore' },
+      ],
+    },
   ],
 })

--- a/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing.ts
+++ b/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing.ts
@@ -351,7 +351,9 @@ export default createRule<RuleOptions, MessageIds>({
         case 'TSEnumBody': {
           const allTokens = sourceCode.getTokens(node)
           const openingToken = allTokens.find(token => isOpeningBraceToken(token))!
-          const closingToken = allTokens.findLast(token => isClosingBraceToken(token))!
+          const closingToken = (node.type === 'ObjectPattern' && node.typeAnnotation)
+            ? sourceCode.getTokenBefore(node.typeAnnotation)!
+            : allTokens.findLast(token => isClosingBraceToken(token))!
           return [openingToken, closingToken]
         }
         default:


### PR DESCRIPTION


<!-- DO NOT IGNORE THE TEMPLATE! Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guide](https://eslint.style/contribute/guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] If this PR changes documented rule default options, I've confirmed it is not addressing the intentional difference between rule defaults and preset values described in `#890`.

### Description

Fix an issue where the rule would incorrectly identify the closing brace of an object pattern when a type annotation is present, causing incorrect spacing validation.

Previously, `findLast` returned the type literal's closing. Now, when `node.typeAnnotation` exists, we take the token before it, aligning with `object-curly-newline`'s approach.

### Linked Issues

Fixes #1128
