### PR TITLE
fix(generator-star-spacing): preserve comments in autofix

### DIFF
--- a/packages/eslint-plugin/rules/generator-star-spacing/generator-star-spacing.test.ts
+++ b/packages/eslint-plugin/rules/generator-star-spacing/generator-star-spacing.test.ts
@@ -480,6 +480,10 @@ run<RuleOptions, MessageIds>({
       code: '(class {async foo() { }})',
       parserOptions: { ecmaVersion: 8 },
     },
+
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/1230
+    'function */* c */foo(){}',
+    { code: 'function/* c */*foo(){}', options: [{ before: false, after: false }] },
   ],
 
   invalid: [
@@ -1021,6 +1025,19 @@ run<RuleOptions, MessageIds>({
       output: 'class Foo { static async * foo(){} }',
       options: [{ before: true, after: true }],
       errors: [missingBeforeError, missingAfterError],
+    },
+
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/1230
+    {
+      code: 'function * /* c */foo(){}',
+      output: 'function */* c */foo(){}',
+      errors: [unexpectedAfterError],
+    },
+    {
+      code: 'function/* c */ *foo(){}',
+      output: 'function/* c */*foo(){}',
+      options: [{ before: false, after: false }],
+      errors: [unexpectedBeforeError],
     },
 
   ],

--- a/packages/eslint-plugin/rules/generator-star-spacing/generator-star-spacing.ts
+++ b/packages/eslint-plugin/rules/generator-star-spacing/generator-star-spacing.ts
@@ -178,8 +178,8 @@ export default createRule<RuleOptions, MessageIds>({
         return
 
       const starToken = getStarToken(node)!
-      const prevToken = sourceCode.getTokenBefore(starToken)!
-      const nextToken = sourceCode.getTokenAfter(starToken)!
+      const prevToken = sourceCode.getTokenBefore(starToken, { includeComments: true })!
+      const nextToken = sourceCode.getTokenAfter(starToken, { includeComments: true })!
 
       let kind: keyof typeof modes = 'named'
 


### PR DESCRIPTION
### Description

`checkFunction` reads the tokens around the generator `*` with `getTokenBefore`/`getTokenAfter` **without** `{ includeComments: true }`, so a comment between `function`/`*`/the identifier is skipped. The `removeRange` fixer then spans from that skipped code token to the star, deleting the comment.

**Example (before fix, default options):**

```js
function */* c */foo(){}
//       ^^^^^^^^^ reported as `unexpectedAfter` and autofixed to `function *foo(){}` — the comment is lost
```

The same happens on the `before` side when a comment sits between the preceding keyword and the star.

**Fix:** add `{ includeComments: true }` to the `getTokenBefore`/`getTokenAfter` calls in `checkFunction`. When the immediately adjacent token is a comment, the spacing check measures the gap up to the comment rather than past it, so the fix only touches the whitespace next to the star and the comment is preserved.

This is the sibling of #1231 (`rest-spread-spacing`) and #1232 (`keyword-spacing`), which apply the same fix.

### Tests added

Two `valid` and two `invalid` cases in `generator-star-spacing.test.ts` covering both the before and after sides. They fail on `main` (the comment is deleted) and pass with this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generator star spacing checks so comments around `function*` declarations are handled more consistently.
  * Added coverage for cases with block comments between the generator star and function name.
  * Autofix behavior now reports and corrects spacing more accurately for commented generator syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->