### PR TITLE
fix(indent)!: enforce property value indentation

### DIFF
--- a/docs/guide/upgrade.md
+++ b/docs/guide/upgrade.md
@@ -69,6 +69,10 @@ If you rely on the previous behavior, configure `"object"` explicitly:
 }
 ```
 
+#### indent
+
+The first token of a property value that starts on a new line after `:` is now required to be indented one level from the `:` token. If you rely on the previous aligned layout, configure `ignoredNodes` for the affected nodes.
+
 #### operator-linebreak
 
 For TypeScript type aliases whose type annotation starts with `|` or `&`, the `=` operator now uses the `"after"` style unless it is configured as `"ignore"`.

--- a/packages/eslint-plugin/rules/indent/indent._js_.test.ts
+++ b/packages/eslint-plugin/rules/indent/indent._js_.test.ts
@@ -1278,19 +1278,19 @@ run<RuleOptions, MessageIds>({
       code: $`
         module.exports = {
           'Unit tests':
-          {
-            rootPath: './',
-            environment: 'node',
-            tests:
-            [
-              'test/test-*.js'
-            ],
-            sources:
-            [
-              '*.js',
-              'test/**.js'
-            ]
-          }
+            {
+              rootPath: './',
+              environment: 'node',
+              tests:
+                [
+                  'test/test-*.js'
+                ],
+              sources:
+                [
+                  '*.js',
+                  'test/**.js'
+                ]
+            }
         };
       `,
       options: [2],
@@ -1534,11 +1534,11 @@ run<RuleOptions, MessageIds>({
         var a =
         {
             actions:
-            [
-                {
-                    name: 'compile'
-                }
-            ]
+                [
+                    {
+                        name: 'compile'
+                    }
+                ]
         };
       `,
       options: [4, { VariableDeclarator: 0, SwitchCase: 1, assignmentOperator: 0 }],
@@ -2651,19 +2651,10 @@ run<RuleOptions, MessageIds>({
     `,
     {
 
-      // Don't lint the indentation of the first token after a :
+      // Indent the first token after a : by one level
       code: $`
         ({code:
           "foo.bar();"})
-      `,
-      options: [2],
-    },
-    {
-
-      // Don't lint the indentation of the first token after a :
-      code: $`
-        ({code:
-        "foo.bar();"})
       `,
       options: [2],
     },
@@ -6501,7 +6492,7 @@ run<RuleOptions, MessageIds>({
           {
               type
               :
-              "json"
+                  "json"
           }
           ,
       )
@@ -6559,6 +6550,19 @@ run<RuleOptions, MessageIds>({
       `,
       options: [2],
       errors: expectedErrors([[3, 2, 0]]),
+    },
+    {
+      // Require one extra indentation level for the first token after a :
+      code: $`
+        ({code:
+        "foo.bar();"})
+      `,
+      output: $`
+        ({code:
+          "foo.bar();"})
+      `,
+      options: [2],
+      errors: expectedErrors([[2, 2, 0]]),
     },
     {
       code: $`
@@ -14179,7 +14183,7 @@ run<RuleOptions, MessageIds>({
             {
                 type
                 :
-        "json"
+                    "json"
             }
             ,
         )
@@ -14254,6 +14258,35 @@ run<RuleOptions, MessageIds>({
           : undefined
       `,
       options: [2, { offsetTernaryExpressions: true }],
+    },
+    // https://github.com/eslint-stylistic/eslint-stylistic/issues/1188
+    {
+      code: $`
+        const obj = {
+          key:
+              [
+                15,
+                27
+              ]
+        };
+      `,
+      output: $`
+        const obj = {
+        \tkey:
+        \t\t[
+        \t\t\t15,
+        \t\t\t27
+        \t\t]
+        };
+      `,
+      options: ['tab'],
+      errors: expectedErrors('tab', [
+        [2, 1, '2 spaces'],
+        [3, 2, '6 spaces'],
+        [4, 3, '8 spaces'],
+        [5, 3, '8 spaces'],
+        [6, 2, '6 spaces'],
+      ]),
     },
   ],
 })

