### PR TITLE
feat(space-infix-ops): add ignoreOperators option

### DIFF
--- a/packages/eslint-plugin/rules/space-infix-ops/README.md
+++ b/packages/eslint-plugin/rules/space-infix-ops/README.md
@@ -26,7 +26,7 @@ This rule is aimed at ensuring there are spaces around infix operators.
 This rule accepts a single options argument with the following defaults:
 
 ```json
-"space-infix-ops": ["error", { "int32Hint": false }]
+"space-infix-ops": ["error", { "int32Hint": false, "ignoreOperators": [], "ignoreTypes": false }]
 ```
 
 ### `int32Hint`
@@ -86,6 +86,16 @@ type Foo<T = true> = T
 ```
 
 :::
+
+### `ignoreOperators`
+
+Set the `ignoreOperators` option to a list of operators that should not require surrounding spaces. Operators are matched by their exact text, so ignoring `+` does not ignore `+=`.
+
+```json
+"space-infix-ops": ["error", { "ignoreOperators": ["*", "/", "^"] }]
+```
+
+With this configuration, `a^b + c*d + e/f` is valid while `+` is still checked.
 
 ### `ignoreTypes`
 

--- a/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops._js_.test.ts
+++ b/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops._js_.test.ts
@@ -35,6 +35,14 @@ run<RuleOptions, MessageIds>({
     { code: 'a ** b', parserOptions: { ecmaVersion: 7 } },
     { code: 'a|0', options: [{ int32Hint: true }] },
     { code: 'a |0', options: [{ int32Hint: true }] },
+    { code: 'a^b + c*d + e/f', options: [{ ignoreOperators: ['*', '/', '^'] }] },
+    { code: 'a+b', options: [{ ignoreOperators: ['+'] }] },
+    { code: 'a+=b', options: [{ ignoreOperators: ['+='] }] },
+    { code: 'a&&b', options: [{ ignoreOperators: ['&&'] }] },
+    { code: 'a?b:c', options: [{ ignoreOperators: ['?', ':'] }] },
+    { code: 'var a=b', options: [{ ignoreOperators: ['='] }] },
+    { code: 'a|0', options: [{ int32Hint: true, ignoreOperators: [] }] },
+    { code: 'a|0', options: [{ int32Hint: false, ignoreOperators: ['|'] }] },
 
     // Type Annotations
     { code: 'function foo(a: number = 0) { }', parser: tsParser, parserOptions: { ecmaVersion: 6 } },
@@ -58,6 +66,30 @@ run<RuleOptions, MessageIds>({
     { code: 'class C { #a = b; }', parserOptions: { ecmaVersion: 2022 } },
   ],
   invalid: [
+    {
+      code: 'a^b+c',
+      output: 'a^b + c',
+      options: [{ ignoreOperators: ['*', '/', '^'] }],
+      errors: [{
+        messageId: 'missingSpace',
+        data: { operator: '+' },
+        line: 1,
+        column: 4,
+        endColumn: 5,
+      }],
+    },
+    {
+      code: 'a+=b',
+      output: 'a += b',
+      options: [{ ignoreOperators: ['+'] }],
+      errors: [{
+        messageId: 'missingSpace',
+        data: { operator: '+=' },
+        line: 1,
+        column: 2,
+        endColumn: 4,
+      }],
+    },
     {
       code: 'a+b',
       output: 'a + b',

--- a/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops._ts_.test.ts
+++ b/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops._ts_.test.ts
@@ -423,6 +423,26 @@ run<RuleOptions, MessageIds>({
       }],
     },
     {
+      code: 'type Test = string|number;',
+      options: [{
+        ignoreOperators: ['|'],
+        ignoreTypes: false,
+      }],
+    },
+    {
+      code: 'type Test = string&number;',
+      options: [{
+        ignoreOperators: ['&'],
+        ignoreTypes: false,
+      }],
+    },
+    {
+      code: 'type Test<T> = T extends boolean?true:false',
+      options: [{
+        ignoreOperators: ['?', ':'],
+      }],
+    },
+    {
       code: `
         interface IFoo {
           id: string&number;
@@ -2456,6 +2476,17 @@ run<RuleOptions, MessageIds>({
       errors: [
         { messageId: 'missingSpace', line: 1, column: 36 },
         { messageId: 'missingSpace', line: 1, column: 43 },
+      ],
+    },
+    {
+      code: `type Test = string|number&boolean;`,
+      output: `type Test = string|number & boolean;`,
+      options: [{
+        ignoreOperators: ['|'],
+        ignoreTypes: false,
+      }],
+      errors: [
+        { messageId: 'missingSpace', line: 1, column: 26 },
       ],
     },
   ],

--- a/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops.ts
+++ b/packages/eslint-plugin/rules/space-infix-ops/space-infix-ops.ts
@@ -20,6 +20,13 @@ export default createRule<RuleOptions, MessageIds>({
           int32Hint: {
             type: 'boolean',
           },
+          ignoreOperators: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+            uniqueItems: true,
+          },
           ignoreTypes: {
             type: 'boolean',
           },
@@ -30,6 +37,7 @@ export default createRule<RuleOptions, MessageIds>({
     defaultOptions: [
       {
         int32Hint: false,
+        ignoreOperators: [],
         ignoreTypes: false,
       },
     ],
@@ -38,7 +46,8 @@ export default createRule<RuleOptions, MessageIds>({
     },
   },
   create(context, [options]) {
-    const { int32Hint, ignoreTypes } = options!
+    const { int32Hint, ignoreOperators, ignoreTypes } = options!
+    const ignoredOperators = new Set(ignoreOperators)
 
     const sourceCode = context.sourceCode
 
@@ -107,10 +116,16 @@ export default createRule<RuleOptions, MessageIds>({
 
       const nonSpacedNode = getFirstNonSpacedToken(leftNode, rightNode, operator)
 
-      if (nonSpacedNode) {
-        if (!(int32Hint && sourceCode.getText(node).endsWith('|0')))
-          report(node, nonSpacedNode)
-      }
+      if (!nonSpacedNode)
+        return
+
+      if (int32Hint && sourceCode.getText(node).endsWith('|0'))
+        return
+
+      if (ignoredOperators.has(operator))
+        return
+
+      report(node, nonSpacedNode)
     }
 
     function isSpaceChar(token: Token): boolean {
@@ -130,6 +145,9 @@ export default createRule<RuleOptions, MessageIds>({
         rightNode,
         isSpaceChar,
       )!
+
+      if (ignoredOperators.has(operator.value))
+        return
 
       const prev = sourceCode.getTokenBefore(operator)!
       const next = sourceCode.getTokenAfter(operator)!
@@ -176,7 +194,12 @@ export default createRule<RuleOptions, MessageIds>({
           skipFunctionParenthesis,
         )
 
-        if (!ignoreTypes && operator != null && UNIONS.includes(operator.value)) {
+        if (
+          !ignoreTypes
+          && operator != null
+          && UNIONS.includes(operator.value)
+          && !ignoredOperators.has(operator.value)
+        ) {
           const prev = sourceCode.getTokenBefore(operator)
           const next = sourceCode.getTokenAfter(operator)
 

--- a/packages/eslint-plugin/rules/space-infix-ops/types.d.ts
+++ b/packages/eslint-plugin/rules/space-infix-ops/types.d.ts
@@ -1,9 +1,10 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: NsKkSXq3JrP0tE3E8uHASkNUd6prbB2Gi1wGa4oDmgE */
+/* @checksum: 1tBk9eazuWObtClYGd27BeoPht-GOHqh1B--IiASciw */
 
 export interface SpaceInfixOpsSchema0 {
   int32Hint?: boolean
+  ignoreOperators?: string[]
   ignoreTypes?: boolean
 }
 


### PR DESCRIPTION
Implements the boundary from [#780 (comment)](https://github.com/eslint-stylistic/eslint-stylistic/issues/780#issuecomment-5023643947): `ignoreOperators` is an exact-match `string[]` (default `[]`) applied at all three of the rule's report paths — binary/assignment/logical, the shared `=`/`?`/`:` punctuator helper, and TS union/intersection. Worth noting the reach: a listed `=` covers declarators, class fields, enum members, and type-alias/parameter defaults, and `?`/`:` span both ternaries and conditional types, matched per punctuator. `int32Hint` keeps precedence (its guard runs first; both directions test-locked) and `ignoreTypes` is untouched. Exact text matching means ignoring `+` does not ignore `+=`. With the option absent, behavior is unchanged.

Your `a^b + c*d + e/f` example is a test case, plus the invalid twin (`a^b+c` fixes only the `+`). 14 new cases across the JS/TS suites; `types.d.ts` regenerated via `pnpm run update`; full suite 18,395 green plus Node 20 and ESLint 9 legs.

Closes #780


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an `ignoreOperators` option to the `space-infix-ops` lint rule.
  - Operators listed in this option are excluded from spacing checks, including binary, assignment, union, intersection, and conditional-type operators.
  - Updated rule configuration documentation with examples and defaults.

- **Bug Fixes**
  - Ensured non-ignored operators continue to be reported and automatically fixed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->