### PR TITLE
docs(max-len): document conflict with layout fixers

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -81,3 +81,13 @@ Also refer to [Migration Guide](/guide/migration#when-should-i-migrate).
 Rule docs show each rule's **native defaults** — how they behave without any configuration. However, our [`recommended`](/guide/config-presets#static-configurations) preset intentionally overrides some defaults for consistency. Use the [`all`](/guide/config-presets#enable-all-available-rules) preset if you want all native defaults.
 
 You can use [`@eslint/config-inspector`](https://github.com/eslint/config-inspector) to visualize your actual resolved configuration.
+
+## `max-len` and layout fixers conflict after `--fix`
+
+### What happens
+
+Layout rules with fixers collapse or expand whitespace during `--fix` without checking the resulting line length. Combined with `max-len`, `--fix` can introduce errors that can't be auto-recovered.
+
+### Why this happens
+
+**This is not a bug in any individual rule.** It's a structural limitation: ESLint fixers operate independently and have no mechanism to check width constraints. And this plugin does not add — and does not plan to add — width-awareness to layout fixers.

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -81,18 +81,3 @@ Also refer to [Migration Guide](/guide/migration#when-should-i-migrate).
 Rule docs show each rule's **native defaults** — how they behave without any configuration. However, our [`recommended`](/guide/config-presets#static-configurations) preset intentionally overrides some defaults for consistency. Use the [`all`](/guide/config-presets#enable-all-available-rules) preset if you want all native defaults.
 
 You can use [`@eslint/config-inspector`](https://github.com/eslint/config-inspector) to visualize your actual resolved configuration.
-
-## `max-len` and layout fixers conflict after `--fix`
-
-### What happens
-
-Layout rules with fixers collapse or expand whitespace during `--fix` without checking the resulting line length. Combined with `max-len`, `--fix` can introduce errors that can't be auto-recovered.
-
-### Why this happens
-
-**This is not a bug in any individual rule.** It's a structural limitation: ESLint fixers operate independently and have no mechanism to check width constraints. And this plugin does not add — and does not plan to add — width-awareness to layout fixers.
-
-### Workarounds
-
-- Use a dedicated formatter ([Prettier](https://prettier.io/), [dprint](https://dprint.dev/), [oxfmt](https://oxc.rs/)) for layout concerns and disable conflicting layout rules.
-- Adjust your `max-len` threshold to accommodate the minimum width your layout rules produce.

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -91,3 +91,8 @@ Layout rules with fixers collapse or expand whitespace during `--fix` without ch
 ### Why this happens
 
 **This is not a bug in any individual rule.** It's a structural limitation: ESLint fixers operate independently and have no mechanism to check width constraints. And this plugin does not add — and does not plan to add — width-awareness to layout fixers.
+
+### Workarounds
+
+- Use a dedicated formatter ([Prettier](https://prettier.io/), [dprint](https://dprint.dev/), [oxfmt](https://oxc.rs/)) for layout concerns and disable conflicting layout rules.
+- Adjust your `max-len` threshold to accommodate the minimum width your layout rules produce.

--- a/packages/eslint-plugin/rules/max-len/README.md
+++ b/packages/eslint-plugin/rules/max-len/README.md
@@ -215,3 +215,15 @@ var dep = require('really/really/really/really/really/really/really/really/long/
 ```
 
 :::
+
+## Autofix limitations
+
+`max-len` reports lines that exceed the configured limit, but it does not wrap them automatically. Some autofixable layout rules can remove line breaks or increase indentation. As a result, running `eslint --fix` may leave or introduce `max-len` violations.
+
+ESLint does not coordinate a rule's fixes with the configured limit of `max-len`. Therefore, the output of `--fix` is not guaranteed to satisfy this rule.
+
+### Ways to avoid this
+
+- Use a dedicated formatter such as [Prettier](https://prettier.io/), [dprint](https://dprint.dev/), or [oxfmt](https://oxc.rs/) for layout, and disable overlapping autofixable layout rules. Formatters generally treat line width as a wrapping preference rather than a hard limit, so you may still need to relax or disable `max-len`.
+- If you keep ESLint layout fixers enabled, choose compatible rule options and a suitable `max-len` limit, then manually resolve any remaining violations.
+- Use options such as [`ignoreComments`](#ignorecomments), [`ignoreStrings`](#ignorestrings), [`ignoreUrls`](#ignoreurls), or [`ignorePattern`](#ignorepattern) when specific kinds of long lines are acceptable.


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- If this PR contains unrelated changes, they should be in a separate commit/PR.
- If this PR changes documented rule defaults, confirm it does not conflict with the [FAQ](https://eslint.style/guide/faq#why-are-some-rule-defaults-different-from-documentation).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Close #1227 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on the limitations of automatic fixes for the `max-len` rule.
  * Documented recommended approaches for formatters, compatible layout settings, manual cleanup, and selective ignores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->