### PR TITLE
feat: extend directive comments

### DIFF
--- a/packages/eslint-plugin/rules/line-comment-position/line-comment-position.ts
+++ b/packages/eslint-plugin/rules/line-comment-position/line-comment-position.ts
@@ -1,5 +1,5 @@
 import type { MessageIds, RuleOptions } from './types'
-import { COMMENTS_IGNORE_PATTERN, isTokenOnSameLine } from '#utils/ast'
+import { isDirectiveComment, isTokenOnSameLine } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 export default createRule<RuleOptions, MessageIds>({
@@ -51,7 +51,6 @@ export default createRule<RuleOptions, MessageIds>({
     const above = position === 'above'
     const customIgnoreRegExp = ignorePattern ? new RegExp(ignorePattern, 'u') : null
 
-    const defaultIgnoreRegExp = COMMENTS_IGNORE_PATTERN
     const fallThroughRegExp = /^\s*falls?\s?through/u
     const sourceCode = context.sourceCode
 
@@ -63,7 +62,7 @@ export default createRule<RuleOptions, MessageIds>({
           if (node.type !== 'Line')
             return
 
-          if (applyDefaultIgnorePatterns && (defaultIgnoreRegExp.test(node.value) || fallThroughRegExp.test(node.value)))
+          if (applyDefaultIgnorePatterns && (isDirectiveComment(node) || fallThroughRegExp.test(node.value)))
             return
 
           if (customIgnoreRegExp?.test(node.value))

--- a/packages/eslint-plugin/rules/lines-around-comment/lines-around-comment.ts
+++ b/packages/eslint-plugin/rules/lines-around-comment/lines-around-comment.ts
@@ -1,6 +1,6 @@
 import type { ASTNode, Token, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
-import { AST_NODE_TYPES, AST_TOKEN_TYPES, COMMENTS_IGNORE_PATTERN, isCommentToken, isHashbangComment, isNodeOfTypes, isOpeningBraceToken, isTokenOnSameLine } from '#utils/ast'
+import { AST_NODE_TYPES, AST_TOKEN_TYPES, isCommentToken, isDirectiveComment, isHashbangComment, isNodeOfTypes, isOpeningBraceToken, isTokenOnSameLine } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 /**
@@ -135,7 +135,6 @@ export default createRule<RuleOptions, MessageIds>({
   },
   create(context, [options]) {
     const normalizedOptions = options!
-    const defaultIgnoreRegExp = COMMENTS_IGNORE_PATTERN
     const {
       beforeBlockComment,
       afterBlockComment,
@@ -305,7 +304,7 @@ export default createRule<RuleOptions, MessageIds>({
     ): void {
       if (
         applyDefaultIgnorePatterns !== false
-        && defaultIgnoreRegExp.test(token.value)
+        && isDirectiveComment(token)
       ) {
         return
       }

--- a/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style.test.ts
+++ b/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style.test.ts
@@ -440,6 +440,45 @@ run<RuleOptions, MessageIds>({
       `,
       options: ['starred-block'],
     },
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/1249
+    // Tool directives must stay as line comments so their consumers can recognize them.
+    {
+      code: $`
+        // keep this matrix laid out by hand
+        // prettier-ignore
+        const m = [
+          1,0,0,
+          0,1,0,
+          0,0,1,
+        ];
+      `,
+      options: ['starred-block'],
+    },
+    ...[
+      'v8 ignore next',
+      'v8 ignore if -- @preserve',
+      'v8 ignore start -- @preserve',
+      'v8 ignore stop -- @preserve',
+      'v8 ignore file -- @preserve',
+      'c8 ignore next',
+      'c8 ignore start',
+      'c8 ignore stop',
+      'node:coverage ignore next',
+      'node:coverage disable',
+      'node:coverage enable',
+      'webpackChunkName: "chunk"',
+      'webpackFetchPriority: "high"',
+      'webpackMode: "lazy"',
+      'webpackExports: ["default"]',
+      'webpackInclude: /\\.json$/',
+      'webpackExclude: /\\.noimport\\.json$/',
+      'webpackPrefetch: true',
+      'webpackPreload: true',
+      'webpackIgnore: true',
+    ].map(directive => ({
+      code: `// why this directive is needed\n// ${directive}\nfoo();`,
+      options: ['starred-block'] as RuleOptions,
+    })),
     {
       code: $`
         let x = 5; // first number
@@ -1703,6 +1742,25 @@ ${'                   '}
       `,
       options: ['starred-block'],
       errors: [{ messageId: 'expectedBlock', line: 1 }, { messageId: 'expectedBlock', line: 4 }],
+    },
+    // Prefix lookalikes are ordinary prose and must still be converted.
+    {
+      code: $`
+        // prettier-ignorement
+        // v8 ignored next
+        // node:coverage ignored next
+        // webpackChunkNameExtra: "chunk"
+      `,
+      output: $`
+        /*
+         * prettier-ignorement
+         * v8 ignored next
+         * node:coverage ignored next
+         * webpackChunkNameExtra: "chunk"
+         */
+      `,
+      options: ['starred-block'],
+      errors: [{ messageId: 'expectedBlock', line: 1 }],
     },
   ],
 })

--- a/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style.ts
+++ b/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style.ts
@@ -5,7 +5,7 @@
 
 import type { Token, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
-import { COMMENTS_IGNORE_PATTERN, isHashbangComment, isSingleLine, isTokenOnSameLine, isWhiteSpaces, LINEBREAK_MATCHER, WHITE_SPACES_PATTERN } from '#utils/ast'
+import { isDirectiveComment, isHashbangComment, isSingleLine, isTokenOnSameLine, isWhiteSpaces, LINEBREAK_MATCHER, WHITE_SPACES_PATTERN } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 export default createRule<RuleOptions, MessageIds>({
@@ -455,7 +455,7 @@ export default createRule<RuleOptions, MessageIds>({
       Program() {
         return sourceCode.getAllComments()
           .filter((comment) => {
-            if (isHashbangComment(comment) || COMMENTS_IGNORE_PATTERN.test(comment.value))
+            if (isHashbangComment(comment) || isDirectiveComment(comment))
               return false
 
             const tokenBefore = sourceCode.getTokenBefore(comment, { includeComments: true })

--- a/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style.ts
+++ b/packages/eslint-plugin/rules/multiline-comment-style/multiline-comment-style.ts
@@ -8,11 +8,6 @@ import type { MessageIds, RuleOptions } from './types'
 import { COMMENTS_IGNORE_PATTERN, isHashbangComment, isSingleLine, isTokenOnSameLine, isWhiteSpaces, LINEBREAK_MATCHER, WHITE_SPACES_PATTERN } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
-// TypeScript directive comments (e.g. `// @ts-expect-error`). Merging these into a
-// block comment or with neighboring comments would stop them from being recognized
-// by the TypeScript compiler, so they are treated like other ignored comments.
-const TS_DIRECTIVE_PATTERN = /^\s*@ts-(?:expect-error|ignore|nocheck|check)(?![\w-])/u
-
 export default createRule<RuleOptions, MessageIds>({
   name: 'multiline-comment-style',
   meta: {
@@ -460,7 +455,7 @@ export default createRule<RuleOptions, MessageIds>({
       Program() {
         return sourceCode.getAllComments()
           .filter((comment) => {
-            if (isHashbangComment(comment) || COMMENTS_IGNORE_PATTERN.test(comment.value) || TS_DIRECTIVE_PATTERN.test(comment.value))
+            if (isHashbangComment(comment) || COMMENTS_IGNORE_PATTERN.test(comment.value))
               return false
 
             const tokenBefore = sourceCode.getTokenBefore(comment, { includeComments: true })

--- a/packages/eslint-plugin/rules/spaced-comment/spaced-comment.ts
+++ b/packages/eslint-plugin/rules/spaced-comment/spaced-comment.ts
@@ -5,8 +5,7 @@
 import type { Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
 import escapeRegExp from 'escape-string-regexp'
-import { isHashbangComment, LINEBREAKS } from '#utils/ast'
-import { isTripleSlashReference } from '#utils/ast/comment'
+import { isHashbangComment, isTripleSlashReference, LINEBREAKS } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 /**

--- a/shared/utils/ast.ts
+++ b/shared/utils/ast.ts
@@ -1,3 +1,4 @@
+export * from './ast/comment'
 export * from './ast/general'
 
 export {

--- a/shared/utils/ast/comment.ts
+++ b/shared/utils/ast/comment.ts
@@ -1,5 +1,10 @@
 import type { Tree } from '#types'
 
+/**
+ * @see https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html
+ */
+const TRIPLE_SLASH_REFERENCE_PATTERN = /^\/\s*<(?:reference|amd-)/u
+
 const COMMENT_DIRECTIVE_PATTERNS = [
   /^\s*eslint/u,
   /^\s*@ts-(?:expect-error|ignore|nocheck|check)(?![\w-])/u,
@@ -13,13 +18,8 @@ const COMMENT_DIRECTIVE_PATTERNS = [
   /^\s*globals?\s+/u,
   /^\s*exported\s+/u,
   /^\s*jscs/u,
-  /^\s*\/\s*<(?:reference|amd-)/u,
+  TRIPLE_SLASH_REFERENCE_PATTERN,
 ] as const
-
-/**
- * @see https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html
- */
-const TRIPLE_SLASH_REFERENCE_PATTERN = /^\/\s*<(?:reference|amd-)/u
 
 /**
  * Checks if a comment contains a directive that must retain its position and form.

--- a/shared/utils/ast/comment.ts
+++ b/shared/utils/ast/comment.ts
@@ -1,9 +1,32 @@
 import type { Tree } from '#types'
 
+const COMMENT_DIRECTIVE_PATTERNS = [
+  /^\s*eslint/u,
+  /^\s*@ts-(?:expect-error|ignore|nocheck|check)(?![\w-])/u,
+  /^\s*prettier-ignore(?![\w-])/u,
+  /^\s*[vc]8\s+ignore(?![\w-])/u,
+  /^\s*node:coverage\s+(?:disable|enable|ignore\s+next)(?![\w-])/u,
+  /^\s*webpack(?:ChunkName|FetchPriority|Mode|Exports|Include|Exclude|Prefetch|Preload|Ignore)\s*:/u,
+  /^\s*jshint\s+/u,
+  /^\s*jslint\s+/u,
+  /^\s*istanbul\s+/u,
+  /^\s*globals?\s+/u,
+  /^\s*exported\s+/u,
+  /^\s*jscs/u,
+  /^\s*\/\s*<(?:reference|amd-)/u,
+] as const
+
 /**
  * @see https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html
  */
 const TRIPLE_SLASH_REFERENCE_PATTERN = /^\/\s*<(?:reference|amd-)/u
+
+/**
+ * Checks if a comment contains a directive that must retain its position and form.
+ */
+export function isDirectiveComment(comment: Tree.Comment): boolean {
+  return COMMENT_DIRECTIVE_PATTERNS.some(pattern => pattern.test(comment.value))
+}
 
 /**
  * Checks if a comment is a triple-slash reference directive (e.g., `/// <reference types="..." />`)

--- a/shared/utils/ast/general.ts
+++ b/shared/utils/ast/general.ts
@@ -4,7 +4,7 @@ import { isClosingParenToken, isColonToken, isCommentToken, isFunction, isOpenin
 import { visitorKeys } from '@typescript-eslint/visitor-keys'
 import { latestEcmaVersion, tokenize } from 'espree'
 
-export const COMMENTS_IGNORE_PATTERN = /^\s*(?:eslint|@ts-(?:expect-error|ignore|nocheck|check)(?![\w-])|jshint\s+|jslint\s+|istanbul\s+|globals?\s+|exported\s+|jscs|\/\s*<(?:reference|amd-))/u
+export const COMMENTS_IGNORE_PATTERN = /^\s*(?:eslint|@ts-(?:expect-error|ignore|nocheck|check)(?![\w-])|prettier-ignore(?![\w-])|[vc]8\s+ignore(?![\w-])|node:coverage\s+(?:disable|enable|ignore\s+next)(?![\w-])|webpack(?:ChunkName|FetchPriority|Mode|Exports|Include|Exclude|Prefetch|Preload|Ignore)\s*:|jshint\s+|jslint\s+|istanbul\s+|globals?\s+|exported\s+|jscs|\/\s*<(?:reference|amd-))/u
 
 export const LINEBREAKS = /* @__PURE__ */ new Set(['\r\n', '\r', '\n', '\u2028', '\u2029'])
 

--- a/shared/utils/ast/general.ts
+++ b/shared/utils/ast/general.ts
@@ -4,7 +4,7 @@ import { isClosingParenToken, isColonToken, isCommentToken, isFunction, isOpenin
 import { visitorKeys } from '@typescript-eslint/visitor-keys'
 import { latestEcmaVersion, tokenize } from 'espree'
 
-export const COMMENTS_IGNORE_PATTERN = /^\s*(?:eslint|jshint\s+|jslint\s+|istanbul\s+|globals?\s+|exported\s+|jscs|\/\s*<(?:reference|amd-))/u
+export const COMMENTS_IGNORE_PATTERN = /^\s*(?:eslint|@ts-(?:expect-error|ignore|nocheck|check)(?![\w-])|jshint\s+|jslint\s+|istanbul\s+|globals?\s+|exported\s+|jscs|\/\s*<(?:reference|amd-))/u
 
 export const LINEBREAKS = /* @__PURE__ */ new Set(['\r\n', '\r', '\n', '\u2028', '\u2029'])
 

--- a/shared/utils/ast/general.ts
+++ b/shared/utils/ast/general.ts
@@ -4,8 +4,6 @@ import { isClosingParenToken, isColonToken, isCommentToken, isFunction, isOpenin
 import { visitorKeys } from '@typescript-eslint/visitor-keys'
 import { latestEcmaVersion, tokenize } from 'espree'
 
-export const COMMENTS_IGNORE_PATTERN = /^\s*(?:eslint|@ts-(?:expect-error|ignore|nocheck|check)(?![\w-])|prettier-ignore(?![\w-])|[vc]8\s+ignore(?![\w-])|node:coverage\s+(?:disable|enable|ignore\s+next)(?![\w-])|webpack(?:ChunkName|FetchPriority|Mode|Exports|Include|Exclude|Prefetch|Preload|Ignore)\s*:|jshint\s+|jslint\s+|istanbul\s+|globals?\s+|exported\s+|jscs|\/\s*<(?:reference|amd-))/u
-
 export const LINEBREAKS = /* @__PURE__ */ new Set(['\r\n', '\r', '\n', '\u2028', '\u2029'])
 
 // A set of node types that can contain a list of statements


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- If this PR contains unrelated changes, they should be in a separate commit/PR.
- If this PR changes documented rule defaults, confirm it does not conflict with the [FAQ](https://eslint.style/guide/faq#why-are-some-rule-defaults-different-from-documentation).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Related Rules
- line-comment-position
- lines-around-comment
- multiline-comment-style

Fix #1249

### Linked Issues

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comment handling for ESLint, TypeScript, formatter, runtime, webpack, coverage, and related tool directives.
  * Prevented supported directive comments from being incorrectly reformatted or flagged by comment-style rules.
  * Ensured hashbangs and recognized tool directives retain their intended comment formatting.
  * Added coverage for valid directive comments and lookalike text to ensure only genuine directives receive special treatment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->