### PR TITLE
fix(indent-binary-ops): avoid chain continuation indent

### DIFF
--- a/packages/eslint-plugin/rules/indent-binary-ops/indent-binary-ops.test.ts
+++ b/packages/eslint-plugin/rules/indent-binary-ops/indent-binary-ops.test.ts
@@ -134,6 +134,16 @@ run<RuleOptions, MessageIds>({
         c()
       }
     `,
+    $`
+      const anchor = document.getElementById('anchor');
+      if (
+        (anchor && (anchor.getAttribute('href')
+                      ?.startsWith('#tab_name_')) === false)
+        && anchor.tabIndex === 0
+      ) {
+        console.log('test');
+      }
+    `,
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/rules/indent-binary-ops/indent-binary-ops.test.ts
+++ b/packages/eslint-plugin/rules/indent-binary-ops/indent-binary-ops.test.ts
@@ -144,6 +144,16 @@ run<RuleOptions, MessageIds>({
         console.log('test');
       }
     `,
+    $`
+      const elem = document.getElementById('elem');
+      if (
+        (elem && (elem.getAttribute('href')
+                    .toLowerCase()) === 'test')
+        && elem.tabIndex === 0
+      ) {
+        console.log('test');
+      }
+    `,
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/rules/indent-binary-ops/indent-binary-ops.ts
+++ b/packages/eslint-plugin/rules/indent-binary-ops/indent-binary-ops.ts
@@ -126,6 +126,8 @@ export default createRule<RuleOptions, MessageIds>({
       //   we bump the indentation level by one.
       const firstTokenOfLineLeft = firstTokenOfLine(tokenLeft.loc.start.line)
       const lastTokenOfLineLeft = lastTokenOfLine(tokenLeft.loc.start.line)
+      const hasMoreCloseParensOnLeftLine = lastTokenOfLineLeft?.value === ')' && isGreaterThanCloseBracketOfLine(tokenLeft.loc.start.line)
+      const isMemberChainCloseLine = hasMoreCloseParensOnLeftLine && ['.', '?.'].includes(firstTokenOfLineLeft?.value || '')
       const needAdditionIndent = false
         // First line is a keyword (but exclude `typeof`, `instanceof`, `this`)
         || (isKeywordToken(firstTokenOfLineLeft) && !['typeof', 'instanceof', 'this'].includes(firstTokenOfLineLeft.value))
@@ -141,12 +143,12 @@ export default createRule<RuleOptions, MessageIds>({
       const needSubtractionIndent = false
         // End of line is a closing bracket
         || (
-          lastTokenOfLineLeft?.value === ')'
-          && isGreaterThanCloseBracketOfLine(tokenLeft.loc.start.line)
+          hasMoreCloseParensOnLeftLine
           && ![']', ')', '}'].includes(firstTokenOfLineLeft?.value || '')
+          && !isMemberChainCloseLine
         )
 
-      const indentLeft = getIndentOfLine(tokenLeft.loc.start.line)
+      const indentLeft = getIndentOfLine(isMemberChainCloseLine ? node.loc.start.line : tokenLeft.loc.start.line)
       const indentRight = getIndentOfLine(tokenRight.loc.start.line)
       const indentTarget = getTargetIndent(indentLeft, needAdditionIndent, needSubtractionIndent)
 


### PR DESCRIPTION
## Summary

Fix `indent-binary-ops` so member/optional-chain continuation lines are not used as the indentation base for the following binary/logical continuation.

## What changed

- Added a regression test for an optional chain inside a grouped logical expression.
- Reused the expression start line indent when the left operand closes on a member-chain continuation line.

## Why

Issue #1209 reports a false positive where `&& anchor.tabIndex === 0` is autofixed to align with a deeply indented `?.startsWith(...)` continuation line.

## Testing

- `pnpm test indent-binary-ops --run`
- `pnpm run build`
- `pnpm run lint`
- `pnpm test --run`
- `pnpm run typecheck`
- `git diff --check`

Fixes #1209


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indentation handling for multi-line logical conditions with optional chaining and member-chain endings, preventing incorrect auto-fixes and preserving intended formatting. Impact: fewer false-positive lint fixes for these patterns.

* **Tests**
  * Added validation cases to ensure these multi-line optional-chaining/member-chain scenarios are recognized as correctly formatted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eslint-stylistic/eslint-stylistic/pull/1211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->