### PR TITLE
fix(multiline-comment-style): Ignore TypeScript directive comments

### DIFF
--- a/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style.test.ts
+++ b/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style.test.ts
@@ -420,6 +420,26 @@ run<RuleOptions, MessageIds>({
       `,
       options: ['starred-block'],
     },
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/917
+    // TypeScript directive comments must be left untouched so they keep applying
+    // to the code below them, instead of being merged into a block comment.
+    {
+      code: $`
+        // @ts-expect-error TS(2322) some message
+        foo();
+      `,
+      options: ['starred-block'],
+    },
+    {
+      code: $`
+        // @ts-ignore
+        // @ts-expect-error
+        // @ts-nocheck
+        // @ts-check
+        foo();
+      `,
+      options: ['starred-block'],
+    },
     {
       code: $`
         let x = 5; // first number
@@ -1616,6 +1636,73 @@ ${'                   '}
         { messageId: 'missingStar', line: 5 },
         { messageId: 'alignment', line: 6 },
       ],
+    },
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/917
+    // A trailing TypeScript directive must not be pulled into the block comment;
+    // only the preceding line comments are merged.
+    {
+      code: $`
+        // This is
+        // a multiline comment
+        // @ts-expect-error TS(2322) some message
+        foo();
+      `,
+      output: $`
+        /*
+         * This is
+         * a multiline comment
+         */
+        // @ts-expect-error TS(2322) some message
+        foo();
+      `,
+      options: ['starred-block'],
+      errors: [{ messageId: 'expectedBlock', line: 1 }],
+    },
+    // A directive written with a colon (e.g. `@ts-expect-error: reason`) is still a
+    // directive and must not be merged into the block comment.
+    {
+      code: $`
+        // This is
+        // a multiline comment
+        // @ts-expect-error: TS(2322) some message
+        foo();
+      `,
+      output: $`
+        /*
+         * This is
+         * a multiline comment
+         */
+        // @ts-expect-error: TS(2322) some message
+        foo();
+      `,
+      options: ['starred-block'],
+      errors: [{ messageId: 'expectedBlock', line: 1 }],
+    },
+    // A TypeScript directive in the middle splits the surrounding line comments
+    // into two groups and is itself left untouched.
+    {
+      code: $`
+        // Top A
+        // Top B
+        // @ts-ignore some message
+        // Bottom A
+        // Bottom B
+        foo();
+      `,
+      output: $`
+        /*
+         * Top A
+         * Top B
+         */
+        // @ts-ignore some message
+        /*
+         * Bottom A
+         * Bottom B
+         */
+        foo();
+      `,
+      options: ['starred-block'],
+      errors: [{ messageId: 'expectedBlock', line: 1 }, { messageId: 'expectedBlock', line: 4 }],
     },
   ],
 })

--- a/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style.ts
+++ b/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style.ts
@@ -8,6 +8,11 @@ import type { MessageIds, RuleOptions } from './types'
 import { COMMENTS_IGNORE_PATTERN, isHashbangComment, isSingleLine, isTokenOnSameLine, isWhiteSpaces, LINEBREAK_MATCHER, WHITE_SPACES_PATTERN } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
+// TypeScript directive comments (e.g. `// @ts-expect-error`). Merging these into a
+// block comment or with neighboring comments would stop them from being recognized
+// by the TypeScript compiler, so they are treated like other ignored comments.
+const TS_DIRECTIVE_PATTERN = /^\s*@ts-(?:expect-error|ignore|nocheck|check)(?![\w-])/u
+
 export default createRule<RuleOptions, MessageIds>({
   name: 'multiline-comment-style',
   meta: {
@@ -455,7 +460,7 @@ export default createRule<RuleOptions, MessageIds>({
       Program() {
         return sourceCode.getAllComments()
           .filter((comment) => {
-            if (isHashbangComment(comment) || COMMENTS_IGNORE_PATTERN.test(comment.value))
+            if (isHashbangComment(comment) || COMMENTS_IGNORE_PATTERN.test(comment.value) || TS_DIRECTIVE_PATTERN.test(comment.value))
               return false
 
             const tokenBefore = sourceCode.getTokenBefore(comment, { includeComments: true })


### PR DESCRIPTION
`multiline-comment-style` could rewrite TypeScript directive line comments into block comments, which breaks directives like `@ts-expect-error` because TypeScript no longer applies them to the following line.
This keeps `@ts-expect-error`, `@ts-ignore`, `@ts-nocheck`, and `@ts-check` comments out of this rule's multiline-comment conversion path. I checked it with the focused rule test passing 130 tests, changed-file ESLint, typecheck, the full unit run passing 18,366 tests, fixtures, build, and diff checks.
Fixes #917


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the `multiline-comment-style` rule to properly handle TypeScript directive comments (`@ts-expect-error`, `@ts-ignore`, `@ts-nocheck`, `@ts-check`), preventing incorrect merging or modification of these directives.

* **Tests**
  * Added test cases for TypeScript directive comment handling in the `multiline-comment-style` rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->