--- a/packages/eslint-plugin/rules/indent/indent.ts
+++ b/packages/eslint-plugin/rules/indent/indent.ts
@@ -821,8 +821,9 @@ export default createRule<RuleOptions, MessageIds>({
       Property(node) {
         if (!node.shorthand && !node.method && node.kind === 'init') {
           const colon = sourceCode.getFirstTokenBetween(node.key, node.value, isColonToken)!
+          const valueToken = sourceCode.getTokenAfter(colon)!
 
-          offsets.ignoreToken(sourceCode.getTokenAfter(colon)!)
+          offsets.setDesiredOffset(valueToken, colon, 1)
         }
       },
 

--- a/packages/eslint-plugin/rules/lines-around-comment/lines-around-comment._js_.test.ts
+++ b/packages/eslint-plugin/rules/lines-around-comment/lines-around-comment._js_.test.ts
@@ -677,9 +677,9 @@ run<RuleOptions, MessageIds>({
     // check for object start comments
     {
       code:
-            'var a,\n\n'
-            + '// line\n'
-            + 'b;',
+        'var a,\n\n'
+        + '// line\n'
+        + 'b;',
       options: [{
         beforeLineComment: true,
         allowObjectStart: true,
@@ -687,10 +687,10 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'var obj = {\n'
-            + '  // line at object start\n'
-            + '  g: 1\n'
-            + '};',
+        'var obj = {\n'
+        + '  // line at object start\n'
+        + '  g: 1\n'
+        + '};',
       options: [{
         beforeLineComment: true,
         allowObjectStart: true,
@@ -698,13 +698,13 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'function hi() {\n'
-            + '  return {\n'
-            + '    // hi\n'
-            + '    test: function() {\n'
-            + '    }\n'
-            + '  }\n'
-            + '}',
+        'function hi() {\n'
+        + '  return {\n'
+        + '    // hi\n'
+        + '    test: function() {\n'
+        + '    }\n'
+        + '  }\n'
+        + '}',
       options: [{
         beforeLineComment: true,
         allowObjectStart: true,
@@ -712,10 +712,10 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'var obj = {\n'
-            + '  /* block comment at object start*/\n'
-            + '  g: 1\n'
-            + '};',
+        'var obj = {\n'
+        + '  /* block comment at object start*/\n'
+        + '  g: 1\n'
+        + '};',
       options: [{
         beforeBlockComment: true,
         allowObjectStart: true,
@@ -723,15 +723,15 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'function hi() {\n'
-            + '  return {\n'
-            + '    /**\n'
-            + '    * hi\n'
-            + '    */\n'
-            + '    test: function() {\n'
-            + '    }\n'
-            + '  }\n'
-            + '}',
+        'function hi() {\n'
+        + '  return {\n'
+        + '    /**\n'
+        + '    * hi\n'
+        + '    */\n'
+        + '    test: function() {\n'
+        + '    }\n'
+        + '  }\n'
+        + '}',
       options: [{
         beforeLineComment: true,
         allowObjectStart: true,
@@ -739,22 +739,10 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const {\n'
-            + '  // line at object start\n'
-            + '  g: a\n'
-            + '} = {};',
-      options: [{
-        beforeLineComment: true,
-        allowObjectStart: true,
-      }],
-      parserOptions: { ecmaVersion: 6 },
-    },
-    {
-      code:
-            'const {\n'
-            + '  // line at object start\n'
-            + '  g\n'
-            + '} = {};',
+        'const {\n'
+        + '  // line at object start\n'
+        + '  g: a\n'
+        + '} = {};',
       options: [{
         beforeLineComment: true,
         allowObjectStart: true,
@@ -763,10 +751,22 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const {\n'
-            + '  /* block comment at object-like start*/\n'
-            + '  g: a\n'
-            + '} = {};',
+        'const {\n'
+        + '  // line at object start\n'
+        + '  g\n'
+        + '} = {};',
+      options: [{
+        beforeLineComment: true,
+        allowObjectStart: true,
+      }],
+      parserOptions: { ecmaVersion: 6 },
+    },
+    {
+      code:
+        'const {\n'
+        + '  /* block comment at object-like start*/\n'
+        + '  g: a\n'
+        + '} = {};',
       options: [{
         beforeBlockComment: true,
         allowObjectStart: true,
@@ -775,10 +775,10 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const {\n'
-            + '  /* block comment at object-like start*/\n'
-            + '  g\n'
-            + '} = {};',
+        'const {\n'
+        + '  /* block comment at object-like start*/\n'
+        + '  g\n'
+        + '} = {};',
       options: [{
         beforeBlockComment: true,
         allowObjectStart: true,
@@ -789,9 +789,9 @@ run<RuleOptions, MessageIds>({
     // check for object end comments
     {
       code:
-            'var a,\n'
-            + '// line\n\n'
-            + 'b;',
+        'var a,\n'
+        + '// line\n\n'
+        + 'b;',
       options: [{
         afterLineComment: true,
         allowObjectEnd: true,
@@ -799,10 +799,10 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'var obj = {\n'
-            + '  g: 1\n'
-            + '  // line at object end\n'
-            + '};',
+        'var obj = {\n'
+        + '  g: 1\n'
+        + '  // line at object end\n'
+        + '};',
       options: [{
         afterLineComment: true,
         allowObjectEnd: true,
@@ -810,13 +810,13 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'function hi() {\n'
-            + '  return {\n'
-            + '    test: function() {\n'
-            + '    }\n'
-            + '    // hi\n'
-            + '  }\n'
-            + '}',
+        'function hi() {\n'
+        + '  return {\n'
+        + '    test: function() {\n'
+        + '    }\n'
+        + '    // hi\n'
+        + '  }\n'
+        + '}',
       options: [{
         afterLineComment: true,
         allowObjectEnd: true,
@@ -824,11 +824,11 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'var obj = {\n'
-            + '  g: 1\n'
-            + '  \n'
-            + '  /* block comment at object end*/\n'
-            + '};',
+        'var obj = {\n'
+        + '  g: 1\n'
+        + '  \n'
+        + '  /* block comment at object end*/\n'
+        + '};',
       options: [{
         afterBlockComment: true,
         allowObjectEnd: true,
@@ -836,16 +836,16 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'function hi() {\n'
-            + '  return {\n'
-            + '    test: function() {\n'
-            + '    }\n'
-            + '    \n'
-            + '    /**\n'
-            + '    * hi\n'
-            + '    */\n'
-            + '  }\n'
-            + '}',
+        'function hi() {\n'
+        + '  return {\n'
+        + '    test: function() {\n'
+        + '    }\n'
+        + '    \n'
+        + '    /**\n'
+        + '    * hi\n'
+        + '    */\n'
+        + '  }\n'
+        + '}',
       options: [{
         afterBlockComment: true,
         allowObjectEnd: true,
@@ -853,10 +853,10 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const {\n'
-            + '  g: a\n'
-            + '  // line at object end\n'
-            + '} = {};',
+        'const {\n'
+        + '  g: a\n'
+        + '  // line at object end\n'
+        + '} = {};',
       options: [{
         afterLineComment: true,
         allowObjectEnd: true,
@@ -865,10 +865,10 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const {\n'
-            + '  g\n'
-            + '  // line at object end\n'
-            + '} = {};',
+        'const {\n'
+        + '  g\n'
+        + '  // line at object end\n'
+        + '} = {};',
       options: [{
         afterLineComment: true,
         allowObjectEnd: true,
@@ -877,11 +877,11 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const {\n'
-            + '  g: a\n'
-            + '  \n'
-            + '  /* block comment at object-like end*/\n'
-            + '} = {};',
+        'const {\n'
+        + '  g: a\n'
+        + '  \n'
+        + '  /* block comment at object-like end*/\n'
+        + '} = {};',
       options: [{
         afterBlockComment: true,
         allowObjectEnd: true,
@@ -890,11 +890,11 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const {\n'
-            + '  g\n'
-            + '  \n'
-            + '  /* block comment at object-like end*/\n'
-            + '} = {};',
+        'const {\n'
+        + '  g\n'
+        + '  \n'
+        + '  /* block comment at object-like end*/\n'
+        + '} = {};',
       options: [{
         afterBlockComment: true,
         allowObjectEnd: true,
@@ -905,9 +905,9 @@ run<RuleOptions, MessageIds>({
     // check for array start comments
     {
       code:
-            'var a,\n\n'
-            + '// line\n'
-            + 'b;',
+        'var a,\n\n'
+        + '// line\n'
+        + 'b;',
       options: [{
         beforeLineComment: true,
         allowArrayStart: true,
@@ -915,10 +915,10 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'var arr = [\n'
-            + '  // line at array start\n'
-            + '  1\n'
-            + '];',
+        'var arr = [\n'
+        + '  // line at array start\n'
+        + '  1\n'
+        + '];',
       options: [{
         beforeLineComment: true,
         allowArrayStart: true,
@@ -926,10 +926,10 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'var arr = [\n'
-            + '  /* block comment at array start*/\n'
-            + '  1\n'
-            + '];',
+        'var arr = [\n'
+        + '  /* block comment at array start*/\n'
+        + '  1\n'
+        + '];',
       options: [{
         beforeBlockComment: true,
         allowArrayStart: true,
@@ -937,10 +937,10 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const [\n'
-            + '  // line at array start\n'
-            + '  a\n'
-            + '] = [];',
+        'const [\n'
+        + '  // line at array start\n'
+        + '  a\n'
+        + '] = [];',
       options: [{
         beforeLineComment: true,
         allowArrayStart: true,
@@ -949,10 +949,10 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const [\n'
-            + '  /* block comment at array start*/\n'
-            + '  a\n'
-            + '] = [];',
+        'const [\n'
+        + '  /* block comment at array start*/\n'
+        + '  a\n'
+        + '] = [];',
       options: [{
         beforeBlockComment: true,
         allowArrayStart: true,
@@ -963,9 +963,9 @@ run<RuleOptions, MessageIds>({
     // check for array end comments
     {
       code:
-            'var a,\n'
-            + '// line\n\n'
-            + 'b;',
+        'var a,\n'
+        + '// line\n\n'
+        + 'b;',
       options: [{
         afterLineComment: true,
         allowArrayEnd: true,
@@ -973,10 +973,10 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'var arr = [\n'
-            + '  1\n'
-            + '  // line at array end\n'
-            + '];',
+        'var arr = [\n'
+        + '  1\n'
+        + '  // line at array end\n'
+        + '];',
       options: [{
         afterLineComment: true,
         allowArrayEnd: true,
@@ -984,11 +984,11 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'var arr = [\n'
-            + '  1\n'
-            + '  \n'
-            + '  /* block comment at array end*/\n'
-            + '];',
+        'var arr = [\n'
+        + '  1\n'
+        + '  \n'
+        + '  /* block comment at array end*/\n'
+        + '];',
       options: [{
         afterBlockComment: true,
         allowArrayEnd: true,
@@ -996,10 +996,10 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const [\n'
-            + '  a\n'
-            + '  // line at array end\n'
-            + '] = [];',
+        'const [\n'
+        + '  a\n'
+        + '  // line at array end\n'
+        + '] = [];',
       options: [{
         afterLineComment: true,
         allowArrayEnd: true,
@@ -1008,11 +1008,11 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const [\n'
-            + '  a\n'
-            + '  \n'
-            + '  /* block comment at array end*/\n'
-            + '] = [];',
+        'const [\n'
+        + '  a\n'
+        + '  \n'
+        + '  /* block comment at array end*/\n'
+        + '] = [];',
       options: [{
         afterBlockComment: true,
         allowArrayEnd: true,
@@ -1023,12 +1023,12 @@ run<RuleOptions, MessageIds>({
     // ignorePattern
     {
       code:
-            'foo;\n\n'
-            + '/* eslint-disable no-underscore-dangle */\n\n'
-            + 'this._values = values;\n'
-            + 'this._values2 = true;\n'
-            + '/* eslint-enable no-underscore-dangle */\n'
-            + 'bar',
+        'foo;\n\n'
+        + '/* eslint-disable no-underscore-dangle */\n\n'
+        + 'this._values = values;\n'
+        + 'this._values2 = true;\n'
+        + '/* eslint-enable no-underscore-dangle */\n'
+        + 'bar',
       options: [{
         beforeBlockComment: true,
         afterBlockComment: true,
@@ -1640,16 +1640,16 @@ run<RuleOptions, MessageIds>({
     // object start comments
     {
       code:
-            'var obj = {\n'
-            + '  // line at object start\n'
-            + '  g: 1\n'
-            + '};',
+        'var obj = {\n'
+        + '  // line at object start\n'
+        + '  g: 1\n'
+        + '};',
       output:
-            'var obj = {\n'
-            + '\n'
-            + '  // line at object start\n'
-            + '  g: 1\n'
-            + '};',
+        'var obj = {\n'
+        + '\n'
+        + '  // line at object start\n'
+        + '  g: 1\n'
+        + '};',
       options: [{
         beforeLineComment: true,
       }],
@@ -1657,66 +1657,22 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'function hi() {\n'
-            + '  return {\n'
-            + '    // hi\n'
-            + '    test: function() {\n'
-            + '    }\n'
-            + '  }\n'
-            + '}',
+        'function hi() {\n'
+        + '  return {\n'
+        + '    // hi\n'
+        + '    test: function() {\n'
+        + '    }\n'
+        + '  }\n'
+        + '}',
       output:
-            'function hi() {\n'
-            + '  return {\n'
-            + '\n'
-            + '    // hi\n'
-            + '    test: function() {\n'
-            + '    }\n'
-            + '  }\n'
-            + '}',
-      options: [{
-        beforeLineComment: true,
-      }],
-      errors: [{ messageId: 'before', line: 3 }],
-    },
-    {
-      code:
-            'var obj = {\n'
-            + '  /* block comment at object start*/\n'
-            + '  g: 1\n'
-            + '};',
-      output:
-            'var obj = {\n'
-            + '\n'
-            + '  /* block comment at object start*/\n'
-            + '  g: 1\n'
-            + '};',
-      options: [{
-        beforeBlockComment: true,
-      }],
-      errors: [{ messageId: 'before', line: 2 }],
-    },
-    {
-      code:
-            'function hi() {\n'
-            + '  return {\n'
-            + '    /**\n'
-            + '    * hi\n'
-            + '    */\n'
-            + '    test: function() {\n'
-            + '    }\n'
-            + '  }\n'
-            + '}',
-      output:
-            'function hi() {\n'
-            + '  return {\n'
-            + '\n'
-            + '    /**\n'
-            + '    * hi\n'
-            + '    */\n'
-            + '    test: function() {\n'
-            + '    }\n'
-            + '  }\n'
-            + '}',
+        'function hi() {\n'
+        + '  return {\n'
+        + '\n'
+        + '    // hi\n'
+        + '    test: function() {\n'
+        + '    }\n'
+        + '  }\n'
+        + '}',
       options: [{
         beforeLineComment: true,
       }],
@@ -1724,16 +1680,60 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const {\n'
-            + '  // line at object start\n'
-            + '  g: a\n'
-            + '} = {};',
+        'var obj = {\n'
+        + '  /* block comment at object start*/\n'
+        + '  g: 1\n'
+        + '};',
       output:
-            'const {\n'
-            + '\n'
-            + '  // line at object start\n'
-            + '  g: a\n'
-            + '} = {};',
+        'var obj = {\n'
+        + '\n'
+        + '  /* block comment at object start*/\n'
+        + '  g: 1\n'
+        + '};',
+      options: [{
+        beforeBlockComment: true,
+      }],
+      errors: [{ messageId: 'before', line: 2 }],
+    },
+    {
+      code:
+        'function hi() {\n'
+        + '  return {\n'
+        + '    /**\n'
+        + '    * hi\n'
+        + '    */\n'
+        + '    test: function() {\n'
+        + '    }\n'
+        + '  }\n'
+        + '}',
+      output:
+        'function hi() {\n'
+        + '  return {\n'
+        + '\n'
+        + '    /**\n'
+        + '    * hi\n'
+        + '    */\n'
+        + '    test: function() {\n'
+        + '    }\n'
+        + '  }\n'
+        + '}',
+      options: [{
+        beforeLineComment: true,
+      }],
+      errors: [{ messageId: 'before', line: 3 }],
+    },
+    {
+      code:
+        'const {\n'
+        + '  // line at object start\n'
+        + '  g: a\n'
+        + '} = {};',
+      output:
+        'const {\n'
+        + '\n'
+        + '  // line at object start\n'
+        + '  g: a\n'
+        + '} = {};',
       options: [{
         beforeLineComment: true,
       }],
@@ -1742,16 +1742,16 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const {\n'
-            + '  // line at object start\n'
-            + '  g\n'
-            + '} = {};',
+        'const {\n'
+        + '  // line at object start\n'
+        + '  g\n'
+        + '} = {};',
       output:
-            'const {\n'
-            + '\n'
-            + '  // line at object start\n'
-            + '  g\n'
-            + '} = {};',
+        'const {\n'
+        + '\n'
+        + '  // line at object start\n'
+        + '  g\n'
+        + '} = {};',
       options: [{
         beforeLineComment: true,
       }],
@@ -1760,16 +1760,16 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const {\n'
-            + '  /* block comment at object-like start*/\n'
-            + '  g: a\n'
-            + '} = {};',
+        'const {\n'
+        + '  /* block comment at object-like start*/\n'
+        + '  g: a\n'
+        + '} = {};',
       output:
-            'const {\n'
-            + '\n'
-            + '  /* block comment at object-like start*/\n'
-            + '  g: a\n'
-            + '} = {};',
+        'const {\n'
+        + '\n'
+        + '  /* block comment at object-like start*/\n'
+        + '  g: a\n'
+        + '} = {};',
       options: [{
         beforeBlockComment: true,
       }],
@@ -1778,16 +1778,16 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const {\n'
-            + '  /* block comment at object-like start*/\n'
-            + '  g\n'
-            + '} = {};',
+        'const {\n'
+        + '  /* block comment at object-like start*/\n'
+        + '  g\n'
+        + '} = {};',
       output:
-            'const {\n'
-            + '\n'
-            + '  /* block comment at object-like start*/\n'
-            + '  g\n'
-            + '} = {};',
+        'const {\n'
+        + '\n'
+        + '  /* block comment at object-like start*/\n'
+        + '  g\n'
+        + '} = {};',
       options: [{
         beforeBlockComment: true,
       }],
@@ -1798,16 +1798,16 @@ run<RuleOptions, MessageIds>({
     // object end comments
     {
       code:
-            'var obj = {\n'
-            + '  g: 1\n'
-            + '  // line at object end\n'
-            + '};',
+        'var obj = {\n'
+        + '  g: 1\n'
+        + '  // line at object end\n'
+        + '};',
       output:
-            'var obj = {\n'
-            + '  g: 1\n'
-            + '  // line at object end\n'
-            + '\n'
-            + '};',
+        'var obj = {\n'
+        + '  g: 1\n'
+        + '  // line at object end\n'
+        + '\n'
+        + '};',
       options: [{
         afterLineComment: true,
       }],
@@ -1815,22 +1815,22 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'function hi() {\n'
-            + '  return {\n'
-            + '    test: function() {\n'
-            + '    }\n'
-            + '    // hi\n'
-            + '  }\n'
-            + '}',
+        'function hi() {\n'
+        + '  return {\n'
+        + '    test: function() {\n'
+        + '    }\n'
+        + '    // hi\n'
+        + '  }\n'
+        + '}',
       output:
-            'function hi() {\n'
-            + '  return {\n'
-            + '    test: function() {\n'
-            + '    }\n'
-            + '    // hi\n'
-            + '\n'
-            + '  }\n'
-            + '}',
+        'function hi() {\n'
+        + '  return {\n'
+        + '    test: function() {\n'
+        + '    }\n'
+        + '    // hi\n'
+        + '\n'
+        + '  }\n'
+        + '}',
       options: [{
         afterLineComment: true,
       }],
@@ -1838,18 +1838,18 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'var obj = {\n'
-            + '  g: 1\n'
-            + '  \n'
-            + '  /* block comment at object end*/\n'
-            + '};',
+        'var obj = {\n'
+        + '  g: 1\n'
+        + '  \n'
+        + '  /* block comment at object end*/\n'
+        + '};',
       output:
-            'var obj = {\n'
-            + '  g: 1\n'
-            + '  \n'
-            + '  /* block comment at object end*/\n'
-            + '\n'
-            + '};',
+        'var obj = {\n'
+        + '  g: 1\n'
+        + '  \n'
+        + '  /* block comment at object end*/\n'
+        + '\n'
+        + '};',
       options: [{
         afterBlockComment: true,
       }],
@@ -1857,28 +1857,28 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'function hi() {\n'
-            + '  return {\n'
-            + '    test: function() {\n'
-            + '    }\n'
-            + '    \n'
-            + '    /**\n'
-            + '    * hi\n'
-            + '    */\n'
-            + '  }\n'
-            + '}',
+        'function hi() {\n'
+        + '  return {\n'
+        + '    test: function() {\n'
+        + '    }\n'
+        + '    \n'
+        + '    /**\n'
+        + '    * hi\n'
+        + '    */\n'
+        + '  }\n'
+        + '}',
       output:
-            'function hi() {\n'
-            + '  return {\n'
-            + '    test: function() {\n'
-            + '    }\n'
-            + '    \n'
-            + '    /**\n'
-            + '    * hi\n'
-            + '    */\n'
-            + '\n'
-            + '  }\n'
-            + '}',
+        'function hi() {\n'
+        + '  return {\n'
+        + '    test: function() {\n'
+        + '    }\n'
+        + '    \n'
+        + '    /**\n'
+        + '    * hi\n'
+        + '    */\n'
+        + '\n'
+        + '  }\n'
+        + '}',
       options: [{
         afterBlockComment: true,
       }],
@@ -1886,16 +1886,16 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const {\n'
-            + '  g: a\n'
-            + '  // line at object end\n'
-            + '} = {};',
+        'const {\n'
+        + '  g: a\n'
+        + '  // line at object end\n'
+        + '} = {};',
       output:
-            'const {\n'
-            + '  g: a\n'
-            + '  // line at object end\n'
-            + '\n'
-            + '} = {};',
+        'const {\n'
+        + '  g: a\n'
+        + '  // line at object end\n'
+        + '\n'
+        + '} = {};',
       options: [{
         afterLineComment: true,
       }],
@@ -1904,16 +1904,16 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const {\n'
-            + '  g\n'
-            + '  // line at object end\n'
-            + '} = {};',
+        'const {\n'
+        + '  g\n'
+        + '  // line at object end\n'
+        + '} = {};',
       output:
-            'const {\n'
-            + '  g\n'
-            + '  // line at object end\n'
-            + '\n'
-            + '} = {};',
+        'const {\n'
+        + '  g\n'
+        + '  // line at object end\n'
+        + '\n'
+        + '} = {};',
       options: [{
         afterLineComment: true,
       }],
@@ -1922,18 +1922,18 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const {\n'
-            + '  g: a\n'
-            + '  \n'
-            + '  /* block comment at object-like end*/\n'
-            + '} = {};',
+        'const {\n'
+        + '  g: a\n'
+        + '  \n'
+        + '  /* block comment at object-like end*/\n'
+        + '} = {};',
       output:
-            'const {\n'
-            + '  g: a\n'
-            + '  \n'
-            + '  /* block comment at object-like end*/\n'
-            + '\n'
-            + '} = {};',
+        'const {\n'
+        + '  g: a\n'
+        + '  \n'
+        + '  /* block comment at object-like end*/\n'
+        + '\n'
+        + '} = {};',
       options: [{
         afterBlockComment: true,
       }],
@@ -1942,18 +1942,18 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const {\n'
-            + '  g\n'
-            + '  \n'
-            + '  /* block comment at object-like end*/\n'
-            + '} = {};',
+        'const {\n'
+        + '  g\n'
+        + '  \n'
+        + '  /* block comment at object-like end*/\n'
+        + '} = {};',
       output:
-            'const {\n'
-            + '  g\n'
-            + '  \n'
-            + '  /* block comment at object-like end*/\n'
-            + '\n'
-            + '} = {};',
+        'const {\n'
+        + '  g\n'
+        + '  \n'
+        + '  /* block comment at object-like end*/\n'
+        + '\n'
+        + '} = {};',
       options: [{
         afterBlockComment: true,
       }],
@@ -1964,16 +1964,16 @@ run<RuleOptions, MessageIds>({
     // array start comments
     {
       code:
-            'var arr = [\n'
-            + '  // line at array start\n'
-            + '  1\n'
-            + '];',
+        'var arr = [\n'
+        + '  // line at array start\n'
+        + '  1\n'
+        + '];',
       output:
-            'var arr = [\n'
-            + '\n'
-            + '  // line at array start\n'
-            + '  1\n'
-            + '];',
+        'var arr = [\n'
+        + '\n'
+        + '  // line at array start\n'
+        + '  1\n'
+        + '];',
       options: [{
         beforeLineComment: true,
       }],
@@ -1981,16 +1981,16 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'var arr = [\n'
-            + '  /* block comment at array start*/\n'
-            + '  1\n'
-            + '];',
+        'var arr = [\n'
+        + '  /* block comment at array start*/\n'
+        + '  1\n'
+        + '];',
       output:
-            'var arr = [\n'
-            + '\n'
-            + '  /* block comment at array start*/\n'
-            + '  1\n'
-            + '];',
+        'var arr = [\n'
+        + '\n'
+        + '  /* block comment at array start*/\n'
+        + '  1\n'
+        + '];',
       options: [{
         beforeBlockComment: true,
       }],
@@ -1998,16 +1998,16 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const [\n'
-            + '  // line at array start\n'
-            + '  a\n'
-            + '] = [];',
+        'const [\n'
+        + '  // line at array start\n'
+        + '  a\n'
+        + '] = [];',
       output:
-            'const [\n'
-            + '\n'
-            + '  // line at array start\n'
-            + '  a\n'
-            + '] = [];',
+        'const [\n'
+        + '\n'
+        + '  // line at array start\n'
+        + '  a\n'
+        + '] = [];',
       options: [{
         beforeLineComment: true,
       }],
@@ -2016,16 +2016,16 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const [\n'
-            + '  /* block comment at array start*/\n'
-            + '  a\n'
-            + '] = [];',
+        'const [\n'
+        + '  /* block comment at array start*/\n'
+        + '  a\n'
+        + '] = [];',
       output:
-            'const [\n'
-            + '\n'
-            + '  /* block comment at array start*/\n'
-            + '  a\n'
-            + '] = [];',
+        'const [\n'
+        + '\n'
+        + '  /* block comment at array start*/\n'
+        + '  a\n'
+        + '] = [];',
       options: [{
         beforeBlockComment: true,
       }],
@@ -2036,16 +2036,16 @@ run<RuleOptions, MessageIds>({
     // array end comments
     {
       code:
-            'var arr = [\n'
-            + '  1\n'
-            + '  // line at array end\n'
-            + '];',
+        'var arr = [\n'
+        + '  1\n'
+        + '  // line at array end\n'
+        + '];',
       output:
-            'var arr = [\n'
-            + '  1\n'
-            + '  // line at array end\n'
-            + '\n'
-            + '];',
+        'var arr = [\n'
+        + '  1\n'
+        + '  // line at array end\n'
+        + '\n'
+        + '];',
       options: [{
         afterLineComment: true,
       }],
@@ -2053,18 +2053,18 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'var arr = [\n'
-            + '  1\n'
-            + '  \n'
-            + '  /* block comment at array end*/\n'
-            + '];',
+        'var arr = [\n'
+        + '  1\n'
+        + '  \n'
+        + '  /* block comment at array end*/\n'
+        + '];',
       output:
-            'var arr = [\n'
-            + '  1\n'
-            + '  \n'
-            + '  /* block comment at array end*/\n'
-            + '\n'
-            + '];',
+        'var arr = [\n'
+        + '  1\n'
+        + '  \n'
+        + '  /* block comment at array end*/\n'
+        + '\n'
+        + '];',
       options: [{
         afterBlockComment: true,
       }],
@@ -2072,16 +2072,16 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const [\n'
-            + '  a\n'
-            + '  // line at array end\n'
-            + '] = [];',
+        'const [\n'
+        + '  a\n'
+        + '  // line at array end\n'
+        + '] = [];',
       output:
-            'const [\n'
-            + '  a\n'
-            + '  // line at array end\n'
-            + '\n'
-            + '] = [];',
+        'const [\n'
+        + '  a\n'
+        + '  // line at array end\n'
+        + '\n'
+        + '] = [];',
       options: [{
         afterLineComment: true,
       }],
@@ -2090,18 +2090,18 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'const [\n'
-            + '  a\n'
-            + '  \n'
-            + '  /* block comment at array end*/\n'
-            + '] = [];',
+        'const [\n'
+        + '  a\n'
+        + '  \n'
+        + '  /* block comment at array end*/\n'
+        + '] = [];',
       output:
-            'const [\n'
-            + '  a\n'
-            + '  \n'
-            + '  /* block comment at array end*/\n'
-            + '\n'
-            + '] = [];',
+        'const [\n'
+        + '  a\n'
+        + '  \n'
+        + '  /* block comment at array end*/\n'
+        + '\n'
+        + '] = [];',
       options: [{
         afterBlockComment: true,
       }],
@@ -2112,21 +2112,21 @@ run<RuleOptions, MessageIds>({
     // ignorePattern
     {
       code:
-            'foo;\n\n'
-            + '/* eslint-disable no-underscore-dangle */\n\n'
-            + 'this._values = values;\n'
-            + 'this._values2 = true;\n'
-            + '/* eslint-enable no-underscore-dangle */\n'
-            + 'bar',
+        'foo;\n\n'
+        + '/* eslint-disable no-underscore-dangle */\n\n'
+        + 'this._values = values;\n'
+        + 'this._values2 = true;\n'
+        + '/* eslint-enable no-underscore-dangle */\n'
+        + 'bar',
       output:
-            'foo;\n\n'
-            + '/* eslint-disable no-underscore-dangle */\n\n'
-            + 'this._values = values;\n'
-            + 'this._values2 = true;\n'
-            + '\n'
-            + '/* eslint-enable no-underscore-dangle */\n'
-            + '\n'
-            + 'bar',
+        'foo;\n\n'
+        + '/* eslint-disable no-underscore-dangle */\n\n'
+        + 'this._values = values;\n'
+        + 'this._values2 = true;\n'
+        + '\n'
+        + '/* eslint-enable no-underscore-dangle */\n'
+        + '\n'
+        + 'bar',
       options: [{
         beforeBlockComment: true,
         afterBlockComment: true,

--- a/packages/eslint-plugin/rules/max-len/max-len.test.ts
+++ b/packages/eslint-plugin/rules/max-len/max-len.test.ts
@@ -70,28 +70,28 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-                '/* hey there! this is a multiline\n'
-                + '   comment with longish lines in various places\n'
-                + '   but\n'
-                + '   with a short line-length */',
+        '/* hey there! this is a multiline\n'
+        + '   comment with longish lines in various places\n'
+        + '   but\n'
+        + '   with a short line-length */',
       options: [10, 4, { ignoreComments: true }],
     },
     {
       code:
-                '// I like short comments\n'
-                + 'function butLongSourceLines() { weird(eh()) }',
+        '// I like short comments\n'
+        + 'function butLongSourceLines() { weird(eh()) }',
       options: [80, { tabWidth: 4, comments: 30 }],
     },
     {
       code:
-                '// I like longer comments and shorter code\n'
-                + 'function see() { odd(eh()) }',
+        '// I like longer comments and shorter code\n'
+        + 'function see() { odd(eh()) }',
       options: [30, { tabWidth: 4, comments: 80 }],
     },
     {
       code:
-                '// Full line comment\n'
-                + 'someCode(); // With a long trailing comment.',
+        '// Full line comment\n'
+        + 'someCode(); // With a long trailing comment.',
       options: [{ code: 30, tabWidth: 4, comments: 20, ignoreTrailingComments: true }],
     },
     {
@@ -426,8 +426,8 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-                'var foobar = \'this line isn\\\'t matched by the regexp\';\n'
-                + 'var fizzbuzz = \'but this one is matched by the regexp\';\n',
+        'var foobar = \'this line isn\\\'t matched by the regexp\';\n'
+        + 'var fizzbuzz = \'but this one is matched by the regexp\';\n',
       options: [20, 4, { ignorePattern: 'fizzbuzz' }],
       errors: [
         {

--- a/packages/eslint-plugin/rules/no-multiple-empty-lines/no-multiple-empty-lines.test.ts
+++ b/packages/eslint-plugin/rules/no-multiple-empty-lines/no-multiple-empty-lines.test.ts
@@ -275,16 +275,16 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            '\'foo\';\n'
-            + '\n'
-            + '\n'
-            + '`bar`;\n'
-            + '`baz`;',
+        '\'foo\';\n'
+        + '\n'
+        + '\n'
+        + '`bar`;\n'
+        + '`baz`;',
       output:
-            '\'foo\';\n'
-            + '\n'
-            + '`bar`;\n'
-            + '`baz`;',
+        '\'foo\';\n'
+        + '\n'
+        + '`bar`;\n'
+        + '`baz`;',
       options: [{ max: 1 }],
       parserOptions: { ecmaVersion: 6 },
       errors: [getExpectedError(1)],

--- a/packages/eslint-plugin/rules/no-tabs/no-tabs.test.ts
+++ b/packages/eslint-plugin/rules/no-tabs/no-tabs.test.ts
@@ -48,9 +48,9 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'function test(){\n'
-            + '  //\tsdfdsf \n'
-            + '}',
+        'function test(){\n'
+        + '  //\tsdfdsf \n'
+        + '}',
       errors: [{
         messageId: 'unexpectedTab',
         line: 2,
@@ -61,9 +61,9 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'function\ttest(){\n'
-            + '  //sdfdsf \n'
-            + '}',
+        'function\ttest(){\n'
+        + '  //sdfdsf \n'
+        + '}',
       errors: [{
         messageId: 'unexpectedTab',
         line: 1,
@@ -74,9 +74,9 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            'function test(){\n'
-            + '  //\tsdfdsf \n'
-            + '\t}',
+        'function test(){\n'
+        + '  //\tsdfdsf \n'
+        + '\t}',
       errors: [
         {
           messageId: 'unexpectedTab',

--- a/packages/eslint-plugin/rules/no-trailing-spaces/no-trailing-spaces.test.ts
+++ b/packages/eslint-plugin/rules/no-trailing-spaces/no-trailing-spaces.test.ts
@@ -91,76 +91,76 @@ run<RuleOptions, MessageIds>({
   invalid: [
     {
       code:
-            'var short2 = true;\r\n'
-            + '\r\n'
-            + 'module.exports = {\r\n'
-            + '  short: short,    \r\n'
-            + '  short2: short\r\n'
-            + '}',
+        'var short2 = true;\r\n'
+        + '\r\n'
+        + 'module.exports = {\r\n'
+        + '  short: short,    \r\n'
+        + '  short2: short\r\n'
+        + '}',
       output:
-            'var short2 = true;\r\n'
-            + '\r\n'
-            + 'module.exports = {\r\n'
-            + '  short: short,\r\n'
-            + '  short2: short\r\n'
-            + '}',
+        'var short2 = true;\r\n'
+        + '\r\n'
+        + 'module.exports = {\r\n'
+        + '  short: short,\r\n'
+        + '  short2: short\r\n'
+        + '}',
       errors: [{
         messageId: 'trailingSpace',
       }],
     },
     {
       code:
-            'var short2 = true;\n'
-            + '\r\n'
-            + 'module.exports = {\r\n'
-            + '  short: short,    \r\n'
-            + '  short2: short\n'
-            + '}',
+        'var short2 = true;\n'
+        + '\r\n'
+        + 'module.exports = {\r\n'
+        + '  short: short,    \r\n'
+        + '  short2: short\n'
+        + '}',
       output:
-            'var short2 = true;\n'
-            + '\r\n'
-            + 'module.exports = {\r\n'
-            + '  short: short,\r\n'
-            + '  short2: short\n'
-            + '}',
+        'var short2 = true;\n'
+        + '\r\n'
+        + 'module.exports = {\r\n'
+        + '  short: short,\r\n'
+        + '  short2: short\n'
+        + '}',
       errors: [{
         messageId: 'trailingSpace',
       }],
     },
     {
       code:
-            'var short2 = true;\n'
-            + '\n'
-            + 'module.exports = {\n'
-            + '  short: short,    \n'
-            + '  short2: short\n'
-            + '}\n',
+        'var short2 = true;\n'
+        + '\n'
+        + 'module.exports = {\n'
+        + '  short: short,    \n'
+        + '  short2: short\n'
+        + '}\n',
       output:
-            'var short2 = true;\n'
-            + '\n'
-            + 'module.exports = {\n'
-            + '  short: short,\n'
-            + '  short2: short\n'
-            + '}\n',
+        'var short2 = true;\n'
+        + '\n'
+        + 'module.exports = {\n'
+        + '  short: short,\n'
+        + '  short2: short\n'
+        + '}\n',
       errors: [{
         messageId: 'trailingSpace',
       }],
     },
     {
       code:
-            'var short2 = true;\n'
-            + '\n'
-            + 'module.exports = {\n'
-            + '  short,    \n'
-            + '  short2\n'
-            + '}\n',
+        'var short2 = true;\n'
+        + '\n'
+        + 'module.exports = {\n'
+        + '  short,    \n'
+        + '  short2\n'
+        + '}\n',
       output:
-            'var short2 = true;\n'
-            + '\n'
-            + 'module.exports = {\n'
-            + '  short,\n'
-            + '  short2\n'
-            + '}\n',
+        'var short2 = true;\n'
+        + '\n'
+        + 'module.exports = {\n'
+        + '  short,\n'
+        + '  short2\n'
+        + '}\n',
       parserOptions: { ecmaVersion: 6 },
       errors: [{
         messageId: 'trailingSpace',
@@ -168,24 +168,24 @@ run<RuleOptions, MessageIds>({
     },
     {
       code:
-            '\n'
-            + 'measAr.push("<dl></dl>",  \n'
-            + '         " </dt><dd class =\'pta-res\'>");',
+        '\n'
+        + 'measAr.push("<dl></dl>",  \n'
+        + '         " </dt><dd class =\'pta-res\'>");',
       output:
-            '\n'
-            + 'measAr.push("<dl></dl>",\n'
-            + '         " </dt><dd class =\'pta-res\'>");',
+        '\n'
+        + 'measAr.push("<dl></dl>",\n'
+        + '         " </dt><dd class =\'pta-res\'>");',
       errors: [{
         messageId: 'trailingSpace',
       }],
     },
     {
       code:
-            'measAr.push("<dl></dl>",  \n'
-            + '         " </dt><dd class =\'pta-res\'>");',
+        'measAr.push("<dl></dl>",  \n'
+        + '         " </dt><dd class =\'pta-res\'>");',
       output:
-            'measAr.push("<dl></dl>",\n'
-            + '         " </dt><dd class =\'pta-res\'>");',
+        'measAr.push("<dl></dl>",\n'
+        + '         " </dt><dd class =\'pta-res\'>");',
       errors: [{
         messageId: 'trailingSpace',
       }],

--- a/packages/eslint-plugin/rules/quote-props/quote-props._js_.test.ts
+++ b/packages/eslint-plugin/rules/quote-props/quote-props._js_.test.ts
@@ -256,17 +256,17 @@ run<RuleOptions, MessageIds>({
     ],
   }, {
     code:
-        '({\n'
-        + '  /* a */ \'prop1\' /* b */ : /* c */ value1 /* d */ ,\n'
-        + '  /* e */ prop2 /* f */ : /* g */ value2 /* h */,\n'
-        + '  /* i */ "prop3" /* j */ : /* k */ value3 /* l */\n'
-        + '})',
+      '({\n'
+      + '  /* a */ \'prop1\' /* b */ : /* c */ value1 /* d */ ,\n'
+      + '  /* e */ prop2 /* f */ : /* g */ value2 /* h */,\n'
+      + '  /* i */ "prop3" /* j */ : /* k */ value3 /* l */\n'
+      + '})',
     output:
-        '({\n'
-        + '  /* a */ \'prop1\' /* b */ : /* c */ value1 /* d */ ,\n'
-        + '  /* e */ "prop2" /* f */ : /* g */ value2 /* h */,\n'
-        + '  /* i */ "prop3" /* j */ : /* k */ value3 /* l */\n'
-        + '})',
+      '({\n'
+      + '  /* a */ \'prop1\' /* b */ : /* c */ value1 /* d */ ,\n'
+      + '  /* e */ "prop2" /* f */ : /* g */ value2 /* h */,\n'
+      + '  /* i */ "prop3" /* j */ : /* k */ value3 /* l */\n'
+      + '})',
     options: ['consistent'],
     errors: [{
       messageId: 'inconsistentlyQuotedProperty',
@@ -274,17 +274,17 @@ run<RuleOptions, MessageIds>({
     }],
   }, {
     code:
-        '({\n'
-        + '  /* a */ "foo" /* b */ : /* c */ value1 /* d */ ,\n'
-        + '  /* e */ "bar" /* f */ : /* g */ value2 /* h */,\n'
-        + '  /* i */ "baz" /* j */ : /* k */ value3 /* l */\n'
-        + '})',
+      '({\n'
+      + '  /* a */ "foo" /* b */ : /* c */ value1 /* d */ ,\n'
+      + '  /* e */ "bar" /* f */ : /* g */ value2 /* h */,\n'
+      + '  /* i */ "baz" /* j */ : /* k */ value3 /* l */\n'
+      + '})',
     output:
-        '({\n'
-        + '  /* a */ foo /* b */ : /* c */ value1 /* d */ ,\n'
-        + '  /* e */ bar /* f */ : /* g */ value2 /* h */,\n'
-        + '  /* i */ baz /* j */ : /* k */ value3 /* l */\n'
-        + '})',
+      '({\n'
+      + '  /* a */ foo /* b */ : /* c */ value1 /* d */ ,\n'
+      + '  /* e */ bar /* f */ : /* g */ value2 /* h */,\n'
+      + '  /* i */ baz /* j */ : /* k */ value3 /* l */\n'
+      + '})',
     options: ['consistent-as-needed'],
     errors: [
       { messageId: 'redundantQuoting' },


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- If this PR contains unrelated changes, they should be in a separate commit/PR.
- If this PR changes documented rule defaults, confirm it does not conflict with the [FAQ](https://eslint.style/guide/faq#why-are-some-rule-defaults-different-from-documentation).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Close #1188

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Behavior Changes**
  - The `indent` rule now requires property values beginning on a new line after `:` to be indented one level from the colon.

- **Bug Fixes**
  - Updated diagnostics and automatic fixes for previously accepted misaligned property values.
  - Improved indentation handling for nested arrays and JSON import assertions.

- **Documentation**
  - Added upgrade guidance, including how to preserve legacy alignment where needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->