### PR TITLE
docs(list-style): fix rule name in examples and typos

### DIFF
--- a/packages/eslint-plugin/rules/list-style/README.md
+++ b/packages/eslint-plugin/rules/list-style/README.md
@@ -19,7 +19,7 @@ Enforce consistent spacing and line break styles inside brackets.
 
 This rule requires or disallows a line break between object/array/named imports/exports and function parameters and other similar structures.
 
-It check the newline style of the first property or item and apply the same style to the rest of the properties or items. This allows you to easily wrap or unwrap your code consistently.
+It checks the newline style of the first property or item and applies the same style to the rest of the properties or items. This allows you to easily wrap or unwrap your code consistently.
 
 ## Options
 
@@ -284,7 +284,7 @@ let [b] = bar;
 
 You can also specify different options for various node types:
 
-- `ArrayExpression`: arrays expressions
+- `ArrayExpression`: array expressions
 - `ArrayPattern`: array patterns of destructuring assignments
 - `ArrowFunctionExpression`: parameters of arrow function declarations
 - `CallExpression`: parameters of call expressions
@@ -299,13 +299,13 @@ You can also specify different options for various node types:
 - `ObjectPattern`: object patterns of destructuring assignments
 - `TSDeclareFunction`: parameters of function type declarations
 - `TSFunctionType`: parameters of arrow function type declarations
-- `TSInterfaceBody`: interfaces declarations
+- `TSInterfaceBody`: interface declarations
 - `TSEnumBody`: enum declarations
 - `TSTupleType`: tuple types
 - `TSTypeLiteral`: type literals
 - `TSTypeParameterDeclaration`: type parameter declarations
 - `TSTypeParameterInstantiation`: type parameter instantiations
-- `JSONArrayExpression`: arrays expressions in JSON files
+- `JSONArrayExpression`: array expressions in JSON files
 - `JSONObjectExpression`: object literals in JSON files
 
 Example of node-specific override:

--- a/packages/eslint-plugin/rules/list-style/README.md
+++ b/packages/eslint-plugin/rules/list-style/README.md
@@ -286,15 +286,15 @@ You can also specify different options for various node types:
 
 - `ArrayExpression`: array expressions
 - `ArrayPattern`: array patterns of destructuring assignments
-- `ArrowFunctionExpression`: parameters of arrow function declarations
-- `CallExpression`: parameters of call expressions
+- `ArrowFunctionExpression`: parameters of arrow function expressions
+- `CallExpression`: arguments of call expressions
 - `ExportNamedDeclaration`: named exports
 - `FunctionDeclaration`: parameters of function declarations
 - `FunctionExpression`: parameters of function expressions
 - `IfStatement`: condition of if statements
 - `ImportDeclaration`: named imports
 - `ImportAttributes`: import attributes
-- `NewExpression`: parameters of new expressions
+- `NewExpression`: arguments of new expressions
 - `ObjectExpression`: object literals
 - `ObjectPattern`: object patterns of destructuring assignments
 - `TSDeclareFunction`: parameters of function type declarations

--- a/packages/eslint-plugin/rules/list-style/README.md
+++ b/packages/eslint-plugin/rules/list-style/README.md
@@ -206,7 +206,7 @@ Examples of **correct** code with the default `"ignore"` option:
 ::: correct
 
 ```ts
-/* eslint @stylistic/exp-list-style: ["error", { "empty": "ignore" }] */
+/* eslint @stylistic/list-style: ["error", { "empty": "ignore" }] */
 
 const array = [ ]
 const object = {}
@@ -220,7 +220,7 @@ Examples of **correct** code with the `"always"` option:
 ::: correct
 
 ```ts
-/* eslint @stylistic/exp-list-style: ["error", { "empty": "always" }] */
+/* eslint @stylistic/list-style: ["error", { "empty": "always" }] */
 
 const array = [ ]
 const object = { }
@@ -234,7 +234,7 @@ Examples of **incorrect** code with the `"never"` option and `multiLine.minItems
 ::: incorrect
 
 ```ts
-/* eslint @stylistic/exp-list-style: ["error", { "empty": "never", "multiLine": { "minItems": 1 } }] */
+/* eslint @stylistic/list-style: ["error", { "empty": "never", "multiLine": { "minItems": 1 } }] */
 
 const array = [ ]
 const object = {
@@ -249,7 +249,7 @@ Examples of **correct** code with the `"never"` option and `multiLine.minItems` 
 ::: correct
 
 ```ts
-/* eslint @stylistic/exp-list-style: ["error", { "empty": "never", "multiLine": { "minItems": 1 } }] */
+/* eslint @stylistic/list-style: ["error", { "empty": "never", "multiLine": { "minItems": 1 } }] */
 
 const array = []
 const object = {}

--- a/packages/eslint-plugin/rules/list-style/README.md
+++ b/packages/eslint-plugin/rules/list-style/README.md
@@ -297,8 +297,8 @@ You can also specify different options for various node types:
 - `NewExpression`: arguments of new expressions
 - `ObjectExpression`: object literals
 - `ObjectPattern`: object patterns of destructuring assignments
-- `TSDeclareFunction`: parameters of function type declarations
-- `TSFunctionType`: parameters of arrow function type declarations
+- `TSDeclareFunction`: parameters of ambient function declarations and overload signatures
+- `TSFunctionType`: parameters of TypeScript function types
 - `TSInterfaceBody`: interface declarations
 - `TSEnumBody`: enum declarations
 - `TSTupleType`: tuple types


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://eslint.style/contribute/guide).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- If this PR contains unrelated changes, they should be in a separate commit/PR.
- If this PR changes documented rule defaults, confirm it does not conflict with the [FAQ](https://eslint.style/guide/faq#why-are-some-rule-defaults-different-from-documentation).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Documentation fixes for the `list-style` rule README:

- The `empty` option examples still used the experimental rule name `@stylistic/exp-list-style`
- Grammar fixes in `Rule Details` and `overrides` list
- Node type fixes in `overrides`

### Linked Issues

No open issue, doc-only fixes.

### Additional context

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated list-style rule examples to use the current rule name.
  * Corrected grammar and clarified node-type descriptions.
  * Added documentation for additional import, JSON, expression, and parameter node types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->