### PR TITLE
chore(lint): enable e18e checks

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,8 +11,6 @@ const stylisticConfig = stylistic.configs.customize({
 
 export default antfu(
   {
-    // TODO: enable it
-    e18e: false,
     formatters: true,
     ignores: [
       '**/fixtures/**',

--- a/packages/eslint-plugin/rules/jsx-child-element-spacing/jsx-child-element-spacing.ts
+++ b/packages/eslint-plugin/rules/jsx-child-element-spacing/jsx-child-element-spacing.ts
@@ -79,7 +79,7 @@ export default createRule<RuleOptions, MessageIds>({
           && (!nextChild || isInlineElement(nextChild))
           && true
         ) {
-          if (lastChild && String(child.value).match(TEXT_FOLLOWING_ELEMENT_PATTERN)) {
+          if (lastChild && TEXT_FOLLOWING_ELEMENT_PATTERN.test(String(child.value))) {
             context.report({
               messageId: 'spacingAfterPrev',
               node: lastChild,
@@ -89,7 +89,7 @@ export default createRule<RuleOptions, MessageIds>({
               },
             })
           }
-          else if (nextChild && String(child.value).match(TEXT_PRECEDING_ELEMENT_PATTERN)) {
+          else if (nextChild && TEXT_PRECEDING_ELEMENT_PATTERN.test(String(child.value))) {
             context.report({
               messageId: 'spacingBeforeNext',
               node: nextChild,

--- a/packages/eslint-plugin/rules/list-style/list-style.ts
+++ b/packages/eslint-plugin/rules/list-style/list-style.ts
@@ -180,7 +180,7 @@ export default createRule<RuleOptions, MessageIds>({
       if (root.type !== 'TSInterfaceBody' && root.type !== 'TSTypeLiteral')
         return
 
-      return current.value.match(/(?:,|;)$/) ? undefined : ','
+      return /(?:,|;)$/.test(current.value) ? undefined : ','
     }
 
     function checkSpacing(node: ASTNode, left: Token, right: Token, config: BaseConfig) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- If this PR contains unrelated changes, they should be in a separate commit/PR.
- If this PR changes documented rule defaults, confirm it does not conflict with the [FAQ](https://eslint.style/guide/faq#why-are-some-rule-defaults-different-from-documentation).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code-style validation for JSX child spacing and list delimiters while preserving existing diagnostics and behavior.

* **Chores**
  * Removed an unused, disabled lint configuration entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->