### PR TITLE
fix(indent): use first token of line instead of current token for indent width calculation

### DIFF
--- a/packages/eslint-plugin/rules/indent/indent._js_.test.ts
+++ b/packages/eslint-plugin/rules/indent/indent._js_.test.ts
@@ -658,6 +658,16 @@ run<RuleOptions, MessageIds>({
     },
     {
       code: $`
+        export const
+            CONST_1    = 1,
+            CONST_2    = 2,
+            CONST_3    = 3,
+            CONST_LAST = null;
+      `,
+      options: [4, { VariableDeclarator: 'first' }],
+    },
+    {
+      code: $`
         let foo = 1,
             bar =
             2

--- a/packages/eslint-plugin/rules/indent/indent.ts
+++ b/packages/eslint-plugin/rules/indent/indent.ts
@@ -1865,7 +1865,8 @@ export default createRule<RuleOptions, MessageIds>({
             )
 
             const firstTokenOfFirstElement = sourceCode.getFirstToken(node.declarations[0])!
-            const firstVariableIndentWidth = tokenInfo.getTokenIndent(firstTokenOfFirstElement).length - tokenInfo.getTokenIndent(firstToken).length
+            const firstTokenOfFirstTokenLine = tokenInfo.getFirstTokenOfLine(firstToken)!
+            const firstVariableIndentWidth = tokenInfo.getTokenIndent(firstTokenOfFirstElement).length - tokenInfo.getTokenIndent(firstTokenOfFirstTokenLine).length
 
             numericVariableIndent = indentSize === 0 ? 0 : firstVariableIndentWidth / indentSize
           }


### PR DESCRIPTION

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- If this PR contains unrelated changes, they should be in a separate commit/PR.
- If this PR changes documented rule defaults, confirm it does not conflict with the [FAQ](https://eslint.style/guide/faq#why-are-some-rule-defaults-different-from-documentation).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Fixes #1208
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed indentation calculation for multi-line variable declarations with the 'first' alignment option to correctly measure indent levels.

* **Tests**
  * Added test coverage for multi-declarator variable declarations with proper indentation validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eslint-stylistic/eslint-stylistic/pull/1215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->