### PR TITLE
fix(indent): indent type value on new line in type annotations

### DIFF
--- a/packages/eslint-plugin/rules/indent/indent._ts_.test.ts
+++ b/packages/eslint-plugin/rules/indent/indent._ts_.test.ts
@@ -899,6 +899,38 @@ run<RuleOptions, MessageIds>({
     ...individualNodeTests.invalid!,
     {
       code: $`
+        function foo(
+          a:
+          number
+        ) {
+          
+        }
+      `,
+      output: $`
+        function foo(
+          a:
+            number
+        ) {
+          
+        }
+      `,
+      options: [2],
+      errors: [
+        {
+          messageId: 'wrongIndentation',
+          column: 1,
+          endColumn: 3,
+          endLine: 3,
+          line: 3,
+          data: {
+            expected: '4 spaces',
+            actual: 2,
+          },
+        },
+      ],
+    },
+    {
+      code: $`
         type Foo = {
         bar : string,
         age : number,

--- a/packages/eslint-plugin/rules/indent/indent.ts
+++ b/packages/eslint-plugin/rules/indent/indent.ts
@@ -2045,6 +2045,16 @@ export default createRule<RuleOptions, MessageIds>({
         checkMemberExpression(node, node.object, node.property)
       },
 
+      TSTypeAnnotation(node) {
+        // handled by FunctionDeclaration.returnType, FunctionExpression.returnType
+        if (node.parent.type === 'FunctionDeclaration' || node.parent.type === 'FunctionExpression')
+          return
+
+        const colon = sourceCode.getFirstToken(node)!
+        const right = sourceCode.getTokenAfter(colon)!
+        offsets.setDesiredOffset(right, colon, 1)
+      },
+
       TSTypeAliasDeclaration(node) {
         const operator = sourceCode.getTokenBefore(node.typeAnnotation, isNotOpeningParenToken)!
         checkAssignmentOperator(operator)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- If this PR contains unrelated changes, they should be in a separate commit/PR.
- If this PR changes documented rule defaults, confirm it does not conflict with the [FAQ](https://eslint.style/guide/faq#why-are-some-rule-defaults-different-from-documentation).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When a `TSTypeAnnotation`'s type is on a different line than the colon (e.g. parameter type on the next line), the type value was not indented relative to the colon.
Exclude function return types since those are already handled by `returnType` visitors in #884.

### Linked Issues

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indentation handling for multiline type annotations, especially in function parameters.
  * Fixed a case where the type portion after a colon could be indented incorrectly, helping the formatter produce more consistent results.
  * Added coverage for this indentation scenario to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->