### PR TITLE
feat(list-style): support empty structures

### DIFF
--- a/packages/eslint-plugin/rules/list-style/README.md
+++ b/packages/eslint-plugin/rules/list-style/README.md
@@ -30,6 +30,7 @@ This rule accepts an object option:
   - [`"maxItems"`](#maxitems): Maximum number of elements allowed before auto-fixing to multi-line
 - [`"multiLine"`](#multiline): Options for when the node is multi-line
   - [`"minItems"`](#minitems): Minimum number of elements allowed before auto-fixing to single-line
+- [`"empty"`](#empty): How spacing and line breaks are handled for empty structures
 - [`"overrides"`](#overrides): Override options based on bracket type or node type
 
 The default configuration of this rule is:
@@ -192,6 +193,67 @@ let [
   a,
   b
 ] = bar;
+```
+
+:::
+
+### empty
+
+`"ignore"` (default) does not check empty structures. `"always"` requires a space inside an empty structure, while `"never"` disallows spaces. When enabled, empty multiline structures count as having zero items, so `multiLine.minItems` controls whether they collapse to a single line.
+
+Examples of **correct** code with the default `"ignore"` option:
+
+::: correct
+
+```ts
+/* eslint @stylistic/exp-list-style: ["error", { "empty": "ignore" }] */
+
+const array = [ ]
+const object = {}
+foo( )
+```
+
+:::
+
+Examples of **correct** code with the `"always"` option:
+
+::: correct
+
+```ts
+/* eslint @stylistic/exp-list-style: ["error", { "empty": "always" }] */
+
+const array = [ ]
+const object = { }
+foo( )
+```
+
+:::
+
+Examples of **incorrect** code with the `"never"` option and `multiLine.minItems` set to `1`:
+
+::: incorrect
+
+```ts
+/* eslint @stylistic/exp-list-style: ["error", { "empty": "never", "multiLine": { "minItems": 1 } }] */
+
+const array = [ ]
+const object = {
+}
+foo( )
+```
+
+:::
+
+Examples of **correct** code with the `"never"` option and `multiLine.minItems` set to `1`:
+
+::: correct
+
+```ts
+/* eslint @stylistic/exp-list-style: ["error", { "empty": "never", "multiLine": { "minItems": 1 } }] */
+
+const array = []
+const object = {}
+foo()
 ```
 
 :::

--- a/packages/eslint-plugin/rules/list-style/list-style._json_.test.ts
+++ b/packages/eslint-plugin/rules/list-style/list-style._json_.test.ts
@@ -47,6 +47,20 @@ run<RuleOptions, MessageIds>({
   ],
   invalid: [
     {
+      code: `{ "array": [ ], "object": {} }`,
+      output: `{ "array": [], "object": { } }`,
+      options: [{
+        empty: 'never',
+        overrides: {
+          JSONObjectExpression: { empty: 'always' },
+        },
+      }],
+      errors: [
+        { messageId: 'shouldNotSpacing' },
+        { messageId: 'shouldSpacing' },
+      ],
+    },
+    {
       code: $`
         {
           "foo": ["bar",

--- a/packages/eslint-plugin/rules/list-style/list-style.test.ts
+++ b/packages/eslint-plugin/rules/list-style/list-style.test.ts
@@ -32,6 +32,10 @@ run<RuleOptions, MessageIds>({
     'new Foo(a, b)',
     'new Foo(\na,\nb\n)',
     'new (Foo())(a, b)',
+    'new Foo\nbar()',
+    {
+      code: 'const ignoredArray = [ ]\nconst ignoredObject = {}\nignoredCall( )',
+    },
     'function foo<T = {\na: 1,\nb: 2\n}>(a, b) {}',
     'foo(() =>\nbar())',
     `call<{\nfoo: 'bar'\n}>('')`,
@@ -200,8 +204,163 @@ run<RuleOptions, MessageIds>({
         ]
       })
     `,
+    {
+      code: $`
+        foo(
+          // comment
+        )
+        const array = [
+          // comment
+        ]
+      `,
+      options: [{ multiLine: { minItems: 1 } }],
+    },
+    `import value from 'foo' with {}`,
+    `export * from 'foo' with {}`,
   ],
   invalid: [
+    {
+      code: $`
+        const array = [ ]
+        const object = {}
+        const [] = array
+        const {} = object
+        type Tuple = [ ]
+        type Literal = {}
+        interface Empty {}
+        enum EmptyEnum {}
+      `,
+      output: $`
+        const array = []
+        const object = { }
+        const [] = array
+        const { } = object
+        type Tuple = []
+        type Literal = { }
+        interface Empty { }
+        enum EmptyEnum { }
+      `,
+      options: [{
+        empty: 'never',
+        overrides: {
+          '{}': { empty: 'always' },
+        },
+      }],
+      errors: [
+        { messageId: 'shouldNotSpacing', line: 1, column: 16 },
+        { messageId: 'shouldSpacing', line: 2, column: 17 },
+        { messageId: 'shouldSpacing', line: 4, column: 8 },
+        { messageId: 'shouldNotSpacing', line: 5, column: 15 },
+        { messageId: 'shouldSpacing', line: 6, column: 17 },
+        { messageId: 'shouldSpacing', line: 7, column: 18 },
+        { messageId: 'shouldSpacing', line: 8, column: 17 },
+      ],
+    },
+    {
+      code: $`
+        function declaration( ) {}
+        const expression = function ( ) {}
+        const arrow = ( ) => {}
+        declaration( )
+        new expression( )
+        type FunctionType = ( ) => void
+        declare function declared( ): void
+      `,
+      output: $`
+        function declaration() {}
+        const expression = function () {}
+        const arrow = () => {}
+        declaration()
+        new expression()
+        type FunctionType = () => void
+        declare function declared(): void
+      `,
+      options: [{ empty: 'never' }],
+      errors: [
+        { messageId: 'shouldNotSpacing', line: 1, column: 22 },
+        { messageId: 'shouldNotSpacing', line: 2, column: 30 },
+        { messageId: 'shouldNotSpacing', line: 3, column: 16 },
+        { messageId: 'shouldNotSpacing', line: 4, column: 13 },
+        { messageId: 'shouldNotSpacing', line: 5, column: 16 },
+        { messageId: 'shouldNotSpacing', line: 6, column: 22 },
+        { messageId: 'shouldNotSpacing', line: 7, column: 27 },
+      ],
+    },
+    {
+      code: `import { } from 'foo' with {}\nexport { } from 'bar' with {}`,
+      output: `import {} from 'foo' with { }\nexport {} from 'bar' with { }`,
+      options: [{
+        overrides: {
+          ImportAttributes: { empty: 'always' },
+          ImportDeclaration: { empty: 'never' },
+          ExportNamedDeclaration: { empty: 'never' },
+        },
+      }],
+      errors: [
+        { messageId: 'shouldNotSpacing', line: 1, column: 9 },
+        { messageId: 'shouldSpacing', line: 1, column: 29 },
+        { messageId: 'shouldNotSpacing', line: 2, column: 9 },
+        { messageId: 'shouldSpacing', line: 2, column: 29 },
+      ],
+    },
+    {
+      code: $`
+        const array = [
+        ]
+        const object = {
+        }
+        function foo(
+        ) {}
+        foo(
+        )
+        interface Empty {
+        }
+      `,
+      output: $`
+        const array = []
+        const object = { }
+        function foo() {}
+        foo()
+        interface Empty { }
+      `,
+      options: [{
+        empty: 'never',
+        multiLine: { minItems: 1 },
+        overrides: {
+          '{}': { empty: 'always' },
+        },
+      }],
+      errors: [
+        { messageId: 'shouldNotWrap', line: 1, column: 16 },
+        { messageId: 'shouldNotWrap', line: 3, column: 17 },
+        { messageId: 'shouldNotWrap', line: 5, column: 14 },
+        { messageId: 'shouldNotWrap', line: 7, column: 5 },
+        { messageId: 'shouldNotWrap', line: 9, column: 18 },
+      ],
+    },
+    {
+      code: `foo( /* comment */ )\nconst object = {/* comment */}`,
+      output: `foo(/* comment */)\nconst object = { /* comment */ }`,
+      errors: [
+        { messageId: 'shouldNotSpacing', line: 1, column: 5 },
+        { messageId: 'shouldNotSpacing', line: 1, column: 19 },
+        { messageId: 'shouldSpacing', line: 2, column: 17 },
+        { messageId: 'shouldSpacing', line: 2, column: 30 },
+      ],
+    },
+    {
+      code: $`
+        foo(/* comment */
+        )
+      `,
+      output: $`
+        foo(
+        /* comment */
+        )
+      `,
+      options: [{ multiLine: { minItems: 1 } }],
+      errors: [{ messageId: 'shouldWrap', line: 1, column: 5 }],
+    },
     {
       code: $`
         if (

--- a/packages/eslint-plugin/rules/list-style/list-style.test.ts
+++ b/packages/eslint-plugin/rules/list-style/list-style.test.ts
@@ -36,6 +36,7 @@ run<RuleOptions, MessageIds>({
     {
       code: 'const ignoredArray = [ ]\nconst ignoredObject = {}\nignoredCall( )',
     },
+    'foo( /* comment */ )',
     'function foo<T = {\na: 1,\nb: 2\n}>(a, b) {}',
     'foo(() =>\nbar())',
     `call<{\nfoo: 'bar'\n}>('')`,
@@ -341,6 +342,10 @@ run<RuleOptions, MessageIds>({
     {
       code: `foo( /* comment */ )\nconst object = {/* comment */}`,
       output: `foo(/* comment */)\nconst object = { /* comment */ }`,
+      options: [{
+        empty: 'never',
+        overrides: { '{}': { empty: 'always' } },
+      }],
       errors: [
         { messageId: 'shouldNotSpacing', line: 1, column: 5 },
         { messageId: 'shouldNotSpacing', line: 1, column: 19 },
@@ -358,7 +363,7 @@ run<RuleOptions, MessageIds>({
         /* comment */
         )
       `,
-      options: [{ multiLine: { minItems: 1 } }],
+      options: [{ empty: 'never', multiLine: { minItems: 1 } }],
       errors: [{ messageId: 'shouldWrap', line: 1, column: 5 }],
     },
     {

--- a/packages/eslint-plugin/rules/list-style/list-style.ts
+++ b/packages/eslint-plugin/rules/list-style/list-style.ts
@@ -464,7 +464,7 @@ export default createRule<RuleOptions, MessageIds>({
         return
       }
 
-      const isEmpty = items.length === 0 && !sourceCode.commentsExistBetween(left, right)
+      const isEmpty = items.length === 0
       if (isEmpty && config.empty === 'ignore')
         return
 

--- a/packages/eslint-plugin/rules/list-style/list-style.ts
+++ b/packages/eslint-plugin/rules/list-style/list-style.ts
@@ -56,6 +56,10 @@ export default createRule<RuleOptions, MessageIds>({
             type: 'object',
             additionalProperties: false,
             properties: {
+              empty: {
+                type: 'string',
+                enum: ['ignore', 'always', 'never'],
+              },
               singleLine: { $ref: '#/items/0/$defs/singleLineConfig' },
               multiline: { $ref: '#/items/0/$defs/multiLineConfig' },
             },
@@ -70,6 +74,10 @@ export default createRule<RuleOptions, MessageIds>({
         type: 'object',
         additionalProperties: false,
         properties: {
+          empty: {
+            type: 'string',
+            enum: ['ignore', 'always', 'never'],
+          },
           singleLine: { $ref: '#/items/0/$defs/singleLineConfig' },
           multiLine: { $ref: '#/items/0/$defs/multiLineConfig' },
           overrides: {
@@ -112,6 +120,7 @@ export default createRule<RuleOptions, MessageIds>({
     ],
     // #region defaultOptions
     defaultOptions: [{
+      empty: 'ignore',
       singleLine: {
         spacing: 'never',
         maxItems: Number.POSITIVE_INFINITY,
@@ -134,6 +143,7 @@ export default createRule<RuleOptions, MessageIds>({
   create: (context, [options]) => {
     const { sourceCode } = context
     const {
+      empty = 'ignore',
       singleLine,
       multiLine,
       overrides,
@@ -159,6 +169,7 @@ export default createRule<RuleOptions, MessageIds>({
         overridesByNode ??= {}
 
         resolved = {
+          empty: overridesByNode.empty ?? overridesByParen.empty ?? empty,
           singleLine: {
             ...singleLine,
             ...overridesByParen.singleLine,
@@ -183,8 +194,7 @@ export default createRule<RuleOptions, MessageIds>({
       return current.value.match(/(?:,|;)$/) ? undefined : ','
     }
 
-    function checkSpacing(node: ASTNode, left: Token, right: Token, config: BaseConfig) {
-      const shouldSpace = config.singleLine!.spacing === 'always'
+    function checkSpacing(node: ASTNode, left: Token, right: Token, shouldSpace: boolean) {
       const firstToken = sourceCode.getTokenAfter(left, { includeComments: true })!
       const lastToken = sourceCode.getTokenBefore(right, { includeComments: true })!
 
@@ -228,7 +238,45 @@ export default createRule<RuleOptions, MessageIds>({
       }
 
       doCheck(left, firstToken)
-      doCheck(lastToken, right)
+
+      if (firstToken !== right)
+        doCheck(lastToken, right)
+    }
+
+    function checkEmptyWrap(node: ASTNode, left: Token, right: Token, config: BaseConfig) {
+      const firstToken = sourceCode.getTokenAfter(left, { includeComments: true })!
+      const lastToken = sourceCode.getTokenBefore(right, { includeComments: true })!
+
+      if (firstToken !== right) {
+        for (const [prev, next] of [[left, firstToken], [lastToken, right]] as const) {
+          if (isTokenOnSameLine(prev, next)) {
+            context.report({
+              node,
+              messageId: 'shouldWrap',
+              loc: { start: prev.loc.end, end: next.loc.start },
+              data: { prev: prev.value, next: next.value },
+              fix: safeReplaceTextBetween(sourceCode, prev, next, () => '\n'),
+            })
+          }
+        }
+        return
+      }
+
+      if (config.multiline!.minItems === 0)
+        return
+
+      context.report({
+        node,
+        messageId: 'shouldNotWrap',
+        loc: { start: left.loc.end, end: right.loc.start },
+        data: { prev: left.value, next: right.value },
+        fix: safeReplaceTextBetween(
+          sourceCode,
+          left,
+          right,
+          () => config.empty === 'always' ? ' ' : '',
+        ),
+      })
     }
 
     function checkWrap(node: ASTNode, items: (ASTNode | null)[], left: Token, right: Token, config: BaseConfig) {
@@ -336,7 +384,7 @@ export default createRule<RuleOptions, MessageIds>({
       },
     }
 
-    function getLeftParen(node: ASTNode, items: (ASTNode | null)[], type: ParenType) {
+    function getLeftParen(node: ASTNode, items: (ASTNode | null)[], type: ParenType, nodeType: OverrideKey) {
       switch (node.type) {
         // fun?.()
         // fun<T>()
@@ -352,6 +400,16 @@ export default createRule<RuleOptions, MessageIds>({
           return sourceCode.getFirstToken(node)
 
         default: {
+          if (items.length === 0) {
+            const tokens = sourceCode.getTokens(node)
+            const { left, right } = parenMatchers[type]
+            const pairs = tokens
+              .map((token, index) => [token, tokens[index + 1]] as const)
+              .filter(([current, next]) => left(current) && next && right(next))
+
+            return (nodeType === 'ImportAttributes' ? pairs.at(-1) : pairs[0])?.[0] ?? null
+          }
+
           const maybeLeft = sourceCode.getTokenBefore(items[0]!)
           // foo => bar
           const { left: matcher } = parenMatchers[type]
@@ -360,7 +418,12 @@ export default createRule<RuleOptions, MessageIds>({
       }
     }
 
-    function getRightParen(node: ASTNode, items: (ASTNode | null)[], type: ParenType) {
+    function getRightParen(node: ASTNode, items: (ASTNode | null)[], type: ParenType, left: Token) {
+      if (items.length === 0) {
+        const maybeRight = sourceCode.getTokenAfter(left)
+        return maybeRight && parenMatchers[type].right(maybeRight) ? maybeRight : null
+      }
+
       switch (node.type) {
         // const foo = [a, ]
         case AST_NODE_TYPES.ArrayExpression:
@@ -373,7 +436,7 @@ export default createRule<RuleOptions, MessageIds>({
             // const [a, ] = foo
             : sourceCode.getLastToken(node)!
 
-        default:{
+        default: {
           const maybeRight = sourceCode.getTokenAfter(items.at(-1)!, isNotCommaToken)
           // foo => bar
           const { right: matcher } = parenMatchers[type]
@@ -382,25 +445,39 @@ export default createRule<RuleOptions, MessageIds>({
       }
     }
 
-    function check(parenType: ParenType, node: ASTNode, items: (ASTNode | null)[]) {
-      if (items.length === 0)
-        return
-
-      const left = getLeftParen(node, items, parenType)
-      const right = getRightParen(node, items, parenType)
-
-      if (!left || !right)
-        return
-
-      const nodeType = items[0]?.type === 'ImportAttribute' ? 'ImportAttributes' : node.type as OverrideKey
+    function check(parenType: ParenType, node: ASTNode, items: (ASTNode | null)[], overrideKey?: OverrideKey) {
+      const nodeType = overrideKey ?? (items[0]?.type === 'ImportAttribute' ? 'ImportAttributes' : node.type as OverrideKey)
 
       const config = resolveOption(parenType, nodeType)
 
       if (config === 'off')
         return
 
+      const left = getLeftParen(node, items, parenType, nodeType)
+      const right = left && getRightParen(node, items, parenType, left)
+
+      if (
+        !left || !right
+        || left.range[0] < node.range[0]
+        || right.range[1] > node.range[1]
+      ) {
+        return
+      }
+
+      const isEmpty = items.length === 0 && !sourceCode.commentsExistBetween(left, right)
+      if (isEmpty && config.empty === 'ignore')
+        return
+
       if (isTokenOnSameLine(left, right) && items.length <= config.singleLine.maxItems!) {
-        checkSpacing(node, left, right, config)
+        checkSpacing(
+          node,
+          left,
+          right,
+          isEmpty ? config.empty === 'always' : config.singleLine.spacing === 'always',
+        )
+      }
+      else if (items.length === 0) {
+        checkEmptyWrap(node, left, right, config)
       }
       else {
         checkWrap(node, items, left, right, config)
@@ -423,13 +500,14 @@ export default createRule<RuleOptions, MessageIds>({
       },
       ExportAllDeclaration(node) {
         if (node.attributes)
-          check('{}', node, node.attributes)
+          check('{}', node, node.attributes, 'ImportAttributes')
       },
       ExportNamedDeclaration(node) {
-        check('{}', node, node.specifiers)
+        if (!node.declaration)
+          check('{}', node, node.specifiers)
 
         if (node.attributes)
-          check('{}', node, node.attributes)
+          check('{}', node, node.attributes, 'ImportAttributes')
       },
       FunctionDeclaration(node) {
         check('()', node, node.params)
@@ -441,10 +519,16 @@ export default createRule<RuleOptions, MessageIds>({
         check('()', node, [node.test])
       },
       ImportDeclaration(node) {
-        check('{}', node, node.specifiers.filter(specifier => specifier.type === 'ImportSpecifier'))
+        const specifiers = node.specifiers.filter(specifier => specifier.type === 'ImportSpecifier')
+        if (
+          specifiers.length
+          || sourceCode.getTokens(node).some(token => isOpeningBraceToken(token) && token.range[0] < node.source.range[0])
+        ) {
+          check('{}', node, specifiers)
+        }
 
         if (node.attributes)
-          check('{}', node, node.attributes)
+          check('{}', node, node.attributes, 'ImportAttributes')
       },
       JSONArrayExpression(node: Tree.ArrayExpression) {
         check('[]', node, node.elements)

--- a/packages/eslint-plugin/rules/list-style/list-style.ts
+++ b/packages/eslint-plugin/rules/list-style/list-style.ts
@@ -445,24 +445,34 @@ export default createRule<RuleOptions, MessageIds>({
       }
     }
 
-    function check(parenType: ParenType, node: ASTNode, items: (ASTNode | null)[], overrideKey?: OverrideKey) {
-      const nodeType = overrideKey ?? (items[0]?.type === 'ImportAttribute' ? 'ImportAttributes' : node.type as OverrideKey)
-
-      const config = resolveOption(parenType, nodeType)
-
-      if (config === 'off')
-        return
-
-      const left = getLeftParen(node, items, parenType, nodeType)
-      const right = left && getRightParen(node, items, parenType, left)
+    function getParens(node: ASTNode, items: (ASTNode | null)[], type: ParenType, nodeType: OverrideKey) {
+      const left = getLeftParen(node, items, type, nodeType)
+      const right = left && getRightParen(node, items, type, left)
 
       if (
         !left || !right
         || left.range[0] < node.range[0]
         || right.range[1] > node.range[1]
       ) {
-        return
+        return null
       }
+
+      return { left, right }
+    }
+
+    function check(parenType: ParenType, node: ASTNode, items: (ASTNode | null)[], overrideKey?: OverrideKey) {
+      const nodeType = overrideKey ?? node.type as OverrideKey
+
+      const config = resolveOption(parenType, nodeType)
+
+      if (config === 'off')
+        return
+
+      const parens = getParens(node, items, parenType, nodeType)
+      if (!parens)
+        return
+
+      const { left, right } = parens
 
       const isEmpty = items.length === 0
       if (isEmpty && config.empty === 'ignore')

--- a/packages/eslint-plugin/rules/list-style/types.d.ts
+++ b/packages/eslint-plugin/rules/list-style/types.d.ts
@@ -1,10 +1,11 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: bO-QF1vmjhbG-SOI1py-wrNSdizWYw_vlRpd_N-bzaA */
+/* @checksum: 4q_MHCJXCCDAPnzLHlr3tVJatY44E9CkVN9FRtDf-VU */
 
 export type OverrideConfig = BaseConfig | 'off'
 
 export interface ListStyleSchema0 {
+  empty?: 'ignore' | 'always' | 'never'
   singleLine?: SingleLineConfig
   multiLine?: MultiLineConfig
   overrides?: {
@@ -45,6 +46,7 @@ export interface MultiLineConfig {
   minItems?: number
 }
 export interface BaseConfig {
+  empty?: 'ignore' | 'always' | 'never'
   singleLine?: SingleLineConfig
   multiline?: MultiLineConfig
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- If this PR contains unrelated changes, they should be in a separate commit/PR.
- If this PR changes documented rule defaults, confirm it does not conflict with the [FAQ](https://eslint.style/guide/faq#why-are-some-rule-defaults-different-from-documentation).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Adds an `empty` option with `ignore`, `always`, and `never` modes.

### Linked Issues

https://github.com/eslint-stylistic/eslint-stylistic/issues/1030#issuecomment-4138300786
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable spacing rules for empty arrays, objects, calls, imports, exports, and other bracketed constructs.
  - Supports `"ignore"`, `"always"`, and `"never"` modes, with optional overrides for specific syntax types.
  - Added handling for multiline and comment-only constructs, including empty import and export attributes.
  - Added validation for spacing and line wrapping around empty delimiters.

- **Documentation**
  - Documented the new `empty` configuration option, default behavior, spacing modes, multiline handling, and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->