### PR TITLE
fix(comma-dangle): prevent crash when linting non-js files

### DIFF
--- a/packages/eslint-plugin/rules/comma-dangle/comma-dangle.ts
+++ b/packages/eslint-plugin/rules/comma-dangle/comma-dangle.ts
@@ -136,10 +136,10 @@ export default createRule<RuleOptions, MessageIds>({
       }
     }
 
-    const ecmaVersion = context?.languageOptions?.ecmaVersion ?? context.parserOptions.ecmaVersion as EcmaVersion | undefined
+    const ecmaVersion = context.languageOptions?.ecmaVersion ?? context.parserOptions?.ecmaVersion as EcmaVersion | undefined
     const normalizedOptions = normalizeOptions(options, ecmaVersion)
 
-    const isTSX = (context.languageOptions.parserOptions?.ecmaFeatures?.jsx ?? context.parserOptions?.ecmaFeatures?.jsx)
+    const isTSX = (context.languageOptions?.parserOptions?.ecmaFeatures?.jsx ?? context.parserOptions?.ecmaFeatures?.jsx)
       && context.filename?.endsWith('.tsx')
 
     const sourceCode = context.sourceCode


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE! Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guide](https://eslint.style/contribute/guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
- [ ] If this PR changes documented rule default options, I've confirmed it is not addressing the intentional difference between rule defaults and preset values described in `#890`.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

related to https://github.com/eslint-stylistic/eslint-stylistic/issues/1124#issuecomment-3900849310

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
