### PR TITLE
key-spacing: align parenthesized type values from the opening paren

### DIFF
--- a/packages/eslint-plugin/rules/key-spacing/key-spacing._ts_.test.ts
+++ b/packages/eslint-plugin/rules/key-spacing/key-spacing._ts_.test.ts
@@ -6,6 +6,17 @@ run<RuleOptions, MessageIds>({
   name: 'key-spacing',
   rule,
   valid: [
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/189
+    // a parenthesized type value aligns by its opening paren, not the inner type
+    {
+      code: $`
+        interface Foo {
+          bar: 123;
+          baz: (123);
+        }
+      `,
+      options: [{ align: 'value' }],
+    },
     // non-applicable
     {
       code: $`

--- a/packages/eslint-plugin/rules/key-spacing/key-spacing.ts
+++ b/packages/eslint-plugin/rules/key-spacing/key-spacing.ts
@@ -968,7 +968,11 @@ export default createRule<RuleOptions, MessageIds>({
 
         const { typeAnnotation } = node
         const toCheck
-          = align === 'colon' ? typeAnnotation : typeAnnotation.typeAnnotation
+          = align === 'colon'
+            ? typeAnnotation
+            // a parenthesized type starts at `(`; align by the first token after the
+            // colon rather than the inner type node, which sits past it (issue #189)
+            : sourceCode.getTokenAfter(sourceCode.getFirstToken(typeAnnotation)!)!
         const difference = adjustedColumn(toCheck.loc.start) - alignColumn
 
         if (difference) {


### PR DESCRIPTION
Problem I saw:
`key-spacing` could misalign TypeScript type annotations when value alignment was enabled.

A case like `baz: (123)` was measured from the type inside the parentheses instead of from the `(`, so the aligned value started one token too late. Thanks @seahindeniz for the report.

What I changed:
I changed the value-start lookup to use the first token after the colon.

That keeps parenthesized type values aligned from the opening paren, without changing the object-literal path.

How I checked it:
I confirmed the regression test failed before the rule change and passed after it.

I also ran the full `key-spacing` suite, which passed with 283 tests, plus typecheck and lint.

Closes #189

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed alignment behavior for parenthesized type annotations in the key-spacing rule. Alignment now correctly uses the opening parenthesis as the reference point instead of the inner type content.

* **Tests**
  * Added test case to verify correct alignment handling of parenthesized type annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->