### PR TITLE
docs: Mention in an example that it resolves a conflict between `no-extra-parens` and `no-confusing-arrow`

### DIFF
--- a/packages/eslint-plugin/rules/no-extra-parens/README.md
+++ b/packages/eslint-plugin/rules/no-extra-parens/README.md
@@ -444,7 +444,7 @@ const fruits = {
 
 #### ignoredNodes
 
-The following configuration ignores `ConditionalExpression` in `ArrowFunctionExpression` nodes like [`enforceForArrowConditionals`](#enforceforarrowconditionals-deprecated):
+The following configuration resolves the conflict against 'no-confusing-arrow' by ignoring `ConditionalExpression` in `ArrowFunctionExpression` nodes like [`enforceForArrowConditionals`](#enforceforarrowconditionals-deprecated):
 
 Examples of **correct** code for this rule with the `"all", { "ignoredNodes": ["ArrowFunctionExpression[body.type=ConditionalExpression]"] }` option:
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- If this PR contains unrelated changes, they should be in a separate commit/PR.
- If this PR changes documented rule defaults, confirm it does not conflict with the [FAQ](https://eslint.style/guide/faq#why-are-some-rule-defaults-different-from-documentation).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
`no-extra-parens` and `no-confusing-arrow` conflicts on that example,
```ts
const b = a => 1 ? 2 : 3; // prohibited by no-confusing-arrow
const d = c => (1 ? 2 : 3); // prohibited by no-extra-parens
```
and I think this conflict should be documented.

### Additional context
`no-confusing-arrow` might be linked, but I don't know the best way to do it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for the `no-extra-parens` rule configuration to better explain the behavior and conflict resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->