### PR TITLE
fix(object-curly-spacing): correctly handle object patterns with type annotations

### DIFF
--- a/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing._ts_.test.ts
@@ -383,6 +383,10 @@ run<RuleOptions, MessageIds>({
       code: 'enum Foo { }',
       options: ['never', { emptyObjects: 'always' }],
     },
+    {
+      code: `type Foo = ({ changes }?: { changes?: unknown }) => void`,
+      options: ['always'],
+    },
   ],
 
   invalid: [

--- a/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing.ts
+++ b/packages/eslint-plugin/rules/object-curly-spacing/object-curly-spacing.ts
@@ -352,7 +352,7 @@ export default createRule<RuleOptions, MessageIds>({
           const allTokens = sourceCode.getTokens(node)
           const openingToken = allTokens.find(token => isOpeningBraceToken(token))!
           const closingToken = (node.type === 'ObjectPattern' && node.typeAnnotation)
-            ? sourceCode.getTokenBefore(node.typeAnnotation)!
+            ? sourceCode.getTokenBefore(node.typeAnnotation, isClosingBraceToken)!
             : allTokens.findLast(token => isClosingBraceToken(token))!
           return [openingToken, closingToken]
         }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- If this PR contains unrelated changes, they should be in a separate commit/PR.
- If this PR changes documented rule defaults, confirm it does not conflict with the [FAQ](https://eslint.style/guide/faq#why-are-some-rule-defaults-different-from-documentation).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Related: #1129

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Fixes #1214

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `object-curly-spacing` rule now correctly validates brace spacing in object patterns with type annotations.

* **Tests**
  * Added test coverage for object patterns with type annotations under spacing configuration options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eslint-stylistic/eslint-stylistic/pull/1218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->