### PR TITLE
feat(newline-per-chained-call): support overrides

### DIFF
--- a/packages/eslint-plugin/rules/newline-per-chained-call/README.md
+++ b/packages/eslint-plugin/rules/newline-per-chained-call/README.md
@@ -60,6 +60,8 @@ This rule requires a newline after each call in a method chain or deep member ac
 This rule has an object option:
 
 - `"ignoreChainWithDepth"` (default: `2`) allows chains up to a specified depth.
+- `"tabWidth"` (default: `4`) sets the width of tabs when checking an override's `maxLineLength`.
+- `"overrides"` allows imported chains to use a different depth.
 
 ### ignoreChainWithDepth
 
@@ -123,6 +125,40 @@ obj
 ```
 
 :::
+
+### overrides
+
+Use `overrides` to allow a different chain depth for specific imports:
+
+::: correct
+
+```js
+/* eslint @stylistic/newline-per-chained-call: ["error", {
+    "ignoreChainWithDepth": 2,
+    "tabWidth": 4,
+    "overrides": [{
+        "chainRoot": "select",
+        "importedFrom": ["d3", "d3/*"],
+        "maxLineLength": 120,
+        "ignoreChainWithDepth": 5
+    }]
+}] */
+
+import { select } from "d3";
+
+const selection = select("body").selectAll("p").data([4, 8, 15]).enter();
+```
+
+:::
+
+`chainRoot` is the identifier at the root of the chain, and `importedFrom` is where it can be imported from. Both can be a string or an array of strings.
+To match a default import, use an empty string (`""`) in `chainRoot`.
+A trailing `/*` in `importedFrom` matches package subpaths. For example, `["d3", "d3/*"]` matches both `d3` and subpaths such as `d3/selection`.
+
+The first matching override's `ignoreChainWithDepth` replaces the rule-level value.
+
+When `maxLineLength` is set, the override only applies if the relevant source line is within that length.
+Tabs are expanded according to `tabWidth`.
 
 ## When Not To Use It
 

--- a/packages/eslint-plugin/rules/newline-per-chained-call/README.md
+++ b/packages/eslint-plugin/rules/newline-per-chained-call/README.md
@@ -61,7 +61,7 @@ This rule has an object option:
 
 - `"ignoreChainWithDepth"` (default: `2`) allows chains up to a specified depth.
 - `"tabWidth"` (default: `4`) sets the width of tabs when checking an override's `maxLineLength`.
-- `"overrides"` allows imported chains to use a different depth.
+- `"overrides"` allows matching chains to use a different depth.
 
 ### ignoreChainWithDepth
 
@@ -152,13 +152,15 @@ const selection = select("body").selectAll("p").data([4, 8, 15]).enter();
 :::
 
 `chainRoot` is the identifier at the root of the chain, and `importedFrom` is where it can be imported from. Both can be a string or an array of strings.
-To match a default import, use an empty string (`""`) in `chainRoot`.
+When `treatDefaultAsNamespace` is set to `false`, matching a default imports is done using an empty string (`""`).
 A trailing `/*` in `importedFrom` matches package subpaths. For example, `["d3", "d3/*"]` matches both `d3` and subpaths such as `d3/selection`.
 
 The first matching override's `ignoreChainWithDepth` replaces the rule-level value.
 
 When `maxLineLength` is set, the override only applies if the relevant source line is within that length.
 Tabs are expanded according to `tabWidth`.
+
+To match all chains solely based on their line length, omit both `chainRoot` and `importedFrom` and set `maxLineLength`.
 
 ## When Not To Use It
 

--- a/packages/eslint-plugin/rules/newline-per-chained-call/newline-per-chained-call.test.ts
+++ b/packages/eslint-plugin/rules/newline-per-chained-call/newline-per-chained-call.test.ts
@@ -35,6 +35,58 @@ run<RuleOptions, MessageIds>({
         ignoreChainWithDepth: 8,
       }],
     },
+    {
+      code: [
+        'import { select } from \'d3\';',
+        'import { select as selector } from \'d3/v4/core\';',
+        'import d3Default from \'d3\';',
+        'import * as d3Namespace from \'d3/v4\';',
+        'select(\'body\').selectAll(\'p\').data([1]);',
+        'selector(\'body\').selectAll(\'p\').data([1]);',
+        'd3Default.select(\'body\').selectAll(\'p\').data([1]);',
+        'd3Namespace.select(\'body\').selectAll(\'p\').data([1]);',
+        'select?.(\'body\')?.selectAll(\'p\')?.data([1]);',
+      ].join('\n'),
+      options: [{
+        ignoreChainWithDepth: 2,
+        overrides: [{
+          chainRoot: ['select', ''],
+          importedFrom: ['d3', 'd3/*'],
+          ignoreChainWithDepth: 5,
+        }],
+      }],
+    },
+    {
+      code: [
+        'import { select } from \'d3\';',
+        'select(\'body\').selectAll(\'p\').data([1]);',
+      ].join('\n'),
+      options: [{
+        ignoreChainWithDepth: 2,
+        overrides: [{
+          chainRoot: 'select',
+          importedFrom: 'd3',
+          ignoreChainWithDepth: 5,
+          maxLineLength: 40,
+        }],
+      }],
+    },
+    {
+      code: [
+        'import { select } from \'d3\';',
+        '  \tselect(\'body\').selectAll(\'p\').data([1]);',
+      ].join('\n'),
+      options: [{
+        ignoreChainWithDepth: 2,
+        tabWidth: 4,
+        overrides: [{
+          chainRoot: 'select',
+          importedFrom: 'd3',
+          ignoreChainWithDepth: 5,
+          maxLineLength: 44,
+        }],
+      }],
+    },
   ],
   invalid: [
     {
@@ -367,6 +419,155 @@ run<RuleOptions, MessageIds>({
         endLine: 1,
         endColumn: 35,
       }],
+    },
+    {
+      code: [
+        'import { select } from \'other-library\';',
+        'import { select as subpath } from \'d3/v4\';',
+        'select(\'body\').selectAll(\'p\').data([1]);',
+        'subpath(\'body\').selectAll(\'p\').data([1]);',
+      ].join('\n'),
+      output: [
+        'import { select } from \'other-library\';',
+        'import { select as subpath } from \'d3/v4\';',
+        'select(\'body\').selectAll(\'p\')',
+        '.data([1]);',
+        'subpath(\'body\').selectAll(\'p\')',
+        '.data([1]);',
+      ].join('\n'),
+      options: [{
+        ignoreChainWithDepth: 2,
+        overrides: [{
+          chainRoot: 'select',
+          importedFrom: 'd3',
+          ignoreChainWithDepth: 5,
+        }],
+      }],
+      errors: [
+        { messageId: 'expected', data: { callee: '.data' } },
+        { messageId: 'expected', data: { callee: '.data' } },
+      ],
+    },
+    {
+      code: [
+        'import { select } from \'d3\';',
+        'import { select as other } from \'d3-other\';',
+        'select(\'body\').selectAll(\'p\').data([1]);',
+        'other(\'body\').selectAll(\'p\').data([1]);',
+      ].join('\n'),
+      output: [
+        'import { select } from \'d3\';',
+        'import { select as other } from \'d3-other\';',
+        'select(\'body\').selectAll(\'p\')',
+        '.data([1]);',
+        'other(\'body\').selectAll(\'p\')',
+        '.data([1]);',
+      ].join('\n'),
+      options: [{
+        ignoreChainWithDepth: 2,
+        overrides: [{
+          chainRoot: 'select',
+          importedFrom: 'd3/*',
+          ignoreChainWithDepth: 5,
+        }],
+      }],
+      errors: [
+        { messageId: 'expected', data: { callee: '.data' } },
+        { messageId: 'expected', data: { callee: '.data' } },
+      ],
+    },
+    {
+      code: [
+        'import d3Default from \'d3\';',
+        'import * as d3Namespace from \'d3\';',
+        'd3Default.select(\'body\').selectAll(\'p\').data([1]);',
+        'd3Namespace.select(\'body\').selectAll(\'p\').data([1]);',
+      ].join('\n'),
+      output: [
+        'import d3Default from \'d3\';',
+        'import * as d3Namespace from \'d3\';',
+        'd3Default.select(\'body\').selectAll(\'p\').data([1]);',
+        'd3Namespace.select(\'body\').selectAll(\'p\')',
+        '.data([1]);',
+      ].join('\n'),
+      options: [{
+        ignoreChainWithDepth: 2,
+        overrides: [{
+          chainRoot: '',
+          importedFrom: 'd3',
+          ignoreChainWithDepth: 5,
+        }],
+      }],
+      errors: [{ messageId: 'expected', data: { callee: '.data' } }],
+    },
+    {
+      code: [
+        'import { select } from \'d3\';',
+        'function test(select) {',
+        '  return select(\'body\').selectAll(\'p\').data([1]);',
+        '}',
+      ].join('\n'),
+      output: [
+        'import { select } from \'d3\';',
+        'function test(select) {',
+        '  return select(\'body\').selectAll(\'p\')',
+        '.data([1]);',
+        '}',
+      ].join('\n'),
+      options: [{
+        ignoreChainWithDepth: 2,
+        overrides: [{
+          chainRoot: 'select',
+          importedFrom: 'd3',
+          ignoreChainWithDepth: 5,
+        }],
+      }],
+      errors: [{ messageId: 'expected', data: { callee: '.data' } }],
+    },
+    {
+      code: [
+        'import { select } from \'d3\';',
+        'select(\'body\').selectAll(\'p\').data([1]);',
+      ].join('\n'),
+      output: [
+        'import { select } from \'d3\';',
+        'select(\'body\').selectAll(\'p\')',
+        '.data([1]);',
+      ].join('\n'),
+      options: [{
+        ignoreChainWithDepth: 5,
+        overrides: [{
+          chainRoot: 'select',
+          importedFrom: 'd3',
+          ignoreChainWithDepth: 2,
+        }, {
+          chainRoot: 'select',
+          importedFrom: 'd3',
+          ignoreChainWithDepth: 5,
+        }],
+      }],
+      errors: [{ messageId: 'expected', data: { callee: '.data' } }],
+    },
+    {
+      code: [
+        'import { select } from \'d3\';',
+        'const selection = select(\'body\').selectAll(\'p\').data([1]);',
+      ].join('\n'),
+      output: [
+        'import { select } from \'d3\';',
+        'const selection = select(\'body\').selectAll(\'p\')',
+        '.data([1]);',
+      ].join('\n'),
+      options: [{
+        ignoreChainWithDepth: 2,
+        overrides: [{
+          chainRoot: 'select',
+          importedFrom: 'd3',
+          ignoreChainWithDepth: 5,
+          maxLineLength: 40,
+        }],
+      }],
+      errors: [{ messageId: 'expected', data: { callee: '.data' } }],
     }, // Optional chaining
     {
       code: 'obj?.foo1()?.foo2()?.foo3()',

--- a/packages/eslint-plugin/rules/newline-per-chained-call/newline-per-chained-call.test.ts
+++ b/packages/eslint-plugin/rules/newline-per-chained-call/newline-per-chained-call.test.ts
@@ -50,7 +50,7 @@ run<RuleOptions, MessageIds>({
       options: [{
         ignoreChainWithDepth: 2,
         overrides: [{
-          chainRoot: ['select', ''],
+          chainRoot: ['select'],
           importedFrom: ['d3', 'd3/*'],
           ignoreChainWithDepth: 5,
         }],
@@ -495,6 +495,7 @@ run<RuleOptions, MessageIds>({
         overrides: [{
           chainRoot: '',
           importedFrom: 'd3',
+          treatDefaultAsNamespace: false,
           ignoreChainWithDepth: 5,
         }],
       }],

--- a/packages/eslint-plugin/rules/newline-per-chained-call/newline-per-chained-call.test.ts
+++ b/packages/eslint-plugin/rules/newline-per-chained-call/newline-per-chained-call.test.ts
@@ -87,6 +87,20 @@ run<RuleOptions, MessageIds>({
         }],
       }],
     },
+    {
+      code: [
+        'import { select } from \'d3\';',
+        'select(\'body\').selectAll(\'p\').data([1]);',
+        'object.foo().bar().baz();',
+      ].join('\n'),
+      options: [{
+        ignoreChainWithDepth: 2,
+        overrides: [{
+          ignoreChainWithDepth: 5,
+          maxLineLength: 40,
+        }],
+      }],
+    },
   ],
   invalid: [
     {
@@ -569,6 +583,21 @@ run<RuleOptions, MessageIds>({
         }],
       }],
       errors: [{ messageId: 'expected', data: { callee: '.data' } }],
+    },
+    {
+      code: 'const longerValue = object.foo().bar().baz();',
+      output: [
+        'const longerValue = object.foo().bar()',
+        '.baz();',
+      ].join('\n'),
+      options: [{
+        ignoreChainWithDepth: 2,
+        overrides: [{
+          ignoreChainWithDepth: 5,
+          maxLineLength: 40,
+        }],
+      }],
+      errors: [{ messageId: 'expected', data: { callee: '.baz' } }],
     }, // Optional chaining
     {
       code: 'obj?.foo1()?.foo2()?.foo3()',

--- a/packages/eslint-plugin/rules/newline-per-chained-call/newline-per-chained-call.ts
+++ b/packages/eslint-plugin/rules/newline-per-chained-call/newline-per-chained-call.ts
@@ -2,11 +2,12 @@
  * @fileoverview Rule to ensure newline per method call when chaining calls
  * @author Rajendra Patil
  * @author Burak Yigit Kaya
+ * @author Gilad S.
  */
 
