### PR TITLE
fix(type-annotation-spacing): remake `overrides` options to avoid `key-spacing` conflict

### DIFF
--- a/packages/eslint-plugin/rules/type-annotation-spacing/README.md
+++ b/packages/eslint-plugin/rules/type-annotation-spacing/README.md
@@ -1,5 +1,7 @@
 ---
 description: Require consistent spacing around type annotations.
+related_rules:
+  - key-spacing
 ---
 
 # type-annotation-spacing
@@ -178,31 +180,22 @@ class Foo {
 
 ### overrides
 
-#### questionMark
+> [!TIP]
+>
+> Because for the [key-spacing](key-spacing) rule some alignment options require multiple spaces in properties of object literals and import attributes. You can set `property` to `"ignore"` to avoid the conflict.
 
-Controls spacing around the `?` token of an optional type annotation. The `before` option sets the space before `?`, and the `after` option sets the space between `?` and `:`. If unset, the existing `before`/`after` defaults are kept and a space between `?` and `:` is disallowed.
+Spacing overrides can be customized using the options listed below. Most options accept an object format, `{ before: true, after: false }`, to set precise formatting rules. The configuration can also be set to `"ignore"` to bypass rule enforcement, with the exception of the `colon` option.
 
-Examples of **correct** code for this rule with the `{ "overrides": { "questionMark": { "before": true, "after": true } } }` option:
-
-::: correct
-
-```ts
-/* eslint @stylistic/type-annotation-spacing: ["error", { "overrides": { "questionMark": { "before": true, "after": true } } }] */
-
-interface Example {
-    type ? : string;
-}
-
-function example(type ? : string): void {}
-```
-
-:::
+- `colon` (no support `"ignore"` value)
+- `variable`
+- `parameter`
+- `property`
+- `returnType`
+- `questionMark`
 
 #### colon
 
 Examples of **incorrect** code for this rule with the `{ "before": false, "after": false, "overrides": { "colon": { "before": true, "after": true } } }` option:
-
-<!--tabs-->
 
 ::: incorrect
 
@@ -250,6 +243,92 @@ class Foo {
 type Foo = {
     name: (name : string)=>string;
 }
+```
+
+:::
+
+#### property
+
+Examples of **incorrect** code for this rule with the `{ "before": false, "after": false, "overrides": { "property": { "before": true, "after": true } } }` option:
+
+::: incorrect
+
+```ts
+/* eslint @stylistic/type-annotation-spacing: ["error", { "before": false, "after": false, "overrides": { "property": { "before": true, "after": true } } }] */
+class Foo {
+    bar: string;
+    baz:string;
+    bat :string;
+}
+
+interface Foo {
+    bar: string;
+    baz:string;
+    bat :string;
+}
+```
+
+:::
+
+Examples of **correct** code for this rule with the `{ "before": false, "after": false, "overrides": { "property": { "before": true, "after": true } } }` option:
+
+::: correct
+
+```ts
+/* eslint @stylistic/type-annotation-spacing: ["error", { "before": false, "after": false, "overrides": { "property": { "before": true, "after": true } } }] */
+
+class Foo {
+    name : string;
+}
+
+interface Foo {
+    name : string;
+}
+
+type Foo = {
+    name : (name:string)=>string;
+}
+```
+
+:::
+
+Examples of **correct** code for this rule with the `{ "before": false, "after": false, "overrides": { "property": "ignore" } }` option. Where no property type spacing is changed so it won't conflict with `key-spacing` or any spacing rule:
+
+::: correct
+
+```ts
+/* eslint @stylistic/type-annotation-spacing: ["error", { "before": false, "after": false, "overrides": { "property": "ignore" } }] */
+class Foo {
+    bar: string;
+    baz:string;
+    bat :string;
+}
+
+interface Foo {
+    bar: string;
+    baz:string;
+    bat :string;
+}
+```
+
+:::
+
+#### questionMark
+
+Controls spacing around the `?` token of an optional type annotation. The `before` option sets the space before `?`, and the `after` option sets the space between `?` and `:`. If unset, the existing `before`/`after` defaults are kept and a space between `?` and `:` is disallowed.
+
+Examples of **correct** code for this rule with the `{ "overrides": { "questionMark": { "before": true, "after": true } } }` option:
+
+::: correct
+
+```ts
+/* eslint @stylistic/type-annotation-spacing: ["error", { "overrides": { "questionMark": { "before": true, "after": true } } }] */
+
+interface Example {
+    type ? : string;
+}
+
+function example(type ? : string): void {}
 ```
 
 :::

--- a/packages/eslint-plugin/rules/type-annotation-spacing/type-annotation-spacing.test.ts
+++ b/packages/eslint-plugin/rules/type-annotation-spacing/type-annotation-spacing.test.ts
@@ -787,6 +787,20 @@ run<RuleOptions, MessageIds>({
       options: [{ before: true }],
     },
     {
+      code: 'const foo :    string;',
+      options: [
+        {
+          overrides: {
+            colon: {
+              after: false,
+              before: true,
+            },
+            variable: 'ignore',
+          },
+        },
+      ],
+    },
+    {
       code: 'const foo:string;',
       options: [
         {
@@ -815,6 +829,25 @@ run<RuleOptions, MessageIds>({
             variable: {
               after: false,
             },
+          },
+        },
+      ],
+    },
+    {
+      code: $`
+        interface Foo {
+          name: string;
+          greet() :string;
+        }
+      `,
+      options: [
+        {
+          overrides: {
+            colon: {
+              after: false,
+              before: true,
+            },
+            property: 'ignore',
           },
         },
       ],
@@ -861,6 +894,20 @@ run<RuleOptions, MessageIds>({
       ],
     },
     {
+      code: 'function foo(name  :  string) {}',
+      options: [
+        {
+          overrides: {
+            colon: {
+              after: false,
+              before: true,
+            },
+            parameter: 'ignore',
+          },
+        },
+      ],
+    },
+    {
       code: 'function foo(name:string) {}',
       options: [
         {
@@ -889,6 +936,20 @@ run<RuleOptions, MessageIds>({
             parameter: {
               after: false,
             },
+          },
+        },
+      ],
+    },
+    {
+      code: 'function foo()  :  string {}',
+      options: [
+        {
+          overrides: {
+            colon: {
+              after: false,
+              before: true,
+            },
+            returnType: 'ignore',
           },
         },
       ],

--- a/packages/eslint-plugin/rules/type-annotation-spacing/type-annotation-spacing.ts
+++ b/packages/eslint-plugin/rules/type-annotation-spacing/type-annotation-spacing.ts
@@ -90,7 +90,7 @@ export default createRule<RuleOptions, MessageIds>({
             },
             additionalProperties: false,
           },
-          spacingConfigOrIgnore: {
+          spacingConfigWithIgnore: {
             oneOf: [
               {
                 type: 'string',
@@ -108,11 +108,11 @@ export default createRule<RuleOptions, MessageIds>({
             type: 'object',
             properties: {
               colon: { $ref: '#/items/0/$defs/spacingConfig' },
-              variable: { $ref: '#/items/0/$defs/spacingConfigOrIgnore' },
-              parameter: { $ref: '#/items/0/$defs/spacingConfigOrIgnore' },
-              property: { $ref: '#/items/0/$defs/spacingConfigOrIgnore' },
-              returnType: { $ref: '#/items/0/$defs/spacingConfigOrIgnore' },
-              questionMark: { $ref: '#/items/0/$defs/spacingConfigOrIgnore' },
+              variable: { $ref: '#/items/0/$defs/spacingConfigWithIgnore' },
+              parameter: { $ref: '#/items/0/$defs/spacingConfigWithIgnore' },
+              property: { $ref: '#/items/0/$defs/spacingConfigWithIgnore' },
+              returnType: { $ref: '#/items/0/$defs/spacingConfigWithIgnore' },
+              questionMark: { $ref: '#/items/0/$defs/spacingConfigWithIgnore' },
             },
             additionalProperties: false,
           },

--- a/packages/eslint-plugin/rules/type-annotation-spacing/type-annotation-spacing.ts
+++ b/packages/eslint-plugin/rules/type-annotation-spacing/type-annotation-spacing.ts
@@ -25,18 +25,18 @@ function createRules(options: TypeAnnotationSpacingSchema0 | undefined): Overrid
   }
   // questionMark governs spacing around the `?` in optional type annotations:
   // `before` is space before `?`, `after` is space between `?` and `:`. Defaults preserve current behavior.
-  const questionMark = {
+  const questionMark = override?.questionMark === 'ignore' ? 'ignore' : {
     before: colon.before,
     after: false,
-    ...override?.questionMark,
+    ...override.questionMark,
   }
 
   return {
     colon,
-    variable: { ...colon, ...override?.variable },
-    property: { ...colon, ...override?.property },
-    parameter: { ...colon, ...override?.parameter },
-    returnType: { ...colon, ...override?.returnType },
+    variable: override?.variable === 'ignore' ? 'ignore' : { ...colon, ...override.variable },
+    property: override?.property === 'ignore' ? 'ignore' : { ...colon, ...override.property },
+    parameter: override?.parameter === 'ignore' ? 'ignore' : { ...colon, ...override.parameter },
+    returnType: override?.returnType === 'ignore' ? 'ignore' : { ...colon, ...override.returnType },
     questionMark,
   }
 }
@@ -90,6 +90,15 @@ export default createRule<RuleOptions, MessageIds>({
             },
             additionalProperties: false,
           },
+          spacingConfigOrIgnore: {
+            oneOf: [
+              {
+                type: 'string',
+                enum: ['ignore'],
+              },
+              { $ref: '#/items/0/$defs/spacingConfig' },
+            ],
+          },
         },
         type: 'object',
         properties: {
@@ -99,11 +108,11 @@ export default createRule<RuleOptions, MessageIds>({
             type: 'object',
             properties: {
               colon: { $ref: '#/items/0/$defs/spacingConfig' },
-              variable: { $ref: '#/items/0/$defs/spacingConfig' },
-              parameter: { $ref: '#/items/0/$defs/spacingConfig' },
-              property: { $ref: '#/items/0/$defs/spacingConfig' },
-              returnType: { $ref: '#/items/0/$defs/spacingConfig' },
-              questionMark: { $ref: '#/items/0/$defs/spacingConfig' },
+              variable: { $ref: '#/items/0/$defs/spacingConfigOrIgnore' },
+              parameter: { $ref: '#/items/0/$defs/spacingConfigOrIgnore' },
+              property: { $ref: '#/items/0/$defs/spacingConfigOrIgnore' },
+              returnType: { $ref: '#/items/0/$defs/spacingConfigOrIgnore' },
+              questionMark: { $ref: '#/items/0/$defs/spacingConfigOrIgnore' },
             },
             additionalProperties: false,
           },
@@ -150,9 +159,14 @@ export default createRule<RuleOptions, MessageIds>({
       let punctuatorTokenStart = punctuatorTokenEnd
       let previousToken = sourceCode.getTokenBefore(punctuatorTokenEnd)!
 
-      let { before, after } = getRules(ruleSet, typeAnnotation)
+      const rule = getRules(ruleSet, typeAnnotation)
+      if (rule === 'ignore') {
+        /** ignore means do not report or fix the problem */
+        return void 0
+      }
+      let { before, after } = rule
 
-      if (previousToken.value === '?') {
+      if (previousToken.value === '?' && ruleSet.questionMark !== 'ignore') {
         const questionMark = ruleSet.questionMark
         const hasInnerSpace = sourceCode.isSpaceBetween(previousToken, punctuatorTokenStart)
         // space between ? and :

--- a/packages/eslint-plugin/rules/type-annotation-spacing/types.d.ts
+++ b/packages/eslint-plugin/rules/type-annotation-spacing/types.d.ts
@@ -1,17 +1,19 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: 0_8KE1pUa6UDFEIg9ElCoTaoCjKEyxP7H98oRPr91yY */
+/* @checksum: D-fY9SckJ9kkYgPeSHnbqrFRQdB9tFNbq_tqb_HYeR8 */
+
+export type SpacingConfigOrIgnore = 'ignore' | SpacingConfig
 
 export interface TypeAnnotationSpacingSchema0 {
   before?: boolean
   after?: boolean
   overrides?: {
     colon?: SpacingConfig
-    variable?: SpacingConfig
-    parameter?: SpacingConfig
-    property?: SpacingConfig
-    returnType?: SpacingConfig
-    questionMark?: SpacingConfig
+    variable?: SpacingConfigOrIgnore
+    parameter?: SpacingConfigOrIgnore
+    property?: SpacingConfigOrIgnore
+    returnType?: SpacingConfigOrIgnore
+    questionMark?: SpacingConfigOrIgnore
   }
 }
 export interface SpacingConfig {

--- a/packages/eslint-plugin/rules/type-annotation-spacing/types.d.ts
+++ b/packages/eslint-plugin/rules/type-annotation-spacing/types.d.ts
@@ -1,19 +1,21 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: D-fY9SckJ9kkYgPeSHnbqrFRQdB9tFNbq_tqb_HYeR8 */
+/* @checksum: pgv4yhnlgKghpHQCSxCVsAfXGeiptdo98NqHwAmDgMI */
 
-export type SpacingConfigOrIgnore = 'ignore' | SpacingConfig
+export type SpacingConfigWithIgnore
+  = | 'ignore'
+    | SpacingConfig
 
 export interface TypeAnnotationSpacingSchema0 {
   before?: boolean
   after?: boolean
   overrides?: {
     colon?: SpacingConfig
-    variable?: SpacingConfigOrIgnore
-    parameter?: SpacingConfigOrIgnore
-    property?: SpacingConfigOrIgnore
-    returnType?: SpacingConfigOrIgnore
-    questionMark?: SpacingConfigOrIgnore
+    variable?: SpacingConfigWithIgnore
+    parameter?: SpacingConfigWithIgnore
+    property?: SpacingConfigWithIgnore
+    returnType?: SpacingConfigWithIgnore
+    questionMark?: SpacingConfigWithIgnore
   }
 }
 export interface SpacingConfig {


### PR DESCRIPTION


<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- If this PR contains unrelated changes, they should be in a separate commit/PR.
- If this PR changes documented rule defaults, confirm it does not conflict with the [FAQ](https://eslint.style/guide/faq#why-are-some-rule-defaults-different-from-documentation).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

> [!WARNING]
> **TODO** This is a WIP PR because I'm still working on the test case. It could take a bit longer but after that everything will be ready. But the PR opens for review and suggestion.

### Description

This PR modify the behaviour of `overrides` option so the rule can ignore linting/formatting specific parts. This is made to avoid conflicting with other rule such as `key-spacing` rule. 

Here is the main change of the PR:

```ts
type SpacingConfigOrIgnore = 'ignore' | SpacingConfig

interface TypeAnnotationSpacingSchema0 {
  before?: boolean
  after?: boolean
  overrides?: {
    colon?: SpacingConfig
    variable?: SpacingConfigOrIgnore
    parameter?: SpacingConfigOrIgnore
    property?: SpacingConfigOrIgnore
    returnType?: SpacingConfigOrIgnore
    questionMark?: SpacingConfigOrIgnore
  }
}
```

So basically, aside `overrides.colon`, all the keys can be ignored. When the rule is **ignored**, the format will do nothing to change the code. Aside adding a new option for all the `overrides.*` keys, nothing is changed.

### Linked Issues

Resolves https://github.com/eslint-stylistic/eslint-stylistic/issues/1219

### Additional context

Pass all the available tests so I could somewhat say that there is no backward compatibility problem so far.

The PR was done with help of @9romise and my itchiness over the little conflict.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `'ignore'` option to type-annotation-spacing rule overrides, allowing users to skip spacing validation for specific annotation contexts (variables, parameters, properties, return types, and question marks).

* **Documentation**
  * Updated type-annotation-spacing rule documentation with expanded configuration examples and guidance on handling conflicts with related ESLint rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eslint-stylistic/eslint-stylistic/pull/1220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->