### PR TITLE
fix(keyword-spacing): preserve comments in autofix

### DIFF
--- a/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._js_.test.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing._js_.test.ts
@@ -614,6 +614,10 @@ run<RuleOptions, MessageIds>({
     'if (a);else;',
     { code: 'if(a); else ;', options: [NEITHER] },
 
+    // preserve comments between keyword and neighbor in NEITHER mode (sibling of #1231)
+    { code: 'if(a) {} /* comment */ else{}', options: [NEITHER] },
+    { code: 'if(a) {}else /* comment */ {}', options: [NEITHER] },
+
     // ----------------------------------------------------------------------
     // export
     // ----------------------------------------------------------------------

--- a/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing.ts
+++ b/packages/eslint-plugin/rules/keyword-spacing/keyword-spacing.ts
@@ -112,7 +112,7 @@ export default createRule<RuleOptions, MessageIds>({
      * @param pattern A pattern of the previous token to check.
      */
     function unexpectSpaceBefore(token: Token, pattern: RegExp) {
-      const prevToken = sourceCode.getTokenBefore(token)
+      const prevToken = sourceCode.getTokenBefore(token, { includeComments: true })
 
       if (prevToken
         && (CHECK_TYPE.test(prevToken.type) || pattern.test(prevToken.value))
@@ -166,7 +166,7 @@ export default createRule<RuleOptions, MessageIds>({
      * @param pattern A pattern of the next token to check.
      */
     function unexpectSpaceAfter(token: Token, pattern: RegExp) {
-      const nextToken = sourceCode.getTokenAfter(token)
+      const nextToken = sourceCode.getTokenAfter(token, { includeComments: true })
 
       if (nextToken
         && (CHECK_TYPE.test(nextToken.type) || pattern.test(nextToken.value))


### PR DESCRIPTION
### Description

`unexpectSpaceBefore` and `unexpectSpaceAfter` call `getTokenBefore`/`getTokenAfter` **without** `{ includeComments: true }`. This causes the returned token to skip over any comment sitting between the keyword and its neighbor. The `removeRange` fixer then spans from that skipped (code) token all the way to the keyword — deleting the comment along the way.

**Example (before fix):**
```js
// options: [{ before: false, after: false }]
if(a) {} /* comment */ else{}
//       ^^^^^^^^^^^^^^ autofix deletes this comment
```

**Fix:** add `{ includeComments: true }` to both `getTokenBefore` in `unexpectSpaceBefore` (line 115) and `getTokenAfter` in `unexpectSpaceAfter` (line 169). When the immediately adjacent token is a comment, its type (`Block`/`Line`) and value fail the `CHECK_TYPE`/pattern guard, so the report is suppressed and the comment is preserved.

This is the sibling of #1231 which applied the same fix to `rest-spread-spacing`.

### Linked Issues

Sibling of #1231 (`rest-spread-spacing` same pattern).

### Test cases added

Two `valid` entries in `keyword-spacing._js_.test.ts` covering both sides (comment before `else`, comment after `else`) under `NEITHER` mode — these cases triggered errors before this fix and pass cleanly after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated keyword-spacing behavior to correctly account for comments when checking spacing around `if`/`else`, preventing inaccurate reports and fixes.
  * Ensured comment placement is preserved when using the “no space” (`NEITHER`) spacing mode.
* **Tests**
  * Added new test coverage for valid comment placements between `if` blocks and `else`, and immediately around `else`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->