### PR TITLE
fix(multiline-ternary): ignore nested conditional expressions when ignoreJSX option is set

### DIFF
--- a/packages/eslint-plugin/rules/multiline-ternary/multiline-ternary.test.ts
+++ b/packages/eslint-plugin/rules/multiline-ternary/multiline-ternary.test.ts
@@ -48,6 +48,15 @@ run<RuleOptions, MessageIds>({
       options: ['always', { ignoreJSX: true }],
       parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } },
     },
+    {
+      code: $`
+        <>
+          {a ? <div /> : b ? <div /> : null}
+        </>
+      `,
+      options: ['always', { ignoreJSX: true }],
+      parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } },
+    },
 
     // "always-multiline"
     { code: 'a\n? b\n: c', options: ['always-multiline'] },
@@ -94,6 +103,16 @@ run<RuleOptions, MessageIds>({
       options: ['always-multiline', { ignoreJSX: true }],
       parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } },
     },
+    {
+      code: $`
+        <>
+          {a ? <div /> : b ?
+            <div /> : null}
+        </>
+      `,
+      options: ['always-multiline', { ignoreJSX: true }],
+      parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } },
+    },
 
     // "never"
     { code: 'a ? b : c', options: ['never'] },
@@ -125,6 +144,17 @@ run<RuleOptions, MessageIds>({
           {a 
             ? <div /> 
             : <div />}
+        </>
+      `,
+      options: ['never', { ignoreJSX: true }],
+      parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } },
+    },
+    {
+      code: $`
+        <>
+          {a ? <div /> : b
+            ? <div />
+            : null}
         </>
       `,
       options: ['never', { ignoreJSX: true }],

--- a/packages/eslint-plugin/rules/multiline-ternary/multiline-ternary.ts
+++ b/packages/eslint-plugin/rules/multiline-ternary/multiline-ternary.ts
@@ -64,9 +64,14 @@ export default createRule<RuleOptions, MessageIds>({
         const hasComments = !!sourceCode.getCommentsInside(node).length
 
         if (ignoreJSX) {
-          if (node.parent.type === 'JSXElement'
-            || node.parent.type === 'JSXFragment'
-            || node.parent.type === 'JSXExpressionContainer') {
+          let parent = node.parent
+
+          while (parent.type === 'ConditionalExpression')
+            parent = parent.parent
+
+          if (parent.type === 'JSXElement'
+            || parent.type === 'JSXFragment'
+            || parent.type === 'JSXExpressionContainer') {
             return null
           }
         }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- If this PR contains unrelated changes, they should be in a separate commit/PR.
- If this PR changes documented rule defaults, confirm it does not conflict with the [FAQ](https://eslint.style/guide/faq#why-are-some-rule-defaults-different-from-documentation).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixes false positives for nested conditional expressions with ignoreJSX, for example:

<img width="692" height="320" alt="image" src="https://github.com/user-attachments/assets/a7a957d6-6d48-47da-a702-f7f17130b007" />