-import type { Tree } from '#types'
+import type { Scope, Tree } from '#types'
 import type { MessageIds, RuleOptions } from './types'
-import { isNotClosingParenToken, isTokenOnSameLine, LINEBREAK_MATCHER, skipChainExpression } from '#utils/ast'
+import { getStaticPropertyName, isNotClosingParenToken, isTokenOnSameLine, LINEBREAK_MATCHER, skipChainExpression } from '#utils/ast'
 import { createRule } from '#utils/create-rule'
 
 export default createRule<RuleOptions, MessageIds>({
@@ -25,10 +26,53 @@ export default createRule<RuleOptions, MessageIds>({
           minimum: 1,
           maximum: 10,
         },
+        tabWidth: {
+          type: 'integer',
+          minimum: 0,
+        },
+        overrides: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              chainRoot: {
+                anyOf: [
+                  { type: 'string' },
+                  {
+                    type: 'array',
+                    items: { type: 'string' },
+                    minItems: 1,
+                  },
+                ],
+              },
+              importedFrom: {
+                anyOf: [
+                  { type: 'string' },
+                  {
+                    type: 'array',
+                    items: { type: 'string' },
+                    minItems: 1,
+                  },
+                ],
+              },
+              maxLineLength: {
+                type: 'integer',
+                minimum: 1,
+              },
+              ignoreChainWithDepth: {
+                type: 'integer',
+                minimum: 1,
+                maximum: 10,
+              },
+            },
+            required: ['chainRoot', 'importedFrom', 'ignoreChainWithDepth'],
+            additionalProperties: false,
+          },
+        },
       },
       additionalProperties: false,
     }],
