### PR TITLE
fix(type-generic-spacing): handle space before generic in class expressions

### DIFF
--- a/packages/eslint-plugin/rules/type-generic-spacing/type-generic-spacing.test.ts
+++ b/packages/eslint-plugin/rules/type-generic-spacing/type-generic-spacing.test.ts
@@ -38,7 +38,8 @@ run<RuleOptions, MessageIds>({
       }
     `,
     `const toSortedImplementation = Array.prototype.toSorted || function <T>(name: T): void {}`,
-    `const foo = class <T> { value: T; }`,
+    `class Foo<T> {}`,
+    `const foo = class<T> {}`,
   ],
   invalid: ([
     ['const val: Set< string> = new Set()', 'const val: Set<string> = new Set()'],
@@ -82,6 +83,8 @@ run<RuleOptions, MessageIds>({
       'const toSortedImplementation = Array.prototype.toSorted || function <T>(name: T): void {}',
       2,
     ],
+    ['class Foo <T> {}', 'class Foo<T> {}', 1],
+    ['const foo = class <T> {}', 'const foo = class<T> {}', 1],
   ] as const)
     .map(i => ({
       code: i[0],

--- a/packages/eslint-plugin/rules/type-generic-spacing/type-generic-spacing.ts
+++ b/packages/eslint-plugin/rules/type-generic-spacing/type-generic-spacing.ts
@@ -17,10 +17,6 @@ const PRESERVE_PREFIX_SPACE_BEFORE_GENERIC = new Set<NodeTypes>([
   // handled by `space-unary-ops`
   'TSConstructorType',
   'FunctionExpression',
-  // const foo = class <T> {}
-  //                  ^
-  // handled by `keyword-spacing`
-  'ClassExpression',
 ])
 
 export default createRule<RuleOptions, MessageIds>({


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- If this PR contains unrelated changes, they should be in a separate commit/PR.
- If this PR changes documented rule defaults, confirm it does not conflict with the [FAQ](https://eslint.style/guide/faq#why-are-some-rule-defaults-different-from-documentation).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Before:

```ts
const foo = class <T> { value: T; } // ✅ No error
```

After:

```ts
const foo = class <T> { value: T; } // ❌ Error
// ↓ auto-fix
const foo = class<T> { value: T; }
```

### Linked Issues

Follow up to #1182. It is also a part of #1045

Related to #927.

### Additional context

This change also aligns with [Prettier](https://prettier.io/playground/#N4Igxg9gdgLgprEAucAbAhgZ0wAgGYQQA8AKgHzAC+AOlJFJjDujgLw5gbakU1QgAaEBAAOMAJbRMyUOgBOciAHcACvITSU6VEvQBPaUIBGc9GADWcGAGV0AWzgAZcVDjI82zHCEQjAKzgwGAB1UxFkEBE5OC85ADc3Y1MLK2sRMxcAc2QYOQBXbxAvO3Ec-MK4AA8RODlxB1htAHka0xgIORUITHEJaAiEABNBECrW+oQYbRJaqHlxGPdPQp6oTNQ4AEU8iHgl1C8hP0xK6yyN7d23JA8DwoBHHfgVRRFNECwAWlc4Qd+R3LocSoLIAYQgdjs6Ai2lQI1W6zgAEEYLlxEY8s9as5XPtDiAABYwOyoYIE3oxdJgODWDS9cRxXp6CJgbAjOIFACSUD+sGsYDqYiRPOsMD0GzxhSi3TgoXQ4RQURitQSIyGTTwOOuIFQeBGLliMBe6EyUMlQnScliETFNUwAvEYhGURcIXEgxgBOQAA4AAxCaKPcTRY2m6E3ZZCKZGYLuz3IABMQjyXhI6CMmlu+LgdiMvz+g0c6DWeRNcAAYh0oaisjDMRAQJRKEA).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the `type-generic-spacing` ESLint rule to enforce consistent spacing for generic class declarations and expressions, including class expressions with assigned identifiers.

* **Tests**
  * Expanded test coverage to validate spacing enforcement across generic class declaration and expression variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->