### PR TITLE
fix(rest-spread-spacing): preserve comments in autofix

### DIFF
--- a/packages/eslint-plugin/rules/rest-spread-spacing/rest-spread-spacing.test.ts
+++ b/packages/eslint-plugin/rules/rest-spread-spacing/rest-spread-spacing.test.ts
@@ -1,8 +1,3 @@
-/**
- * @fileoverview Enforce spacing between rest and spread operators and their expressions.
- * @author Kai Cataldo
- */
-
 import type { MessageIds, RuleOptions } from './types'
 import { run } from '#test'
 import rule from './rest-spread-spacing'
@@ -42,6 +37,11 @@ run<RuleOptions, MessageIds>({
     { code: 'let { x, y, ... z } = { x: 1, y: 2, a: 3, b: 4 };', options: ['always'], parserOptions: { ecmaVersion: 2018 } },
     { code: 'let { x, y, ...\tz } = { x: 1, y: 2, a: 3, b: 4 };', options: ['always'], parserOptions: { ecmaVersion: 2018 } },
     { code: 'let { x, y, ...\nz } = { x: 1, y: 2, a: 3, b: 4 };', options: ['always'], parserOptions: { ecmaVersion: 2018 } },
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/1230
+    '[.../** @type {string} */ (expr)]',
+    '[.../* comment1 */ /* comment2 */ (expr)]',
+    { code: '[... /** @type {string} */ (expr)]', options: ['always'] },
+    { code: '[... /* a */ /* b */ (expr)]', options: ['always'] },
   ],
 
   invalid: [
@@ -701,6 +701,25 @@ run<RuleOptions, MessageIds>({
         endColumn: 16,
         messageId: 'expectedWhitespace',
         data: { type: 'rest property' },
+      }],
+    },
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/1230
+    {
+      code: '[... /** @type {string} */ (expr)]',
+      output: '[.../** @type {string} */ (expr)]',
+      options: ['never'],
+      errors: [{
+        messageId: 'unexpectedWhitespace',
+        data: { type: 'spread' },
+      }],
+    },
+    {
+      code: '[.../** @type {string} */ (expr)]',
+      output: '[... /** @type {string} */ (expr)]',
+      options: ['always'],
+      errors: [{
+        messageId: 'expectedWhitespace',
+        data: { type: 'spread' },
       }],
     },
   ],

--- a/packages/eslint-plugin/rules/rest-spread-spacing/rest-spread-spacing.ts
+++ b/packages/eslint-plugin/rules/rest-spread-spacing/rest-spread-spacing.ts
@@ -41,7 +41,7 @@ export default createRule<RuleOptions, MessageIds>({
         | Tree.RestElement,
     ) {
       const operator = sourceCode.getFirstToken(node)!
-      const nextToken = sourceCode.getTokenAfter(operator)!
+      const nextToken = sourceCode.getTokenAfter(operator, { includeComments: true })!
       const hasWhitespace = sourceCode.isSpaceBetween(operator, nextToken)
       let type
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- If this PR contains unrelated changes, they should be in a separate commit/PR.
- If this PR changes documented rule defaults, confirm it does not conflict with the [FAQ](https://eslint.style/guide/faq#why-are-some-rule-defaults-different-from-documentation).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Resolves #1230

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spacing checks around rest/spread syntax when comments appear between the operator and the next item.
  * Fixed rule behavior so it reports and auto-fixes whitespace more consistently in these cases.
  * Expanded coverage for additional comment-heavy spacing scenarios to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->