-    defaultOptions: [{ ignoreChainWithDepth: 2 }],
+    defaultOptions: [{ ignoreChainWithDepth: 2, tabWidth: 4 }],
     messages: {
       expected: 'Expected line break before `{{callee}}`.',
     },
@@ -36,9 +80,16 @@ export default createRule<RuleOptions, MessageIds>({
   create(context, [options]) {
     const {
       ignoreChainWithDepth,
+      overrides,
+      tabWidth,
     } = options!
 
     const sourceCode = context.sourceCode
+
+    interface ChainRoot {
+      identifier: Tree.Identifier
+      member: Tree.MemberExpression | null
+    }
 
     /**
      * Get the prefix of a given MemberExpression node.
@@ -74,6 +125,126 @@ export default createRule<RuleOptions, MessageIds>({
       return prefix + lines[0] + suffix
     }
 
+    function getChainRoot(node: Tree.MemberExpression): ChainRoot | null {
+      let current = skipChainExpression(node)
+      let member: Tree.MemberExpression | null = null
+
+      while (current.type === 'MemberExpression' || current.type === 'CallExpression') {
+        if (current.type === 'MemberExpression')
+          member = current
+
+        current = skipChainExpression(current.type === 'MemberExpression' ? current.object : current.callee)
+      }
+
+      return current.type === 'Identifier'
+        ? { identifier: current, member }
+        : null
+    }
+
+    function getImportBinding(root: ChainRoot): { chainRoot: string, importedFrom: string } | null {
+      let scope: Scope.Scope | null = sourceCode.getScope(root.identifier)
+
+      while (scope) {
+        const variable = scope.set.get(root.identifier.name)
+
+        if (variable != null) {
+          const definition = variable.defs.find(definition => definition.type === 'ImportBinding')
+
+          if (definition?.parent.type !== 'ImportDeclaration')
+            return null
+
+          let chainRoot = ''
+
+          if (definition.node.type === 'ImportSpecifier') {
+            chainRoot = definition.node.imported.type === 'Identifier'
+              ? definition.node.imported.name
+              : definition.node.imported.value
+          }
+          else if (definition.node.type === 'ImportNamespaceSpecifier') {
+            if (root.member == null)
+              return null
+
+            const namespaceChainRoot = getStaticPropertyName(root.member)
+            if (namespaceChainRoot == null)
+              return null
+
+            chainRoot = namespaceChainRoot
+          }
+
+          return {
+            chainRoot,
+            importedFrom: definition.parent.source.value,
+          }
+        }
+
+        scope = scope.upper
+      }
+
+      return null
+    }
+
+    function matchesValue(configured: string | string[], value: string): boolean {
+      if (Array.isArray(configured))
+        return configured.includes(value)
+
+      return configured === value
+    }
+
+    function matchesImportSource(configured: string | string[], source: string): boolean {
+      if (Array.isArray(configured))
+        return configured.some(value => matchesImportSource(value, source))
+
+      return configured.endsWith('/*')
+        ? source.startsWith(configured.slice(0, -'*'.length))
+        : source === configured
+    }
+
+    function computeLineLength(line: string): number {
+      let extraCharacterCount = 0
+
+      line.replace(/\t/gu, (_, offset) => {
+        const totalOffset = offset + extraCharacterCount
+        const previousTabStopOffset = tabWidth ? totalOffset % tabWidth : 0
+        const spaceCount = tabWidth! - previousTabStopOffset
+
+        extraCharacterCount += spaceCount - 1
+        return ''
+      })
+
+      return Array.from(line).length + extraCharacterCount
+    }
+
+    function resolveOverride(callee: Tree.MemberExpression): number | undefined {
+      if (overrides == null || overrides.length === 0)
+        return undefined
+
+      const root = getChainRoot(callee)
+      if (root == null)
+        return undefined
+
+      const importBinding = getImportBinding(root)
+      if (importBinding == null)
+        return undefined
+
+      for (const override of overrides) {
+        if (!matchesValue(override.chainRoot, importBinding.chainRoot))
+          continue
+        else if (!matchesImportSource(override.importedFrom, importBinding.importedFrom))
+          continue
+
+        if (override.maxLineLength != null) {
+          const line = sourceCode.lines[callee.property.loc.start.line - 1]
+
+          if (computeLineLength(line) > override.maxLineLength)
+            continue
+        }
+
+        return override.ignoreChainWithDepth
+      }
+
+      return undefined
+    }
+
     return {
       'CallExpression:exit': function (node: Tree.CallExpression) {
         const callee = skipChainExpression(node.callee)
@@ -92,7 +263,8 @@ export default createRule<RuleOptions, MessageIds>({
           parent = skipChainExpression(parentCallee.object)
         }
 
-        if (depth > ignoreChainWithDepth! && isTokenOnSameLine(callee.object, callee.property)) {
+        const resolvedIgnoreChainWithDepth = resolveOverride(callee) ?? ignoreChainWithDepth!
+        if (depth > resolvedIgnoreChainWithDepth && isTokenOnSameLine(callee.object, callee.property)) {
           const firstTokenAfterObject = sourceCode.getTokenAfter(callee.object, isNotClosingParenToken)!
 
           context.report({

--- a/packages/eslint-plugin/rules/newline-per-chained-call/newline-per-chained-call.ts
+++ b/packages/eslint-plugin/rules/newline-per-chained-call/newline-per-chained-call.ts
@@ -148,6 +148,11 @@ export default createRule<RuleOptions, MessageIds>({
       return prefix + lines[0] + suffix
     }
 
+    /**
+     * Gets the root identifier and nearest member access of a chained call.
+     * @param node The chained member expression.
+     * @returns The chain root, or null if the root is not an identifier.
+     */
     function getChainRoot(node: Tree.MemberExpression): ChainRoot | null {
       let current = skipChainExpression(node)
       let member: Tree.MemberExpression | null = null
@@ -168,6 +173,11 @@ export default createRule<RuleOptions, MessageIds>({
         : null
     }
 
+    /**
+     * Resolves a chain root to its lexical import binding.
+     * @param root The chain root to resolve.
+     * @returns Information about the import binding, or null if it is not imported.
+     */
     function getImportBinding(root: ChainRoot): null | {
       chainRoot: string
       defaultNamespaceChainRoot: string | null
@@ -220,6 +230,12 @@ export default createRule<RuleOptions, MessageIds>({
       return null
     }
 
+    /**
+     * Checks whether a value matches a configured value or one of its alternatives.
+     * @param configured The configured value or values.
+     * @param value The value to check.
+     * @returns Whether the value matches.
+     */
     function matchesValue(configured: string | string[], value: string): boolean {
       if (Array.isArray(configured))
         return configured.includes(value)
@@ -227,6 +243,12 @@ export default createRule<RuleOptions, MessageIds>({
       return configured === value
     }
 
+    /**
+     * Checks an import source against exact values and trailing subpath wildcards.
+     * @param configured The configured import source or sources.
+     * @param source The import source to check.
+     * @returns Whether the import source matches.
+     */
     function matchesImportSource(configured: string | string[], source: string): boolean {
       if (Array.isArray(configured))
         return configured.some(value => matchesImportSource(value, source))
@@ -236,6 +258,11 @@ export default createRule<RuleOptions, MessageIds>({
         : source === configured
     }
 
+    /**
+     * Calculates a physical line's length using the configured tab stops.
+     * @param line The physical source line.
+     * @returns The expanded line length.
+     */
     function computeLineLength(line: string): number {
       let extraCharacterCount = 0
 
@@ -251,6 +278,11 @@ export default createRule<RuleOptions, MessageIds>({
       return Array.from(line).length + extraCharacterCount
     }
 
+    /**
+     * Finds the first override that matches a chained-call candidate.
+     * @param callee The candidate member expression.
+     * @returns The override's chain depth, or undefined when none matches.
+     */
     function resolveOverride(callee: Tree.MemberExpression): number | undefined {
       if (overrides == null || overrides.length === 0)
         return undefined

--- a/packages/eslint-plugin/rules/newline-per-chained-call/newline-per-chained-call.ts
+++ b/packages/eslint-plugin/rules/newline-per-chained-call/newline-per-chained-call.ts
@@ -33,44 +33,63 @@ export default createRule<RuleOptions, MessageIds>({
         overrides: {
           type: 'array',
           items: {
-            type: 'object',
-            properties: {
-              chainRoot: {
-                anyOf: [
-                  { type: 'string' },
-                  {
-                    type: 'array',
-                    items: { type: 'string' },
-                    minItems: 1,
+            anyOf: [
+              {
+                type: 'object',
+                properties: {
+                  chainRoot: {
+                    anyOf: [
+                      { type: 'string' },
+                      {
+                        type: 'array',
+                        items: { type: 'string' },
+                        minItems: 1,
+                      },
+                    ],
                   },
-                ],
-              },
-              importedFrom: {
-                anyOf: [
-                  { type: 'string' },
-                  {
-                    type: 'array',
-                    items: { type: 'string' },
-                    minItems: 1,
+                  importedFrom: {
+                    anyOf: [
+                      { type: 'string' },
+                      {
+                        type: 'array',
+                        items: { type: 'string' },
+                        minItems: 1,
+                      },
+                    ],
                   },
-                ],
+                  treatDefaultAsNamespace: {
+                    type: 'boolean',
+                  },
+                  maxLineLength: {
+                    type: 'integer',
+                    minimum: 1,
+                  },
+                  ignoreChainWithDepth: {
+                    type: 'integer',
+                    minimum: 1,
+                    maximum: 10,
+                  },
+                },
+                required: ['chainRoot', 'importedFrom', 'ignoreChainWithDepth'],
+                additionalProperties: false,
               },
-              treatDefaultAsNamespace: {
-                type: 'boolean',
-                default: true,
+              {
+                type: 'object',
+                properties: {
+                  maxLineLength: {
+                    type: 'integer',
+                    minimum: 1,
+                  },
+                  ignoreChainWithDepth: {
+                    type: 'integer',
+                    minimum: 1,
+                    maximum: 10,
+                  },
+                },
+                required: ['maxLineLength', 'ignoreChainWithDepth'],
+                additionalProperties: false,
               },
-              maxLineLength: {
-                type: 'integer',
-                minimum: 1,
-              },
-              ignoreChainWithDepth: {
-                type: 'integer',
-                minimum: 1,
-                maximum: 10,
-              },
-            },
-            required: ['chainRoot', 'importedFrom', 'ignoreChainWithDepth'],
-            additionalProperties: false,
+            ],
           },
         },
       },
@@ -236,28 +255,31 @@ export default createRule<RuleOptions, MessageIds>({
       if (overrides == null || overrides.length === 0)
         return undefined
 
-      const root = getChainRoot(callee)
-      if (root == null)
-        return undefined
-
-      const importBinding = getImportBinding(root)
-      if (importBinding == null)
-        return undefined
-
+      let importBinding: undefined | ReturnType<typeof getImportBinding>
       for (const override of overrides) {
-        let chainRoot = importBinding.chainRoot
+        if ('chainRoot' in override) {
+          if (importBinding === undefined) {
+            const root = getChainRoot(callee)
+            importBinding = root == null ? null : getImportBinding(root)
+          }
 
-        if (importBinding.isDefault && override.treatDefaultAsNamespace !== false) {
-          if (importBinding.defaultNamespaceChainRoot == null)
+          if (importBinding == null)
             continue
 
-          chainRoot = importBinding.defaultNamespaceChainRoot
-        }
+          let chainRoot = importBinding.chainRoot
 
-        if (!matchesValue(override.chainRoot, chainRoot))
-          continue
-        else if (!matchesImportSource(override.importedFrom, importBinding.importedFrom))
-          continue
+          if (importBinding.isDefault && override.treatDefaultAsNamespace !== false) {
+            if (importBinding.defaultNamespaceChainRoot == null)
+              continue
+
+            chainRoot = importBinding.defaultNamespaceChainRoot
+          }
+
+          if (!matchesValue(override.chainRoot, chainRoot))
+            continue
+          else if (!matchesImportSource(override.importedFrom, importBinding.importedFrom))
+            continue
+        }
 
         if (override.maxLineLength != null) {
           const line = sourceCode.lines[callee.property.loc.start.line - 1]

--- a/packages/eslint-plugin/rules/newline-per-chained-call/newline-per-chained-call.ts
+++ b/packages/eslint-plugin/rules/newline-per-chained-call/newline-per-chained-call.ts
@@ -55,6 +55,10 @@ export default createRule<RuleOptions, MessageIds>({
                   },
                 ],
               },
+              treatDefaultAsNamespace: {
+                type: 'boolean',
+                default: true,
+              },
               maxLineLength: {
                 type: 'integer',
                 minimum: 1,
@@ -130,10 +134,14 @@ export default createRule<RuleOptions, MessageIds>({
       let member: Tree.MemberExpression | null = null
 
       while (current.type === 'MemberExpression' || current.type === 'CallExpression') {
-        if (current.type === 'MemberExpression')
+        if (current.type === 'MemberExpression') {
           member = current
-
-        current = skipChainExpression(current.type === 'MemberExpression' ? current.object : current.callee)
+          current = skipChainExpression(current.object)
+        }
+        else {
+          member = null
+          current = skipChainExpression(current.callee)
+        }
       }
 
       return current.type === 'Identifier'
@@ -141,7 +149,12 @@ export default createRule<RuleOptions, MessageIds>({
         : null
     }
 
-    function getImportBinding(root: ChainRoot): { chainRoot: string, importedFrom: string } | null {
+    function getImportBinding(root: ChainRoot): null | {
+      chainRoot: string
+      defaultNamespaceChainRoot: string | null
+      importedFrom: string
+      isDefault: boolean
+    } {
       let scope: Scope.Scope | null = sourceCode.getScope(root.identifier)
 
       while (scope) {
@@ -154,6 +167,7 @@ export default createRule<RuleOptions, MessageIds>({
             return null
 
           let chainRoot = ''
+          const isDefault = definition.node.type === 'ImportDefaultSpecifier'
 
           if (definition.node.type === 'ImportSpecifier') {
             chainRoot = definition.node.imported.type === 'Identifier'
@@ -173,7 +187,11 @@ export default createRule<RuleOptions, MessageIds>({
 
           return {
             chainRoot,
+            defaultNamespaceChainRoot: (isDefault && root.member != null)
+              ? getStaticPropertyName(root.member) ?? null
+              : null,
             importedFrom: definition.parent.source.value,
+            isDefault,
           }
         }
 
@@ -227,7 +245,16 @@ export default createRule<RuleOptions, MessageIds>({
         return undefined
 
       for (const override of overrides) {
-        if (!matchesValue(override.chainRoot, importBinding.chainRoot))
+        let chainRoot = importBinding.chainRoot
+
+        if (importBinding.isDefault && override.treatDefaultAsNamespace !== false) {
+          if (importBinding.defaultNamespaceChainRoot == null)
+            continue
+
+          chainRoot = importBinding.defaultNamespaceChainRoot
+        }
+
+        if (!matchesValue(override.chainRoot, chainRoot))
           continue
         else if (!matchesImportSource(override.importedFrom, importBinding.importedFrom))
           continue

--- a/packages/eslint-plugin/rules/newline-per-chained-call/newline-per-chained-call.ts
+++ b/packages/eslint-plugin/rules/newline-per-chained-call/newline-per-chained-call.ts
@@ -67,7 +67,6 @@ export default createRule<RuleOptions, MessageIds>({
                   ignoreChainWithDepth: {
                     type: 'integer',
                     minimum: 1,
-                    maximum: 10,
                   },
                 },
                 required: ['chainRoot', 'importedFrom', 'ignoreChainWithDepth'],

--- a/packages/eslint-plugin/rules/newline-per-chained-call/newline-per-chained-call.ts
+++ b/packages/eslint-plugin/rules/newline-per-chained-call/newline-per-chained-call.ts
@@ -28,7 +28,7 @@ export default createRule<RuleOptions, MessageIds>({
         },
         tabWidth: {
           type: 'integer',
-          minimum: 0,
+          minimum: 1,
         },
         overrides: {
           type: 'array',

--- a/packages/eslint-plugin/rules/newline-per-chained-call/types.d.ts
+++ b/packages/eslint-plugin/rules/newline-per-chained-call/types.d.ts
@@ -1,17 +1,23 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: Bz_3Ddi88HQYud0qPn2wl-cAj9kWUJOkUrNIQrV_Wng */
+/* @checksum: ukGyh3-u7rpIacroyk1sCMH20ibxo-KB3bN9MiNP9nQ */
 
 export interface NewlinePerChainedCallSchema0 {
   ignoreChainWithDepth?: number
   tabWidth?: number
-  overrides?: {
-    chainRoot: string | [string, ...string[]]
-    importedFrom: string | [string, ...string[]]
-    treatDefaultAsNamespace?: boolean
-    maxLineLength?: number
-    ignoreChainWithDepth: number
-  }[]
+  overrides?: (
+    | {
+      chainRoot: string | [string, ...string[]]
+      importedFrom: string | [string, ...string[]]
+      treatDefaultAsNamespace?: boolean
+      maxLineLength?: number
+      ignoreChainWithDepth: number
+    }
+    | {
+      maxLineLength: number
+      ignoreChainWithDepth: number
+    }
+  )[]
 }
 
 export type NewlinePerChainedCallRuleOptions = [

--- a/packages/eslint-plugin/rules/newline-per-chained-call/types.d.ts
+++ b/packages/eslint-plugin/rules/newline-per-chained-call/types.d.ts
@@ -1,6 +1,6 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: Wve6MztGdL2Vcy_6qM0jbj1Ync1QXANKFKzt0aaaNFE */
+/* @checksum: Bz_3Ddi88HQYud0qPn2wl-cAj9kWUJOkUrNIQrV_Wng */
 
 export interface NewlinePerChainedCallSchema0 {
   ignoreChainWithDepth?: number
@@ -8,8 +8,9 @@ export interface NewlinePerChainedCallSchema0 {
   overrides?: {
     chainRoot: string | [string, ...string[]]
     importedFrom: string | [string, ...string[]]
-    ignoreChainWithDepth: number
+    treatDefaultAsNamespace?: boolean
     maxLineLength?: number
+    ignoreChainWithDepth: number
   }[]
 }
 

--- a/packages/eslint-plugin/rules/newline-per-chained-call/types.d.ts
+++ b/packages/eslint-plugin/rules/newline-per-chained-call/types.d.ts
@@ -1,9 +1,16 @@
 /* GENERATED, DO NOT EDIT DIRECTLY */
 
-/* @checksum: Bzr-ILAL8zcs1Oj4CeJI6Sn_zvPOE-zAYZyrOmLe_vE */
+/* @checksum: Wve6MztGdL2Vcy_6qM0jbj1Ync1QXANKFKzt0aaaNFE */
 
 export interface NewlinePerChainedCallSchema0 {
   ignoreChainWithDepth?: number
+  tabWidth?: number
+  overrides?: {
+    chainRoot: string | [string, ...string[]]
+    importedFrom: string | [string, ...string[]]
+    ignoreChainWithDepth: number
+    maxLineLength?: number
+  }[]
 }
 
 export type NewlinePerChainedCallRuleOptions = [


### PR DESCRIPTION
### Description

Allow defining overrides for `newline-per-chained-call` for when the root of the chain is imported from a configured module.
For example, this configuration allows Zod chains up to a depth of 5 to remain inline, while other chains continue to use the rule-level depth of 2:

```typescript
/* eslint @stylistic/newline-per-chained-call: ["error", {
    "ignoreChainWithDepth": 2,
    "tabWidth": 4,
    "overrides": [{
        "chainRoot": "z",
        "importedFrom": ["zod", "zod/*"],
        "ignoreChainWithDepth": 5,
        "maxLineLength": 120
    }]
}] */

import { z } from "zod";
import * as zod from "zod";
import { z as customZ } from "zod/v4";

import { z as z2 } from "zod2";


const schema = z.string().min(1).max(100).optional(); // allowed
const schema1 = customZ.string().min(1).max(100).optional(); // allowed
const schema2 = zod.z.string().min(1).max(100).optional(); // allowed

const schema3 = z2.string().min(1).max(100).optional(); // not allowed
```

### Linked Issues

Resolves #620


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added configurable overrides for chained-call formatting based on imported identifiers and source packages.
- Overrides can set different chain-depth thresholds and apply only to lines up to a specified length.
- Added matching for named, default, namespace, aliased, and subpath imports.
- Added configurable tab-width handling for accurate line-length checks.
- Improved handling of optional chaining and shadowed imports.

## Documentation
- Added configuration guidance and examples for the new override options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->